### PR TITLE
Fix malformed HTML in add-app-wizard dialog

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/required-config-entry.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/required-config-entry.html
@@ -14,7 +14,7 @@
             element = null;
         for (var i = 0; i < length; i++) {
           element = data.possibleValues[i]; %>
-        <option value="<%= element.value %>"><% if (data.defaultValue == element.value) { %> selected="selected"<% } %>><%= element.description %></option>
+        <option value="<%= element.value %>"<% if (data.defaultValue == element.value) { %> selected="selected"<% } %>><%= element.description %></option>
         <% } %>
       </select>
     <% } else { %>


### PR DESCRIPTION
Error caused the drop-down lists for enum config keys to be rendered
incorrectly.
