### PR TITLE
jsgui: Replace _.template with custom function that strips comments

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/js/util/brooklyn.js
+++ b/usage/jsgui/src/main/webapp/assets/js/util/brooklyn.js
@@ -21,8 +21,8 @@
 /** brooklyn extension to make console methods available and simplify access to other utils */
 
 define([
-    "brooklyn-view", "brooklyn-utils"
-], function (BrooklynViews, BrooklynUtils) {
+    "underscore", "brooklyn-view", "brooklyn-utils"
+], function (_, BrooklynViews, BrooklynUtils) {
 
     /**
      * Makes the console API safe to use:
@@ -59,6 +59,23 @@ define([
             };
         }
     })();
+
+    var template = _.template;
+    _.mixin({
+        /**
+         * @param {string} text
+         * @return string The text with HTML comments removed.
+         */
+        stripComments: function (text) {
+            return text.replace(/<!--(.|[\n\r\t])*?-->\r?\n?/g, "");
+        },
+        /**
+         * As the real _.template, calling stripComments on text.
+         */
+        template: function (text, data, settings) {
+            return template(_.stripComments(text), data, settings);
+        }
+    });
 
     var Brooklyn = {
         view: BrooklynViews,

--- a/usage/jsgui/src/test/javascript/specs/brooklyn-spec.js
+++ b/usage/jsgui/src/test/javascript/specs/brooklyn-spec.js
@@ -75,6 +75,55 @@ define([
 
             });
         });
+    });
 
+    describe("_.stripComments", function () {
+        it("should strip a basic comment", function () {
+            var text = "<p>abc</p>\n <!-- comment-here --> <p>cba</p>";
+            expect(_.stripComments(text)).toBe("<p>abc</p>\n  <p>cba</p>");
+        });
+
+        it("should return an empty string for an empty comment", function () {
+            expect(_.stripComments("<!---->")).toBe("");
+            expect(_.stripComments("<!-- -->")).toBe("");
+        });
+
+        it("should strip multiple comments", function () {
+            var text = "a<!-- one -->b<!--two-->c<!-- three  -->";
+            expect(_.stripComments(text)).toBe("abc");
+        });
+
+        it("should strip trailing newlines", function () {
+            expect(_.stripComments("<!-- a -->\nb")).toBe("b");
+            expect(_.stripComments("<!-- a -->\rb")).toBe("b");
+        });
+
+        it("should leave text with no comments untouched", function () {
+            var text = "<p>abc</p>";
+            expect(_.stripComments(text)).toBe(text);
+        });
+
+        it("should remove the Apache license header from an HTML template", function () {
+            var text = "<!--\n" +
+                    "Licensed to the Apache Software Foundation (ASF) under one\n" +
+                    "or more contributor license agreements.  See the NOTICE file\n" +
+                    "distributed with this work for additional information\n" +
+                    "regarding copyright ownership.  The ASF licenses this file\n" +
+                    "to you under the Apache License, Version 2.0 (the\n" +
+                    "\"License\"); you may not use this file except in compliance\n" +
+                    "with the License.  You may obtain a copy of the License at\n" +
+                    "\n" +
+                     "http://www.apache.org/licenses/LICENSE-2.0\n" +
+                    "\n" +
+                    "Unless required by applicable law or agreed to in writing,\n" +
+                    "software distributed under the License is distributed on an\n" +
+                    "\"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n" +
+                    "KIND, either express or implied.  See the License for the\n" +
+                    "specific language governing permissions and limitations\n" +
+                    "under the License.\n" +
+                    "-->\n" +
+                    "real content";
+            expect(_.stripComments(text)).toBe("real content");
+        });
     });
 });


### PR DESCRIPTION
Makes the source much more readable. Before:
![screen shot 2014-09-26 at 18 48 39](https://cloud.githubusercontent.com/assets/837527/4425034/67da2018-45a5-11e4-8041-43486b1ea6b3.png)
After:
![screen shot 2014-09-26 at 18 45 43](https://cloud.githubusercontent.com/assets/837527/4425006/07877b70-45a5-11e4-9aca-54c0c1340964.png)

The rendered page itself still contains the Apache license header at the top.

Do we want to replace `_.template` or add an alternate function for use with templates likely to contain a license header? I figured the former saves having to replace lots of function calls and will automatically include all templates added in the future.
