### PR TITLE
Move test to Integration group.

### DIFF
--- a/software/base/src/test/java/brooklyn/entity/pool/ServerPoolTest.java
+++ b/software/base/src/test/java/brooklyn/entity/pool/ServerPoolTest.java
@@ -157,7 +157,7 @@ public class ServerPoolTest extends AbstractServerPoolTest {
         assertAvailableCountEventuallyEquals(0);
     }
 
-    @Test
+    @Test(groups = "Integration")
     public void testAddExistingMachineFromSpec() {
         TestApplication app = createAppWithChildren(getInitialPoolSize());
         app.start(ImmutableList.of(pool.getDynamicLocation()));


### PR DESCRIPTION
The test is a no go on Windows and fails on builds.apache.org (connects to localhost)

---

Cannot establish ssh connection to jenkins @ SshMachineLocation[SshMachineLocation:MNYu:localhost/127.0.0.1](Exhausted available authentication methods). 
Ensure that passwordless and passphraseless ssh access is enabled using standard keys from ~/.ssh or as configured in brooklyn.properties. Check that the target host is accessible, that credentials are correct (location and permissions if using a key), that the SFTP subsystem is available on the remote side, and that there is sufficient random noise in /dev/random on 

Caused by: net.schmizz.sshj.userauth.UserAuthException: Exhausted available authentication methods
    at net.schmizz.sshj.userauth.UserAuthImpl.authenticate(UserAuthImpl.java:114)
    at net.schmizz.sshj.SSHClient.auth(SSHClient.java:205)
    at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:305)
    at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:353)
    at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:283)
    at brooklyn.util.internal.ssh.sshj.SshjClientConnection.create(SshjClientConnection.java:209)
    at brooklyn.util.internal.ssh.sshj.SshjClientConnection.create(SshjClientConnection.java:1)
    at brooklyn.util.internal.ssh.sshj.SshjTool.acquire(SshjTool.java:381)
    ... 19 more
