### PR TITLE
Force UNIX style line endings for shell scripts.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+#Don't auto-convert line endings for shell scripts on Windows (breaks the scripts)
+*.sh text eol=lf


### PR DESCRIPTION
Shell scripts must have UNIX style endings even on Windows so that when the projects is built, packaged and run on Linux they work without errors.
