### PR TITLE
Removes synchronization to prevent deadlock

### DIFF
--- a/core/src/main/java/brooklyn/management/internal/EntityManagementSupport.java
+++ b/core/src/main/java/brooklyn/management/internal/EntityManagementSupport.java
@@ -319,19 +319,21 @@ public class EntityManagementSupport {
         return getManagementContext().getEntitlementManager();
     }
 
-    public synchronized void attemptLegacyAutodeployment(String effectorName) {
-        if (managementContext!=null) {
-            log.warn("Autodeployment suggested but not required for "+entity+"."+effectorName);
-            return;
-        }
-        if (entity instanceof Application) {
-            log.warn("Autodeployment with new management context triggered for "+entity+"."+effectorName+" -- will not be supported in future. Explicit manage call required.");
-            if (initialManagementContext != null) {
-                initialManagementContext.getEntityManager().manage(entity);
-            } else {
-                Entities.startManagement(entity);
+    public void attemptLegacyAutodeployment(String effectorName) {
+        synchronized (this) {
+            if (managementContext != null) {
+                log.warn("Autodeployment suggested but not required for " + entity + "." + effectorName);
+                return;
             }
-            return;
+            if (entity instanceof Application) {
+                log.warn("Autodeployment with new management context triggered for " + entity + "." + effectorName + " -- will not be supported in future. Explicit manage call required.");
+                if (initialManagementContext != null) {
+                    initialManagementContext.getEntityManager().manage(entity);
+                } else {
+                    Entities.startManagement(entity);
+                }
+                return;
+            }
         }
         if ("start".equals(effectorName)) {
             Entity e=entity;


### PR DESCRIPTION
As discussed with @grkvlt 

JStack for deadlock as follows:

```
Found one Java-level deadlock:
=============================
"brooklyn-execmanager-zA0PEnbp-20":
waiting to lock monitor 0x00007fddfbbce918 (object 0x00000007e4732ef8, a brooklyn.entity.webapp.jboss.JBoss7ServerImpl),
which is held by "brooklyn-execmanager-zA0PEnbp-2"
"brooklyn-execmanager-zA0PEnbp-2":
waiting to lock monitor 0x00007fde02109a68 (object 0x00000007e47333c8, a brooklyn.management.internal.EntityManagementSupport),
which is held by "brooklyn-execmanager-zA0PEnbp-20"

Java stack information for the threads listed above:
===================================================
"brooklyn-execmanager-zA0PEnbp-20":
at brooklyn.entity.basic.AbstractEntity.getSubscriptionContext(AbstractEntity.java:1010)
- waiting to lock <0x00000007e4732ef8> (a brooklyn.entity.webapp.jboss.JBoss7ServerImpl)
at brooklyn.entity.basic.AbstractEntity.emitInternal(AbstractEntity.java:1293)
at brooklyn.entity.basic.AbstractEntity.emit(AbstractEntity.java:1289)
at brooklyn.entity.basic.EntityDynamicType.addSensorIfAbsent(EntityDynamicType.java:181)
at brooklyn.entity.basic.AbstractEntity.setAttribute(AbstractEntity.java:780)
at brooklyn.entity.basic.ServiceStateLogic.setExpectedState(ServiceStateLogic.java:117)
at brooklyn.entity.basic.SoftwareProcessImpl.onManagementStarting(SoftwareProcessImpl.java:254)
at brooklyn.management.internal.EntityManagementSupport.onManagementStarting(EntityManagementSupport.java:177)
at brooklyn.management.internal.LocalEntityManager$2.apply(LocalEntityManager.java:254)
at brooklyn.management.internal.LocalEntityManager$2.apply(LocalEntityManager.java:1)
at brooklyn.management.internal.LocalEntityManager.recursively(LocalEntityManager.java:319)
at brooklyn.management.internal.LocalEntityManager.manage(LocalEntityManager.java:248)
at brooklyn.management.internal.EntityManagementSupport.attemptLegacyAutodeployment(EntityManagementSupport.java:340)
- locked <0x00000007e47333c8> (a brooklyn.management.internal.EntityManagementSupport)
at brooklyn.management.internal.EffectorUtils.invokeMethodEffector(EffectorUtils.java:232)
at brooklyn.entity.basic.MethodEffector.call(MethodEffector.java:149)
at brooklyn.entity.trait.Startable$StartEffectorBody.call(Startable.java:54)
at brooklyn.entity.trait.Startable$StartEffectorBody.call(Startable.java:1)
at brooklyn.entity.effector.EffectorTasks$EffectorBodyTaskFactory$1.call(EffectorTasks.java:81)
at brooklyn.util.task.DynamicSequentialTask$DstJob.call(DynamicSequentialTask.java:323)
at brooklyn.util.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:406)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
"brooklyn-execmanager-zA0PEnbp-2":
at brooklyn.management.internal.EntityManagementSupport.getSubscriptionContext(EntityManagementSupport.java:311)
- waiting to lock <0x00000007e47333c8> (a brooklyn.management.internal.EntityManagementSupport)
at brooklyn.entity.basic.AbstractEntity.getSubscriptionContext(AbstractEntity.java:1010)
- locked <0x00000007e4732ef8> (a brooklyn.entity.webapp.jboss.JBoss7ServerImpl)
at brooklyn.entity.basic.AbstractEntity.emitInternal(AbstractEntity.java:1293)
at brooklyn.event.basic.AttributeMap.update(AttributeMap.java:116)
at brooklyn.entity.basic.AbstractEntity.setAttribute(AbstractEntity.java:777)
at brooklyn.enricher.basic.AbstractEnricher.emit(AbstractEnricher.java:107)
at brooklyn.entity.basic.ServiceStateLogic$ComputeServiceState.setActualState(ServiceStateLogic.java:266)
at brooklyn.entity.basic.ServiceStateLogic$ComputeServiceState.onEvent(ServiceStateLogic.java:229)
at brooklyn.management.internal.LocalSubscriptionManager$1.run(LocalSubscriptionManager.java:189)
at brooklyn.util.concurrent.CallableFromRunnable.call(CallableFromRunnable.java:43)
at brooklyn.util.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:406)
at brooklyn.util.task.SingleThreadedScheduler$1.call(SingleThreadedScheduler.java:117)
at java.util.concurrent.FutureTask.run(FutureTask.java:262)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
at java.lang.Thread.run(Thread.java:745)
```
