### PR TITLE
Workaround for builds.apache.org CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
         <concurrentlinkedhashmap.version>1.0_jdk5</concurrentlinkedhashmap.version>
         <maven-replacer-plugin.version>1.5.2</maven-replacer-plugin.version>
         <nodejs-maven-plugin.version>1.0.3</nodejs-maven-plugin.version>
+        <nodejs-maven-binaries.version>0.10.25</nodejs-maven-binaries.version>
         <jasmine-maven-plugin.version>1.2.0.0</jasmine-maven-plugin.version>
 <!-- see comment about fixtures in brooklyn-jsgui
         <jasmine-maven-plugin.version>1.3.1.2</jasmine-maven-plugin.version>

--- a/usage/jsgui/pom.xml
+++ b/usage/jsgui/pom.xml
@@ -42,6 +42,7 @@
         <project.build.webapp>
             ${project.build.directory}/${project.build.finalName}
         </project.build.webapp>
+        <nodejs.path>${project.basedir}/target/nodejs/node</nodejs.path>
     </properties>
 
     <dependencies>
@@ -201,6 +202,50 @@
 
     <profiles>
         <profile>
+            <id>nodejs-path-override</id>
+            <activation>
+                <os><family>linux</family></os>
+            </activation>
+            <properties>
+                <nodejs.path>${project.basedir}/src/build/nodejs</nodejs.path>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.github.skwakman.nodejs-maven-binaries</groupId>
+                    <artifactId>nodejs-maven-binaries</artifactId>
+                    <version>${nodejs-maven-binaries.version}</version>
+                    <classifier>linux-x64</classifier>
+                    <type>zip</type>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${maven-dependency-plugin.version}</version>
+                        <executions>
+                          <execution>
+                            <id>unpack-nodejs64</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                              <goal>unpack-dependencies</goal>
+                            </goals>
+                            <configuration>
+                              <includeGroupIds>com.github.skwakman.nodejs-maven-binaries</includeGroupIds>
+                              <includeArtifactIds>nodejs-maven-binaries</includeArtifactIds>
+                              <outputDirectory>
+                                 ${project.basedir}/target/nodejs64/
+                              </outputDirectory>
+                            </configuration>
+                          </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>Optimize resources</id>
             <activation>
                 <property>
@@ -272,7 +317,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <nodeExecutable>${project.basedir}/target/nodejs/node</nodeExecutable>
+                            <nodeExecutable>${nodejs.path}</nodeExecutable>
                             <optimizerFile>${project.basedir}/src/build/requirejs-maven-plugin/r.js</optimizerFile>
                             <!-- Replaces Maven tokens in the build file with their values -->
                             <filterConfig>true</filterConfig>

--- a/usage/jsgui/src/build/nodejs
+++ b/usage/jsgui/src/build/nodejs
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# nodejs-maven-plugin incorrectly detects the architecture on 
+# Linux x64 running 32 bit Java leading to the installation of
+# invalid nodejs binary - 32 bit on 64 bit OS. This is a
+# wrapper which makes a check for the architecture again and
+# forces the usage of the 64 bit binary. The 64 bit nodejs
+# is installed in advance in case we need it.
+#
+# target/nodejs64/node - the forcibly installed 64 bit binary
+# target/nodejs/node - the binary installed by nodejs-maven-plugin
+#                      could be 32 bit or 64 bit.
+#
+
+MACHINE_TYPE=`uname -m`
+if [ $MACHINE_TYPE = 'x86_64' ]; then
+  NODE_PATH=$( dirname "$0" )/../../target/nodejs64/node
+  chmod +x $NODE_PATH
+  echo Forcing 64 bit nodejs at $NODE_PATH
+else
+  NODE_PATH=$( dirname "$0" )/../../target/nodejs/node
+fi
+
+$NODE_PATH "$@"


### PR DESCRIPTION
The build on builds.apache.org fails due to the wrong nodejs binary being used.

Force usage of 64 bit binary.

<del>Until nodejs-maven-plugin is fixed (see https://github.com/skwakman/nodejs-maven-plugin/issues/8) don't use nodejs with the requirejs optimizer.</del>
