### PR TITLE
Fix for brooklyn.rest.resources.SensorResourceTest.testGetPlain error.

### DIFF
--- a/usage/rest-server/src/test/java/brooklyn/config/render/TestRendererHints.java
+++ b/usage/rest-server/src/test/java/brooklyn/config/render/TestRendererHints.java
@@ -21,7 +21,13 @@ package brooklyn.config.render;
 /** Methods used when testing the {@link RendererHints} regiostry. */
 public class TestRendererHints {
 
-    /** Clear the registry. */
+    /** Clear the registry. 
+     *
+     *  MUST be used by a single test only.
+     *  TestNG interleaves the tests (sequentially) which results in tearDown 
+     *  executing in the middle of another class' tests. Only one tearDown may
+     *  call this method.
+     **/
     public static void clearRegistry() {
         RendererHints.registry.clear();
     }

--- a/usage/rest-server/src/test/java/brooklyn/rest/resources/EntityResourceTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/resources/EntityResourceTest.java
@@ -46,12 +46,6 @@ import com.google.common.collect.Iterables;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.GenericType;
 
-/**
- * Test the {@link SensorApi} implementation.
- * <p>
- * Check that {@link SensorResource} correctly renders {@link AttributeSensor}
- * values, including {@link RendererHints.DisplayValue} hints.
- */
 @Test(singleThreaded = true)
 public class EntityResourceTest extends BrooklynRestResourceTest {
 
@@ -65,12 +59,6 @@ public class EntityResourceTest extends BrooklynRestResourceTest {
 
     private static final String entityEndpoint = "/v1/applications/simple-app/entities/simple-ent";
 
-    /**
-     * Sets up the application and entity.
-     * <p>
-     * Adds a sensor and sets its value to {@code 12345}. Configures a display value
-     * hint that appends {@code frogs} to the value of the sensor.
-     */
     @BeforeClass(alwaysRun = true)
     @Override
     public void setUp() throws Exception {
@@ -87,13 +75,6 @@ public class EntityResourceTest extends BrooklynRestResourceTest {
                 return "RestMockSimpleEntity".equals(input.getEntityType().getSimpleName());
             }
         });
-    }
-
-    @AfterClass(alwaysRun = true)
-    @Override
-    public void tearDown() throws Exception {
-        TestRendererHints.clearRegistry();
-        super.tearDown();
     }
 
     @Test


### PR DESCRIPTION
Failing with expected "12345 frogs" but got "12345". The tearDown in EntityResourceTest
was cleaning the renderer registry in the middle of executing SensorResourceTests' methods.

Turns out TestNG interleaves the tests from separate classes in a single thread (the execution is sequential).

EntityResourceTest seems like copy&pasted from SensorResourceTest with the tearDown
call not needed, removed tearDown and unrelated comments.
