### PR TITLE
Changes non-functional image-name-matcher to imageId

### DIFF
--- a/software/nosql/src/test/java/brooklyn/entity/nosql/cassandra/CassandraNodeLiveTest.java
+++ b/software/nosql/src/test/java/brooklyn/entity/nosql/cassandra/CassandraNodeLiveTest.java
@@ -47,18 +47,18 @@ public class CassandraNodeLiveTest extends AbstractCassandraNodeTest {
 
     @DataProvider(name = "virtualMachineData")
     public Object[][] provideVirtualMachineData() {
-        return new Object[][] { // ImageName, Provider, Region
-            new Object[] { "ubuntu", "aws-ec2", "eu-west-1" },
-            new Object[] { "Ubuntu 12.0", "rackspace-cloudservers-uk", "" },
-            new Object[] { "CentOS 6.2", "rackspace-cloudservers-uk", "" },
+        return new Object[][] { // ImageId, Provider, Region, Description (for logging)
+            new Object[] { "eu-west-1/ami-0307d674", "aws-ec2", "eu-west-1", "Ubuntu Server 14.04 LTS (HVM), SSD Volume Type" },
+            new Object[] { "LON/f9b690bf-88eb-43c2-99cf-391f2558732e", "rackspace-cloudservers-uk", "", "Ubuntu 12.04 LTS (Precise Pangolin)" }, 
+            new Object[] { "LON/a84b1592-6817-42da-a57c-3c13f3cfc1da", "rackspace-cloudservers-uk", "", "CentOS 6.5 (PVHVM)" }, 
         };
     }
 
     @Test(groups = "Live", dataProvider = "virtualMachineData")
-    protected void testOperatingSystemProvider(String imageName, String provider, String region) throws Exception {
-        log.info("Testing Cassandra on {}{} using {}", new Object[] { provider, Strings.isNonEmpty(region) ? ":" + region : "", imageName });
+    protected void testOperatingSystemProvider(String imageId, String provider, String region, String description) throws Exception {
+        log.info("Testing Cassandra on {}{} using {} ({})", new Object[] { provider, Strings.isNonEmpty(region) ? ":" + region : "", description, imageId });
 
-        Map<String, String> properties = MutableMap.of("image-name-matches", imageName);
+        Map<String, String> properties = MutableMap.of("imageId", imageId);
         testLocation = app.getManagementContext().getLocationRegistry()
                 .resolve(provider + (Strings.isNonEmpty(region) ? ":" + region : ""), properties);
 

--- a/software/nosql/src/test/java/brooklyn/entity/nosql/couchdb/CouchDBNodeLiveTest.java
+++ b/software/nosql/src/test/java/brooklyn/entity/nosql/couchdb/CouchDBNodeLiveTest.java
@@ -47,18 +47,18 @@ public class CouchDBNodeLiveTest extends AbstractCouchDBNodeTest {
 
     @DataProvider(name = "virtualMachineData")
     public Object[][] provideVirtualMachineData() {
-        return new Object[][] { // ImageName, Provider, Region
-            new Object[] { "ubuntu", "aws-ec2", "eu-west-1" },
-            new Object[] { "Ubuntu 12.0", "rackspace-cloudservers-uk", "" },
-            new Object[] { "CentOS 6.2", "rackspace-cloudservers-uk", "" },
+        return new Object[][] { // ImageId, Provider, Region, Description (for logging)
+            new Object[] { "eu-west-1/ami-0307d674", "aws-ec2", "eu-west-1", "Ubuntu Server 14.04 LTS (HVM), SSD Volume Type" },
+            new Object[] { "LON/f9b690bf-88eb-43c2-99cf-391f2558732e", "rackspace-cloudservers-uk", "", "Ubuntu 12.04 LTS (Precise Pangolin)" }, 
+            new Object[] { "LON/a84b1592-6817-42da-a57c-3c13f3cfc1da", "rackspace-cloudservers-uk", "", "CentOS 6.5 (PVHVM)" }, 
         };
     }
 
     @Test(groups = "Live", dataProvider = "virtualMachineData")
-    protected void testOperatingSystemProvider(String imageName, String provider, String region) throws Exception {
-        log.info("Testing CouchDB on {}{} using {}", new Object[] { provider, Strings.isNonEmpty(region) ? ":" + region : "", imageName });
+    protected void testOperatingSystemProvider(String imageId, String provider, String region, String description) throws Exception {
+        log.info("Testing CouchDB on {}{} using {} ({})", new Object[] { provider, Strings.isNonEmpty(region) ? ":" + region : "", description, imageId });
 
-        Map<String, String> properties = MutableMap.of("image-name-matches", imageName);
+        Map<String, String> properties = MutableMap.of("imageId", imageId);
         testLocation = app.getManagementContext().getLocationRegistry()
                 .resolve(provider + (Strings.isNonEmpty(region) ? ":" + region : ""), properties);
 

--- a/software/nosql/src/test/java/brooklyn/entity/nosql/solr/SolrServerLiveTest.java
+++ b/software/nosql/src/test/java/brooklyn/entity/nosql/solr/SolrServerLiveTest.java
@@ -53,18 +53,18 @@ public class SolrServerLiveTest extends AbstractSolrServerTest {
 
     @DataProvider(name = "virtualMachineData")
     public Object[][] provideVirtualMachineData() {
-        return new Object[][] { // ImageName, Provider, Region
-            new Object[] { "ubuntu", "aws-ec2", "eu-west-1" },
-            new Object[] { "Ubuntu 12.0", "rackspace-cloudservers-uk", "" },
-            new Object[] { "CentOS 6.2", "rackspace-cloudservers-uk", "" },
+        return new Object[][] { // ImageId, Provider, Region, Description (for logging)
+            new Object[] { "eu-west-1/ami-0307d674", "aws-ec2", "eu-west-1", "Ubuntu Server 14.04 LTS (HVM), SSD Volume Type" },
+            new Object[] { "LON/f9b690bf-88eb-43c2-99cf-391f2558732e", "rackspace-cloudservers-uk", "", "Ubuntu 12.04 LTS (Precise Pangolin)" }, 
+            new Object[] { "LON/a84b1592-6817-42da-a57c-3c13f3cfc1da", "rackspace-cloudservers-uk", "", "CentOS 6.5 (PVHVM)" }, 
         };
     }
 
     @Test(groups = "Live", dataProvider = "virtualMachineData")
-    protected void testOperatingSystemProvider(String imageName, String provider, String region) throws Exception {
-        log.info("Testing Solr on {}{} using {}", new Object[] { provider, Strings.isNonEmpty(region) ? ":" + region : "", imageName });
+    protected void testOperatingSystemProvider(String imageId, String provider, String region, String description) throws Exception {
+        log.info("Testing Solr on {}{} using {} ({})", new Object[] { provider, Strings.isNonEmpty(region) ? ":" + region : "", description, imageId });
 
-        Map<String, String> properties = MutableMap.of("image-name-matches", imageName);
+        Map<String, String> properties = MutableMap.of("imageId", imageId);
         testLocation = app.getManagementContext().getLocationRegistry()
                 .resolve(provider + (Strings.isNonEmpty(region) ? ":" + region : ""), properties);
         solr = app.createAndManageChild(EntitySpec.create(SolrServer.class)


### PR DESCRIPTION
The following tests fail (and may have passed previously as they would have been run on the default image):

Couchbase / Ubuntu 12.04 (Rackspace)
Cassandra / CentOS 6.5 (Rackspace)
All Solr tests (v. 4.7.0 is no longer available on mirrors.ukfast.co.uk, but is on archive.apache.org/dist/lucene/solr)

There is no CentOS 6.2 image available in Rackspace, hence the switch to 6.5
Images courtesy of @aledsage's CloudExplorer (PR #103)

I suggest that these issues should be picked up in a separate PR
