### PR TITLE
bump maven-war-plugin version (old version was fine here but new version...

### DIFF
--- a/usage/jsgui/pom.xml
+++ b/usage/jsgui/pom.xml
@@ -28,8 +28,7 @@
 -->
         <requirejs-maven-plugin.version>2.0.0</requirejs-maven-plugin.version>
 
-        <!-- The maven-war-plugin 2.1+ and the replacer plugin don't work well together. -->
-        <maven-war-plugin.version>2.0.2</maven-war-plugin.version>
+        <maven-war-plugin.version>2.4</maven-war-plugin.version>
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
 
         <project.build.webapp>
@@ -161,6 +160,14 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven-war-plugin.version}</version>
+                <configuration>
+                    <useCache>true</useCache> <!-- to prevent replaced files being overwritten -->
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
... needed in downstream projects),

along with the parameter which fixes the second copy overwriting the files changed by the replacer plugin (for war plugin v 2.1+); confirmed the resulting WAR is identical apart from the pom changes

[this was reviewed and merged by @aledsage in to the old brooklyncentral/brooklyn but the commit did not get moved across to apache]
