### PR TITLE
BROOKLYN-14: rebind policies in separate phase

### DIFF
--- a/api/src/main/java/brooklyn/entity/rebind/RebindSupport.java
+++ b/api/src/main/java/brooklyn/entity/rebind/RebindSupport.java
@@ -18,7 +18,7 @@ public interface RebindSupport<T extends Memento> {
     /**
      * Creates a memento representing this entity's current state. This is useful for when restarting brooklyn.
      */
-    public T getMemento();
+    T getMemento();
 
     /**
      * Reconstructs this entity, given a memento of its state. Sets the internal state 
@@ -29,5 +29,9 @@ public interface RebindSupport<T extends Memento> {
      * 
      * Called before rebind.
      */
-    public void reconstruct(RebindContext rebindContext, T memento);
+    void reconstruct(RebindContext rebindContext, T memento);
+
+    void addPolicies(RebindContext rebindContext, T Memento);
+    
+    void addEnrichers(RebindContext rebindContext, T Memento);
 }

--- a/core/src/main/java/brooklyn/entity/rebind/BasicEnricherRebindSupport.java
+++ b/core/src/main/java/brooklyn/entity/rebind/BasicEnricherRebindSupport.java
@@ -40,15 +40,24 @@ public class BasicEnricherRebindSupport implements RebindSupport<EnricherMemento
         FlagUtils.setFieldsFromFlags(enricher, configBag);
         FlagUtils.setAllConfigKeys(enricher, configBag, false);
         
-        doReconsruct(rebindContext, memento);
+        doReconstruct(rebindContext, memento);
         ((AbstractEnricher)enricher).rebind();
     }
 
+    @Override
+    public void addPolicies(RebindContext rebindContext, EnricherMemento Memento) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addEnrichers(RebindContext rebindContext, EnricherMemento Memento) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * For overriding, to give custom reconsruct behaviour.
      */
-    protected void doReconsruct(RebindContext rebindContext, EnricherMemento memento) {
+    protected void doReconstruct(RebindContext rebindContext, EnricherMemento memento) {
         // default is no-op
     }
 }

--- a/core/src/main/java/brooklyn/entity/rebind/BasicEntityRebindSupport.java
+++ b/core/src/main/java/brooklyn/entity/rebind/BasicEntityRebindSupport.java
@@ -88,14 +88,38 @@ public class BasicEntityRebindSupport implements RebindSupport<EntityMemento> {
         
         setParent(rebindContext, memento);
         addChildren(rebindContext, memento);
-        addPolicies(rebindContext, memento);
-        addEnrichers(rebindContext, memento);
         addMembers(rebindContext, memento);
         addTags(rebindContext, memento);
         addLocations(rebindContext, memento);
 
         doReconstruct(rebindContext, memento);
         ((AbstractEntity)entity).rebind();
+    }
+    
+    @Override
+    public void addPolicies(RebindContext rebindContext, EntityMemento memento) {
+        for (String policyId : memento.getPolicies()) {
+            AbstractPolicy policy = (AbstractPolicy) rebindContext.getPolicy(policyId);
+            if (policy != null) {
+                entity.addPolicy(policy);
+            } else {
+                LOG.warn("Policy not found; discarding policy {} of entity {}({})",
+                        new Object[] {policyId, memento.getType(), memento.getId()});
+            }
+        }
+    }
+    
+    @Override
+    public void addEnrichers(RebindContext rebindContext, EntityMemento memento) {
+        for (String enricherId : memento.getEnrichers()) {
+            AbstractEnricher enricher = (AbstractEnricher) rebindContext.getEnricher(enricherId);
+            if (enricher != null) {
+                entity.addEnricher(enricher);
+            } else {
+                LOG.warn("Enricher not found; discarding enricher {} of entity {}({})",
+                        new Object[] {enricherId, memento.getType(), memento.getId()});
+            }
+        }
     }
     
     /**
@@ -159,30 +183,6 @@ public class BasicEntityRebindSupport implements RebindSupport<EntityMemento> {
             } else {
                 LOG.warn("Location not found; discarding location {} of entity {}({})",
                         new Object[] {id, memento.getType(), memento.getId()});
-            }
-        }
-    }
-    
-    protected void addPolicies(RebindContext rebindContext, EntityMemento memento) {
-        for (String policyId : memento.getPolicies()) {
-            AbstractPolicy policy = (AbstractPolicy) rebindContext.getPolicy(policyId);
-            if (policy != null) {
-                entity.addPolicy(policy);
-            } else {
-                LOG.warn("Policy not found; discarding policy {} of entity {}({})",
-                        new Object[] {policyId, memento.getType(), memento.getId()});
-            }
-        }
-    }
-    
-    protected void addEnrichers(RebindContext rebindContext, EntityMemento memento) {
-        for (String enricherId : memento.getEnrichers()) {
-            AbstractEnricher enricher = (AbstractEnricher) rebindContext.getEnricher(enricherId);
-            if (enricher != null) {
-                entity.addEnricher(enricher);
-            } else {
-                LOG.warn("Enricher not found; discarding enricher {} of entity {}({})",
-                        new Object[] {enricherId, memento.getType(), memento.getId()});
             }
         }
     }

--- a/core/src/main/java/brooklyn/entity/rebind/BasicLocationRebindSupport.java
+++ b/core/src/main/java/brooklyn/entity/rebind/BasicLocationRebindSupport.java
@@ -89,7 +89,17 @@ public class BasicLocationRebindSupport implements RebindSupport<LocationMemento
         location.init(); // TODO deprecated calling init; will be deleted
         location.rebind();
         
-        doReconsruct(rebindContext, memento);
+        doReconstruct(rebindContext, memento);
+    }
+
+    @Override
+    public void addPolicies(RebindContext rebindContext, LocationMemento Memento) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addEnrichers(RebindContext rebindContext, LocationMemento Memento) {
+        throw new UnsupportedOperationException();
     }
 
     protected void addChildren(RebindContext rebindContext, LocationMemento memento) {
@@ -115,7 +125,7 @@ public class BasicLocationRebindSupport implements RebindSupport<LocationMemento
     /**
      * For overriding, to give custom reconsruct behaviour.
      */
