### PR TITLE
Fix stack overflow error

### DIFF
--- a/core/src/main/java/brooklyn/config/render/RendererHints.java
+++ b/core/src/main/java/brooklyn/config/render/RendererHints.java
@@ -93,8 +93,8 @@ public class RendererHints {
     public static Set<Hint<?>> getHintsFor(Object element) { return getHintsFor(element, null); }
 
     @Deprecated /** @deprecated since 0.7.0 only supported for certain types */
-    @SuppressWarnings("rawtypes")
-    public static Set<Hint<?>> getHintsFor(Object element, Class<? extends Hint> optionalHintSuperClass) { return getHintsFor(element, optionalHintSuperClass); }
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static Set<Hint<?>> getHintsFor(Object element, Class<? extends Hint> optionalHintSuperClass) { return (Set<Hint<?>>) _getHintsFor(element, optionalHintSuperClass); }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private static <T extends Hint> Set<T> _getHintsFor(Object element, Class<T> optionalHintSuperClass) {


### PR DESCRIPTION
There is an infinite recursion in the RendererHints. getHintsFor(Object,Class) method. The method is not supposed to be recursive. It also required a cast to prevent compilation errors on the return type because of different generic constraints.

See https://issues.apache.org/jira/browse/BROOKLYN-77.
