### PR TITLE
Fix for failing ItemsInContainersGroupTest

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/AbstractGroupImpl.java
+++ b/core/src/main/java/brooklyn/entity/basic/AbstractGroupImpl.java
@@ -77,6 +77,13 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
     @Override
     public boolean addMember(Entity member) {
         synchronized (members) {
+            if (Entities.isNoLongerManaged(member)) {
+                // Don't add dead entities, as they could never be removed (because addMember could be called in
+                // concurrent thread as removeMember triggered by the unmanage).
+                // Not using Entities.isManaged here, as could be called in entity.init()
+                log.debug("Group {} ignoring new member {}, because it is no longer managed", this, member);
+                return false;
+            }
             member.addGroup((Group)getProxyIfAvailable());
             boolean changed = members.add(member);
             if (changed) {

--- a/core/src/main/java/brooklyn/entity/basic/Entities.java
+++ b/core/src/main/java/brooklyn/entity/basic/Entities.java
@@ -618,6 +618,10 @@ public class Entities {
         return ((EntityInternal)e).getManagementSupport().isDeployed() && ((EntityInternal)e).getManagementContext().isRunning();
     }
 
+    public static boolean isNoLongerManaged(Entity e) {
+        return ((EntityInternal)e).getManagementSupport().isNoLongerManaged();
+    }
+
     /** brings this entity under management iff its ancestor is managed, returns true in that case;
      * otherwise returns false in the expectation that the ancestor will become managed,
      * or throws exception if it has no parent or a non-application root

--- a/policy/src/main/java/brooklyn/policy/loadbalancing/ItemsInContainersGroupImpl.java
+++ b/policy/src/main/java/brooklyn/policy/loadbalancing/ItemsInContainersGroupImpl.java
@@ -40,7 +40,7 @@ public class ItemsInContainersGroupImpl extends DynamicGroupImpl implements Item
             Sensor sensor = event.getSensor();
             
             if (sensor.equals(AbstractGroup.MEMBER_ADDED)) {
-                    onContainerAdded((Entity) value);
+                onContainerAdded((Entity) value);
             } else if (sensor.equals(AbstractGroup.MEMBER_REMOVED)) {
                 onContainerRemoved((Entity) value);
             } else if (sensor.equals(Movable.CONTAINER)) {

--- a/policy/src/test/java/brooklyn/policy/loadbalancing/ItemsInContainersGroupTest.java
+++ b/policy/src/test/java/brooklyn/policy/loadbalancing/ItemsInContainersGroupTest.java
@@ -113,10 +113,14 @@ public class ItemsInContainersGroupTest {
         assertItemsEventually();
     }
 
-    // Failed in build #2197 on cloudbees; 
-    // possible just a timeout, time was set at 5s there, ran for 19 iterations;
-    // since it only takes 5 *millis* locally I'm (Alex) slightly concerned there may
-    // be a real problem of racing on startup, but see if we see it again, with timeout 15s...
+    /*
+     * Previously could fail if...
+     * ItemsInContainersGroupImpl listener got notified of Movable.CONTAINER after entity was unmanaged
+     * (because being done in concurrent threads).
+     * This called ItemsInContainersGroupImpl.onItemMoved, which called addMember to add it back in again.
+     * In AbstractGroup.addMember, we now check if the entity is still managed, to 
+     * ensure there is synchronization for concurrent calls to add/remove member.
+     */
     @Test
     public void testItemUnmanagedIsRemoved() throws Exception {
         MockContainerEntity containerIn = newContainer(app, "A", "ingroup");


### PR DESCRIPTION
- don’t do group.addMember if member is no longer managed
