### PR TITLE
Refactors tests to work around IntelliJ IDEA build issues

### DIFF
--- a/core/src/test/java/brooklyn/entity/hello/LocalEntitiesTest.java
+++ b/core/src/test/java/brooklyn/entity/hello/LocalEntitiesTest.java
@@ -266,7 +266,7 @@ public class LocalEntitiesTest extends BrooklynAppUnitTestSupport {
         app.setConfig(HelloEntity.MY_NAME, "Bob");
         
         HelloEntity dad = app.createAndManageChild(EntitySpec.create(HelloEntity.class));
-        HelloEntity son = entityManager.createEntity(EntitySpec.create(HelloEntity.class)
+        HelloEntity son = (HelloEntity)entityManager.createEntity(EntitySpec.create(HelloEntity.class)
                 .parent(dad)
                 .configure(HelloEntity.MY_NAME, transform(attributeWhenReady(dad, HelloEntity.FAVOURITE_NAME, (Closure)null), new Function<String,String>() {
                     public String apply(String input) {

--- a/software/webapp/src/test/java/brooklyn/entity/proxy/nginx/NginxUrlMappingIntegrationTest.java
+++ b/software/webapp/src/test/java/brooklyn/entity/proxy/nginx/NginxUrlMappingIntegrationTest.java
@@ -417,7 +417,7 @@ public class NginxUrlMappingIntegrationTest extends BrooklynAppLiveTestSupport {
         c1.resize(2);
         List c1jbosses = new ArrayList(c1.getMembers());
         c1jbosses.remove(c1jboss);
-        Entity c1jboss2 = Iterables.getOnlyElement(c1jbosses);
+        Entity c1jboss2 = (Entity)Iterables.getOnlyElement(c1jbosses);
 
         // TODO Have to wait for new app-server; should fix app-servers to block
         // Also wait for TARGET_ADDRESSES to update

--- a/utils/common/src/test/java/brooklyn/util/guava/IfFunctionsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/guava/IfFunctionsTest.java
@@ -41,8 +41,11 @@ public class IfFunctionsTest {
     
     @Test
     public void testPredicateAndSupplier() {
-        checkTF(IfFunctions.ifPredicate(Predicates.equalTo(false)).get(Suppliers.ofInstance("F"))
-            .ifEquals(true).value("T").defaultGet(Suppliers.ofInstance("?")).build(), "?");
+        Function function = IfFunctions.ifPredicate(Predicates.equalTo(false)).get(Suppliers.ofInstance("F"))
+                .ifEquals(true).value("T").defaultGet(Suppliers.ofInstance("?")).build();
+        Assert.assertEquals(function.apply(true), "T");
+        Assert.assertEquals(function.apply(false), "F");
+        Assert.assertEquals(function.apply(null), "?");
     }
 
     @Test


### PR DESCRIPTION
Strictly speaking, this refactoring is unnecessary and undesirable, however it is required in order to work around an IntelliJ IDEA issue that prevents IntelliJ from launching Brooklyn (i.e. by launching `BrooklynJavascriptGuiLauncher`)

With these changes, you can create an IntelliJ Run/Debug configuration that launches `BrooklynJavascriptGuiLauncher`. (In order for the GUI to be available, you need to manually set the working directory of the configuration to e.g. `/Users/martin/Documents/brooklyn/usage/jsgui`)

The issues have been raised with JetBrains here: https://intellij-support.jetbrains.com/requests/38167
