### PR TITLE
eclipse should ignore unknown `copy-dependencies`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -845,6 +845,19 @@
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[2.8,)</versionRange>
+                                        <goals>
+                                            <goal>copy-dependencies</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-assembly-plugin</artifactId>
                                         <versionRange>[2.4.1,)</versionRange>
                                         <goals>


### PR DESCRIPTION
this fragment was removed in #176.  without it, eclipse gives ugly errors about not knowing what to do with "copy-dependencies" in the messaging example and the qa project. @grkvlt does this seem alright or is there a better way?
