### PR TITLE
Adds brooklyn-downstream-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1132,6 +1132,7 @@
                 <module>usage/all</module>
                 <module>usage/dist</module>
                 <module>usage/archetypes/quickstart</module>
+                <module>usage/downstream-parent</module>
             </modules>
         </profile>
         <profile>

--- a/usage/downstream-parent/pom.xml
+++ b/usage/downstream-parent/pom.xml
@@ -1,0 +1,545 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.brooklyn</groupId>
+  <artifactId>brooklyn-downstream-parent</artifactId>
+  <version>0.7.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+  <packaging>pom</packaging>
+  
+  <name>Brooklyn Downstream Project Parent</name>
+  <description>
+      Parent pom that can be used by downstream projects that use Brooklyn,
+      or that contribute additional functionality to Brooklyn.
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <java.version>1.6</java.version>
+    
+    <brooklyn.version>0.7.0-SNAPSHOT</brooklyn.version>  <!-- BROOKLYN_VERSION -->
+
+    <!-- dependency versions should match those used by Brooklyn, to avoid conflicts -->
+    <logback.version>1.0.7</logback.version>
+    <testng.version>6.8</testng.version>
+    <surefire.version>2.13</surefire.version>
+    <guava.version>17.0</guava.version>
+    <xstream.version>1.4.7</xstream.version>
+    <jackson.version>1.9.13</jackson.version>
+    <fasterxml.jackson.version>2.2.0</fasterxml.jackson.version>
+    <jersey.version>1.12</jersey.version>
+    <httpclient.version>4.2.5</httpclient.version>
+    <commons-lang3.version>3.1</commons-lang3.version>
+
+    <includedTestGroups />
+    <excludedTestGroups>Integration,Acceptance,Live,Live-sanity,WIP</excludedTestGroups>
+    
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- this would pull in all brooklyn entities and clouds; 
+             you can cherry pick selected ones instead (for a smaller build) -->
+        <groupId>io.brooklyn</groupId>
+        <artifactId>brooklyn-all</artifactId>
+        <version>${brooklyn.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  
+  <dependencies>
+    <dependency>
+      <!-- this gives us flexible and easy-to-use logging; just edit logback-custom.xml! -->
+      <groupId>io.brooklyn</groupId>
+      <artifactId>brooklyn-logback-xml</artifactId>
+      <version>${brooklyn.version}</version>
+      <!-- optional so that this project has logging; dependencies may redeclare or supply their own; 
+           provided so that it isn't put into the assembly (as it supplies its own explicit logback.xml); 
+           see Logging in the Brooklyn website/userguide for more info -->
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- includes testng and useful logging for tests -->
+      <groupId>io.brooklyn</groupId>
+      <artifactId>brooklyn-test-support</artifactId>
+      <version>${brooklyn.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- includes brooklyn.test.LoggingVerboseReporter -->
+      <groupId>io.brooklyn</groupId>
+      <artifactId>brooklyn-utils-test-support</artifactId>
+      <version>${brooklyn.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <!-- enable snapshots from sonatype -->
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <testSourceDirectory>src/test/java</testSourceDirectory>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.0</version>
+          <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.9</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.1.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.4.1</version>
+          <configuration>
+            <filesets>
+              <fileset>
+                <directory>.</directory>
+                <includes>
+                  <include>brooklyn*.log</include>
+                  <include>brooklyn*.log.*</include>
+                  <include>stacktrace.log</include>
+                  <include>test-output</include>
+                  <include>prodDb.*</include>
+                </includes>
+              </fileset>
+            </filesets>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-eclipse-plugin</artifactId>
+          <version>2.8</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${surefire.version}</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.8</version>
+          <inherited>true</inherited>
+          <configuration>
+            <!-- disabling use because of NPE deploying to sonatype:
+                 http://stackoverflow.com/questions/888199/why-does-maven-install-fail-during-javadoc-generation
+                 http://bugs.sun.com/bugdatabase/view_bug.do;jsessionid=ac084ab7f47c4e7f1df2117cecd?bug_id=5101868
+            -->
+            <use>false</use>
+            <links>
+              <link>http://download.oracle.com/javaee/6/api</link>
+            </links>
+            <keywords>true</keywords>
+            <author>false</author>
+            <quiet>true</quiet>
+            <aggregate>false</aggregate>
+            <detectLinks />
+            <tags>
+              <tag>
+                <name>todo</name>
+                <placement>a</placement>
+                <head>To-do:</head>
+              </tag>
+            </tags>
+          </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.1</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <!-- This configuration is used for Eclipse settings only. -->
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <versionRange>[2.1,)</versionRange>
+                    <goals>
+                      <goal>copy</goal>
+                      <goal>copy-dependencies</goal>
+                      <goal>unpack</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <versionRange>[2.3.4,)</versionRange>
+                    <goals>
+                      <goal>manifest</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <versionRange>[2.7,3)</versionRange>
+                    <goals>
+                      <goal>jar</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <versionRange>[1.0,)</versionRange>
+                    <goals>
+                      <goal>enforce</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                 </pluginExecution>
+                 <pluginExecution>
+                   <pluginExecutionFilter>
+                     <groupId>com.github.skwakman.nodejs-maven-plugin</groupId>
+                     <artifactId>nodejs-maven-plugin</artifactId>
+                     <versionRange>[1.0.3,)</versionRange>
+                     <goals>
+                       <goal>extract</goal>
+                     </goals>
+                   </pluginExecutionFilter>
+                   <action>
+                     <ignore></ignore>
+                   </action>
+                 </pluginExecution>
+                 <pluginExecution>
+                   <pluginExecutionFilter>
+                     <groupId>com.github.mcheely</groupId>
+                     <artifactId>requirejs-maven-plugin</artifactId>
+                     <versionRange>[2.0.0,)</versionRange>
+                     <goals>
+                       <goal>optimize</goal>
+                     </goals>
+                   </pluginExecutionFilter>
+                   <action>
+                     <ignore></ignore>
+                   </action>
+                 </pluginExecution>
+               </pluginExecutions>
+             </lifecycleMappingMetadata>
+           </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+      </plugin>
+      
+      <plugin>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <configuration>
+          <additionalProjectnatures>
+            <projectnature>org.maven.ide.eclipse.maven2Nature</projectnature>
+          </additionalProjectnatures>
+        </configuration>
+      </plugin>
+        
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-Xms256m -Xmx512m -XX:MaxPermSize=512m</argLine>
+          <properties>
+            <property>
+              <name>listener</name>
+              <value>brooklyn.test.LoggingVerboseReporter</value>
+            </property>
+          </properties>
+          <enableAssertions>true</enableAssertions>
+          <groups>${includedTestGroups}</groups>
+          <excludedGroups>${excludedTestGroups}</excludedGroups>
+          <testFailureIgnore>false</testFailureIgnore>
+          <systemPropertyVariables>
+            <verbose>-1</verbose>
+            <net.sourceforge.cobertura.datafile>${project.build.directory}/cobertura/cobertura.ser</net.sourceforge.cobertura.datafile>
+            <cobertura.user.java.nio>false</cobertura.user.java.nio>
+          </systemPropertyVariables>
+          <printSummary>true</printSummary>
+        </configuration>
+      </plugin>
+        
+    </plugins>
+  </build>
+
+  <profiles>
+    <!-- run Integration tests with -PIntegration -->
+    <profile>
+      <id>Integration</id>
+      <properties>
+        <includedTestGroups>Integration</includedTestGroups>
+        <excludedTestGroups>Acceptance,Live,Live-sanity,WIP</excludedTestGroups>
+      </properties>
+    </profile>
+
+    <!-- run Live tests with -PLive -->
+    <profile>
+      <id>Live</id>
+      <properties>
+        <includedTestGroups>Live,Live-sanity</includedTestGroups>
+        <excludedTestGroups>Acceptance,WIP</excludedTestGroups>
+      </properties>
+    </profile>
+    
+    <!-- run Live-sanity tests with -PLive-sanity -->
+    <profile>
+      <id>Live-sanity</id>
+      <properties>
+        <includedTestGroups>Live-sanity</includedTestGroups>
+        <excludedTestGroups>Acceptance,WIP</excludedTestGroups>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>test-jar-creation</id>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+
+    <!-- make sonatype-friendly deployment build with -PSonatype
+         (they require signed artifacts, javadoc and source jars; 
+         this snippet doesn't do everything, as you need to set up a key etc,
+         but it should get you a long way there (and prevent maven faffing).
+         if you don't deploy to sonatype you can delete this, or leave it
+         (it has no effect unless you enter -PSonatype ) -->
+    <profile>
+      <id>Sonatype</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <inherited>true</inherited>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <inherited>true</inherited>
+            <configuration>
+              <!-- disable 'use' reporting because of NPE deploying to sonatype: 
+                   http://stackoverflow.com/questions/888199/why-does-maven-install-fail-during-javadoc-generation 
+                   http://bugs.sun.com/bugdatabase/view_bug.do;jsessionid=ac084ab7f47c4e7f1df2117cecd?bug_id=5101868 -->
+              <use>false</use>
+              <links>
+                <link>http://download.oracle.com/javaee/6/api</link>
+              </links>
+              <keywords>true</keywords>
+              <author>false</author>
+              <quiet>true</quiet>
+              <aggregate>false</aggregate>
+              <detectLinks />
+              <tags>
+                <tag>
+                  <name>todo</name>
+                  <placement>a</placement>
+                  <head>To-do:</head>
+                </tag>
+              </tags>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>Bundle</id>
+      <activation>
+        <file>
+          <!-- NB - this is all the leaf projects, including logback-* (with no src);
+               the archetype project neatly ignores this however -->
+          <exists>${basedir}/src</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <extensions>true</extensions>
+            <!-- configure plugin to generate MANIFEST.MF
+                 adapted from http://blog.knowhowlab.org/2010/06/osgi-tutorial-from-project-structure-to.html -->
+            <executions>
+              <execution>
+                <id>bundle-manifest</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>manifest</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <supportedProjectTypes>
+                <supportedProjectType>jar</supportedProjectType>
+              </supportedProjectTypes>
+              <instructions>
+                <!-- OSGi specific instruction -->
+                <!--
+                    By default packages containing impl and internal
+                    are not included in the export list. Setting an
+                    explicit wildcard will include all packages
+                    regardless of name.
+                    In time we should minimize our export lists to
+                    what is really needed.
+                -->
+                <Export-Package>brooklyn.*</Export-Package>
+              </instructions>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+              <archive>
+                <manifestFile> ${project.build.outputDirectory}/META-INF/MANIFEST.MF </manifestFile>
+              </archive>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
+
+</project>


### PR DESCRIPTION
This can be used by downstream projects, to keep their POMs much simpler and to remove vast amounts of duplication that exist in those downstream projects.

Note that this uses the Java compiler, rather than the groovy compiler.

@grkvlt @ahgittin can you review please?
