### PR TITLE
Register Lifecycle.Transition coalesce adapter so it can be deserialized

### DIFF
--- a/core/src/test/java/brooklyn/entity/basic/LifecycleTransitionTest.java
+++ b/core/src/test/java/brooklyn/entity/basic/LifecycleTransitionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.basic;
+
+import static org.testng.Assert.assertTrue;
+
+import java.util.Date;
+
+import org.testng.annotations.Test;
+
+import brooklyn.entity.basic.Lifecycle.Transition;
+import brooklyn.entity.basic.Lifecycle.TransitionCoalesceFunction;
+
+public class LifecycleTransitionTest {
+    @Test
+    public void testTransitionCoalesce() {
+        Transition t = new Transition(Lifecycle.RUNNING, new Date());
+        String serialized = t.toString();
+        Transition t2 = new TransitionCoalesceFunction().apply(serialized);
+        assertTrue(t.equals(t2), "Deserialized Lifecycle.Transition not equal to original");
+    }
+}

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynEntityMirrorImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynEntityMirrorImpl.java
@@ -62,6 +62,11 @@ public class BrooklynEntityMirrorImpl extends AbstractEntity implements Brooklyn
     
     private HttpFeed mirror;
     
+
+    //Passively mirror entity's state
+    @Override
+    protected void initEnrichers() {}
+
     @Override
     public void init() {
         super.init();


### PR DESCRIPTION
Also don't register lifecycle effectors for mirror entities.
