### PR TITLE
Fix XsltTransformerTest on Windows

### DIFF
--- a/core/src/test/java/brooklyn/entity/rebind/transformer/impl/XsltTransformerTest.java
+++ b/core/src/test/java/brooklyn/entity/rebind/transformer/impl/XsltTransformerTest.java
@@ -31,29 +31,31 @@ import com.google.common.collect.ImmutableMap;
 
 public class XsltTransformerTest {
 
+    private static String NEWLINE = System.getProperty("line.separator");
+    
     @Test
     public void testRenameType() throws Exception {
         String xsltTemplate = ResourceUtils.create(XsltTransformerTest.class).getResourceAsString("classpath://brooklyn/entity/rebind/transformer/renameType.xslt");
         String xslt = TemplateProcessor.processTemplateContents(xsltTemplate, ImmutableMap.of("old_val", "mytype.Before", "new_val", "mytype.After"));
         String input = 
-                "<entity myattrib=\"myval\">"+"\n"+
-                "  <type myattrib2=\"myval2\">mytype.Before</type>"+"\n"+
-                "  <nested>"+"\n"+
-                "    <type myattrib3=\"myval3\">doesNotMatch</type>"+"\n"+
-                "    <type myattrib4=\"myval4\">partial.mytype.Before</type>"+"\n"+
-                "    <type myattrib5=\"myval5\">mytype.Before</type>"+"\n"+
-                "  </nested>"+"\n"+
-                "  <id>myid</id>"+"\n"+
+                "<entity myattrib=\"myval\">"+NEWLINE+
+                "  <type myattrib2=\"myval2\">mytype.Before</type>"+NEWLINE+
+                "  <nested>"+NEWLINE+
+                "    <type myattrib3=\"myval3\">doesNotMatch</type>"+NEWLINE+
+                "    <type myattrib4=\"myval4\">partial.mytype.Before</type>"+NEWLINE+
+                "    <type myattrib5=\"myval5\">mytype.Before</type>"+NEWLINE+
+                "  </nested>"+NEWLINE+
+                "  <id>myid</id>"+NEWLINE+
                 "</entity>";
         String expected = 
-                "<entity myattrib=\"myval\">"+"\n"+
-                "  <type myattrib2=\"myval2\">mytype.After</type>"+"\n"+
-                "  <nested>"+"\n"+
-                "    <type myattrib3=\"myval3\">doesNotMatch</type>"+"\n"+
-                "    <type myattrib4=\"myval4\">partial.mytype.Before</type>"+"\n"+
-                "    <type myattrib5=\"myval5\">mytype.After</type>"+"\n"+
-                "  </nested>"+"\n"+
-                "  <id>myid</id>"+"\n"+
+                "<entity myattrib=\"myval\">"+NEWLINE+
+                "  <type myattrib2=\"myval2\">mytype.After</type>"+NEWLINE+
+                "  <nested>"+NEWLINE+
+                "    <type myattrib3=\"myval3\">doesNotMatch</type>"+NEWLINE+
+                "    <type myattrib4=\"myval4\">partial.mytype.Before</type>"+NEWLINE+
+                "    <type myattrib5=\"myval5\">mytype.After</type>"+NEWLINE+
+                "  </nested>"+NEWLINE+
+                "  <id>myid</id>"+NEWLINE+
                 "</entity>";
         
         XsltTransformer transformer = new XsltTransformer(xslt);
@@ -66,36 +68,36 @@ public class XsltTransformerTest {
         String xsltTemplate = ResourceUtils.create(XsltTransformerTest.class).getResourceAsString("classpath://brooklyn/entity/rebind/transformer/renameField.xslt");
         String xslt = TemplateProcessor.processTemplateContents(xsltTemplate, ImmutableMap.of("class_name", "MyClass", "old_val", "myFieldBefore", "new_val", "myFieldAfter"));
         String input = 
-                "<entity myattrib=\"myval\">"+"\n"+
-                "  <type myattrib2=\"myval2\">mytype.Before</type>"+"\n"+
-                "  <config>"+"\n"+
-                "    <test.conf1>"+"\n"+
-                "      <MyClass>"+"\n"+
-                "        <myFieldBefore class=\"string\">myfieldval</myFieldBefore>"+"\n"+
-                "      </MyClass>"+"\n"+
-                "    </test.conf1>"+"\n"+
-                "    <test.conf2>"+"\n"+
-                "      <MyOtherClass>"+"\n"+
-                "        <myFieldBefore class=\"string\">myfieldval</myFieldBefore>"+"\n"+
-                "      </MyOtherClass>"+"\n"+
-                "    </test.conf2>"+"\n"+
-                "  </config>"+"\n"+
+                "<entity myattrib=\"myval\">"+NEWLINE+
+                "  <type myattrib2=\"myval2\">mytype.Before</type>"+NEWLINE+
+                "  <config>"+NEWLINE+
+                "    <test.conf1>"+NEWLINE+
+                "      <MyClass>"+NEWLINE+
+                "        <myFieldBefore class=\"string\">myfieldval</myFieldBefore>"+NEWLINE+
+                "      </MyClass>"+NEWLINE+
+                "    </test.conf1>"+NEWLINE+
+                "    <test.conf2>"+NEWLINE+
+                "      <MyOtherClass>"+NEWLINE+
+                "        <myFieldBefore class=\"string\">myfieldval</myFieldBefore>"+NEWLINE+
+                "      </MyOtherClass>"+NEWLINE+
+                "    </test.conf2>"+NEWLINE+
+                "  </config>"+NEWLINE+
                 "</entity>";
         String expected = 
-                "<entity myattrib=\"myval\">"+"\n"+
-                "  <type myattrib2=\"myval2\">mytype.Before</type>"+"\n"+
-                "  <config>"+"\n"+
-                "    <test.conf1>"+"\n"+
-                "      <MyClass>"+"\n"+
-                "        <myFieldAfter class=\"string\">myfieldval</myFieldAfter>"+"\n"+
-                "      </MyClass>"+"\n"+
-                "    </test.conf1>"+"\n"+
-                "    <test.conf2>"+"\n"+
-                "      <MyOtherClass>"+"\n"+
-                "        <myFieldBefore class=\"string\">myfieldval</myFieldBefore>"+"\n"+
-                "      </MyOtherClass>"+"\n"+
-                "    </test.conf2>"+"\n"+
-                "  </config>"+"\n"+
+                "<entity myattrib=\"myval\">"+NEWLINE+
+                "  <type myattrib2=\"myval2\">mytype.Before</type>"+NEWLINE+
+                "  <config>"+NEWLINE+
+                "    <test.conf1>"+NEWLINE+
+                "      <MyClass>"+NEWLINE+
+                "        <myFieldAfter class=\"string\">myfieldval</myFieldAfter>"+NEWLINE+
+                "      </MyClass>"+NEWLINE+
+                "    </test.conf1>"+NEWLINE+
+                "    <test.conf2>"+NEWLINE+
+                "      <MyOtherClass>"+NEWLINE+
+                "        <myFieldBefore class=\"string\">myfieldval</myFieldBefore>"+NEWLINE+
+                "      </MyOtherClass>"+NEWLINE+
+                "    </test.conf2>"+NEWLINE+
+                "  </config>"+NEWLINE+
                 "</entity>";
         
         XsltTransformer transformer = new XsltTransformer(xslt);
@@ -108,24 +110,24 @@ public class XsltTransformerTest {
         String xsltTemplate = ResourceUtils.create(XsltTransformerTest.class).getResourceAsString("classpath://brooklyn/entity/rebind/transformer/renameClass.xslt");
         String xslt = TemplateProcessor.processTemplateContents(xsltTemplate, ImmutableMap.of("old_val", "MyClassBefore", "new_val", "MyClassAfter"));
         String input = 
-                "<entity myattrib=\"myval\">"+"\n"+
-                "  <type myattrib2=\"myval2\">mytype.Before</type>"+"\n"+
-                "  <config>"+"\n"+
-                "    <test.conf1>"+"\n"+
-                "      <MyClassBefore>"+"\n"+
-                "      </MyClassBefore>"+"\n"+
-                "    </test.conf1>"+"\n"+
-                "  </config>"+"\n"+
+                "<entity myattrib=\"myval\">"+NEWLINE+
+                "  <type myattrib2=\"myval2\">mytype.Before</type>"+NEWLINE+
+                "  <config>"+NEWLINE+
+                "    <test.conf1>"+NEWLINE+
+                "      <MyClassBefore>"+NEWLINE+
+                "      </MyClassBefore>"+NEWLINE+
+                "    </test.conf1>"+NEWLINE+
+                "  </config>"+NEWLINE+
                 "</entity>";
         String expected = 
-                "<entity myattrib=\"myval\">"+"\n"+
-                "  <type myattrib2=\"myval2\">mytype.Before</type>"+"\n"+
-                "  <config>"+"\n"+
-                "    <test.conf1>"+"\n"+
-                "      <MyClassAfter>"+"\n"+
-                "      </MyClassAfter>"+"\n"+
-                "    </test.conf1>"+"\n"+
-                "  </config>"+"\n"+
+                "<entity myattrib=\"myval\">"+NEWLINE+
+                "  <type myattrib2=\"myval2\">mytype.Before</type>"+NEWLINE+
+                "  <config>"+NEWLINE+
+                "    <test.conf1>"+NEWLINE+
+                "      <MyClassAfter>"+NEWLINE+
+                "      </MyClassAfter>"+NEWLINE+
+                "    </test.conf1>"+NEWLINE+
+                "  </config>"+NEWLINE+
                 "</entity>";
         
         XsltTransformer transformer = new XsltTransformer(xslt);


### PR DESCRIPTION
Hardcoded use of "\n" fails on Windows. Switch to use line.separator
property.
