### PR TITLE
remove java-7-ism Locale.Category.FORMAT

### DIFF
--- a/utils/common/src/main/java/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/brooklyn/util/text/Strings.java
@@ -774,7 +774,7 @@ public class Strings {
     }
     
     public static char getDefaultDecimalSeparator() {
-        return getDecimalSeparator(Locale.getDefault(Locale.Category.FORMAT));
+        return getDecimalSeparator(Locale.getDefault());
     }
 
 }


### PR DESCRIPTION
@neykov is this a reasonable fix given we still support java 6 ?
