### PR TITLE
camp-server: depend on brooklyn-utils-test-support

### DIFF
--- a/camp/camp-base/pom.xml
+++ b/camp/camp-base/pom.xml
@@ -24,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>io.brooklyn</groupId>
-            <artifactId>brooklyn-test-support</artifactId>
+            <artifactId>brooklyn-utils-test-support</artifactId>
             <version>${brooklyn.version}</version>
             <scope>test</scope>
         </dependency>

--- a/camp/camp-server/pom.xml
+++ b/camp/camp-server/pom.xml
@@ -24,6 +24,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.brooklyn</groupId>
+            <artifactId>brooklyn-utils-test-support</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.brooklyn.camp</groupId>
             <artifactId>camp-base</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
- Without this, it can’t find `LoggingVerboseReporter` which is in `brooklyn-utils-test-support`
- camp-base now depends `brooklyn-utils-test-support` instead of `brooklyn-test-support`, because does not need brooklyn-api
