### PR TITLE
Use ASL'ed version of JNA

### DIFF
--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -111,15 +111,25 @@
             <groupId>${jclouds.groupId}.driver</groupId>
             <artifactId>jclouds-sshj</artifactId>
             <exclusions>
+                <!-- provided versions are LGPL-only -->
                 <exclusion>
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jsch.agentproxy.usocket-jna</artifactId>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.jcraft</groupId>
-                    <artifactId>jsch.agentproxy.pageant</artifactId>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>platform</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- dual-licensed under LGPL and ASL 2 -->
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
         <hamcrest.version>1.1</hamcrest.version>
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <maxmind.version>0.8.1</maxmind.version>
+        <jna.version>4.0.0</jna.version>
 
         <includedTestGroups />
         <excludedTestGroups>Integration,Acceptance,Live,WIP</excludedTestGroups>
@@ -595,6 +596,16 @@
                 <groupId>com.maxmind.geoip2</groupId>
                 <artifactId>geoip2</artifactId>
                 <version>${maxmind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${jna.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Instead of excluding dependencies that pull in LGPL only version of JNA force a version which is dual licensed.
