### PR TITLE
be soft not weak (WeakReference -> SoftReference)

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/BrooklynTaskTags.java
+++ b/core/src/main/java/brooklyn/entity/basic/BrooklynTaskTags.java
@@ -208,8 +208,8 @@ public class BrooklynTaskTags extends TaskTags {
         return new WrappedStream(streamType, stream);
     }
     /** creates a tag suitable for marking a stream available on a task, but which might be GC'd */
-    public static WrappedStream tagForStreamWeak(String streamType, ByteArrayOutputStream stream) {
-        Maybe<ByteArrayOutputStream> weakStream = Maybe.weakThen(stream, 
+    public static WrappedStream tagForStreamSoft(String streamType, ByteArrayOutputStream stream) {
+        Maybe<ByteArrayOutputStream> weakStream = Maybe.softThen(stream, 
             Maybe.of(Streams.byteArrayOfString("<contents-garbage-collected>")));
         return new WrappedStream(streamType,
             Suppliers.compose(Functions.toStringFunction(), weakStream),

--- a/core/src/main/java/brooklyn/util/task/BasicTask.java
+++ b/core/src/main/java/brooklyn/util/task/BasicTask.java
@@ -865,7 +865,7 @@ public class BasicTask<T> implements TaskInternal<T> {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void setSubmittedByTask(Task<?> task) {
-        submittedByTask = (Maybe)Maybe.weakThen((Task)task, (Maybe)Maybe.of(BasicTask.newGoneTaskFor(task)));
+        submittedByTask = (Maybe)Maybe.softThen((Task)task, (Maybe)Maybe.of(BasicTask.newGoneTaskFor(task)));
     }
     
     @Override

--- a/core/src/main/java/brooklyn/util/task/system/ProcessTaskWrapper.java
+++ b/core/src/main/java/brooklyn/util/task/system/ProcessTaskWrapper.java
@@ -55,8 +55,8 @@ public abstract class ProcessTaskWrapper<RET> extends ProcessTaskStub implements
     protected ProcessTaskWrapper(AbstractProcessTaskFactory<?,RET> constructor) {
         super(constructor);
         TaskBuilder<Object> tb = constructor.constructCustomizedTaskBuilder();
-        if (stdout!=null) tb.tag(BrooklynTaskTags.tagForStreamWeak(BrooklynTaskTags.STREAM_STDOUT, stdout));
-        if (stderr!=null) tb.tag(BrooklynTaskTags.tagForStreamWeak(BrooklynTaskTags.STREAM_STDERR, stderr));
+        if (stdout!=null) tb.tag(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDOUT, stdout));
+        if (stderr!=null) tb.tag(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDERR, stderr));
         task = (Task<RET>) tb.body(new ProcessTaskInternalJob()).build();
     }
     

--- a/software/base/src/main/java/brooklyn/entity/basic/lifecycle/ScriptHelper.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/lifecycle/ScriptHelper.java
@@ -269,7 +269,7 @@ public class ScriptHelper {
                 stdin.write(line.getBytes());
                 stdin.write("\n".getBytes());
             }
-            tb.tag(BrooklynTaskTags.tagForStreamWeak(BrooklynTaskTags.STREAM_STDIN, stdin));
+            tb.tag(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDIN, stdin));
         } catch (IOException e) {
             log.warn("Error registering stream "+BrooklynTaskTags.STREAM_STDIN+" on "+tb+": "+e, e);
         }
@@ -283,9 +283,9 @@ public class ScriptHelper {
         
         if (gatherOutput) {
             stdout = new ByteArrayOutputStream();
-            tb.tag(BrooklynTaskTags.tagForStreamWeak(BrooklynTaskTags.STREAM_STDOUT, stdout));
+            tb.tag(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDOUT, stdout));
             stderr = new ByteArrayOutputStream();
-            tb.tag(BrooklynTaskTags.tagForStreamWeak(BrooklynTaskTags.STREAM_STDERR, stderr));
+            tb.tag(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDERR, stderr));
         }
         task = tb.build();
         if (isTransient) BrooklynTaskTags.setTransient(task);


### PR DESCRIPTION
use SoftReference when we have a Reference to an object which should be GC'd only when memory gets full
