### PR TITLE
Improve UI shutdown

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/tpl/help/page.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/help/page.html
@@ -50,7 +50,7 @@ under the License.
             $.ajax({
                 type:"POST",
                 url:"/v1/server/shutdown",
-                data: { stopAppsFirst: stopAppsFirst },
+                data: { stopAppsFirst: stopAppsFirst, shutdownTimeout: 0, requestTimeout: 0 },
                 success:function (data) {
                     $('#help-page').fadeTo(500,0.1);
                 },


### PR DESCRIPTION
Wait for the actual result of the shutdown call.
Wait indefinitely for the shutdown result, otherwise we get "invalid" success, not aware if there was indeed a shutdown.