-    protected void doReconsruct(RebindContext rebindContext, LocationMemento memento) {
+    protected void doReconstruct(RebindContext rebindContext, LocationMemento memento) {
         // default is no-op
     }
 }

--- a/core/src/main/java/brooklyn/entity/rebind/BasicPolicyRebindSupport.java
+++ b/core/src/main/java/brooklyn/entity/rebind/BasicPolicyRebindSupport.java
@@ -40,14 +40,24 @@ public class BasicPolicyRebindSupport implements RebindSupport<PolicyMemento> {
         FlagUtils.setFieldsFromFlags(policy, configBag);
         FlagUtils.setAllConfigKeys(policy, configBag, false);
         
-        doReconsruct(rebindContext, memento);
+        doReconstruct(rebindContext, memento);
         ((AbstractPolicy)policy).rebind();
+    }
+
+    @Override
+    public void addPolicies(RebindContext rebindContext, PolicyMemento Memento) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addEnrichers(RebindContext rebindContext, PolicyMemento Memento) {
+        throw new UnsupportedOperationException();
     }
 
     /**
      * For overriding, to give custom reconsruct behaviour.
      */
-    protected void doReconsruct(RebindContext rebindContext, PolicyMemento memento) {
+    protected void doReconstruct(RebindContext rebindContext, PolicyMemento memento) {
         // default is no-op
     }
 }

--- a/core/src/test/java/brooklyn/entity/rebind/RebindLocationTest.java
+++ b/core/src/test/java/brooklyn/entity/rebind/RebindLocationTest.java
@@ -344,8 +344,8 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
                     return getMementoWithProperties(MutableMap.<String,Object>of("myfield", myfield));
                 }
                 @Override
-                protected void doReconsruct(RebindContext rebindContext, LocationMemento memento) {
-                    super.doReconsruct(rebindContext, memento);
+                protected void doReconstruct(RebindContext rebindContext, LocationMemento memento) {
+                    super.doReconstruct(rebindContext, memento);
                     myfield = (String) memento.getCustomField("myfield");
                     rebound = true;
                 }


### PR DESCRIPTION
- Only add policies+enrichers to entities after all entities have had
  their state set, and all relationships (parent-child, 
  group membership, locations) have been set up
- Also corrects spelling of “doReconsruct” in BasicPolicyRebindSupport
  etc
- Improves comments in RebindManagerImpl on rebind’s phases
