### PR TITLE
Brooklyn Install Script

### DIFF
--- a/brooklyn-install.sh
+++ b/brooklyn-install.sh
@@ -275,11 +275,6 @@ ssh ${SSH_OPTS} ${USER}@${HOST} "cat > .brooklyn/catalog.xml" <<EOF
         <iconUrl>http://downloads.cloudsoftcorp.com/brooklyn/catalog/logos/JBoss_by_Red_Hat.png</iconUrl>
     </template>
 
-    <template type="brooklyn.demo.NodeJsTodoApplication" name="NodeJs TODO application">
-        <description>Deploys a Nodejs TODO application with a Redis back end</description>
-        <iconUrl>http://downloads.cloudsoftcorp.com/brooklyn/catalog/logos/nodejs-logo.png</iconUrl>
-    </template>
-
     <template type="brooklyn.demo.SimpleCassandraCluster" name="Demo Cassandra Cluster">
         <description>Deploys a demonstration Cassandra cluster</description>
         <iconUrl>http://downloads.cloudsoftcorp.com/brooklyn/catalog/logos/cassandra-sq-icon.jpg</iconUrl>


### PR DESCRIPTION
Updates to #157 to enable install on EC2 Ubuntu and other hosts that do not have remote root access, and better detection of remote hostname for checking liveness.

```
$ ./brooklyn-install.sh -s -u brooklyn -r ubuntu -k ~/.ssh/id_rsa-adk ec2-54-220-221-225.eu-west-1.compute.amazonaws.com
Installing Brooklyn 0.7.0-M1
Checking 'ec2-54-220-221-225.eu-west-1.compute.amazonaws.com:22' SSH connection......ok!
Installing prerequisite packages......done!
Installing Java 7 packages......done!
Creating 'brooklyn' user......done!
Setting up 'brooklyn' user......done!
Downloading Brooklyn distribution......done!
Configuring Brooklyn properties......done!
Installing examples and configuring catalog......done!
Starting Brooklyn...............done!
Brooklyn Console URL is http://ec2-54-220-221-225.eu-west-1.compute.amazonaws.com:8081/
Checking Brooklyn connection......success!
```
