### PR TITLE
fix check brooklyn.properties when ACL are present

### DIFF
--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynLauncher.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynLauncher.java
@@ -579,7 +579,7 @@ public class BrooklynLauncher {
         if (permission.isAbsent()) {
             LOG.debug("Could not determine permissions of file; assuming ok: "+f);
         } else {
-            if (!permission.get().substring(4).equals("------")) {
+            if (!permission.get().subSequence(4, 10).equals("------")) {
                 throw new FatalRuntimeException("Invalid permissions for file "+file+"; expected ?00 but was "+permission.get());
             }
         }


### PR DESCRIPTION
This should fix an issue that happens on linux server when an extra dot is shown at the end of the file permissions, i.e.: `-rw-------.` instead of `-rw-------` 
