### PR TITLE
Change references to org.apache.brooklyn for Maven groupId

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNode.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNode.java
@@ -73,7 +73,7 @@ public interface BrooklynNode extends SoftwareProcess, UsesJava {
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
             SoftwareProcess.DOWNLOAD_URL,
             "<#if version?contains(\"SNAPSHOT\")>"+
-                "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn&v=${version}&a=brooklyn-dist&c=dist&e=tar.gz" +
+                "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&v=${version}&a=brooklyn-dist&c=dist&e=tar.gz" +
             "<#else>"+
                 "http://search.maven.org/remotecontent?filepath=io/brooklyn/brooklyn-dist/${version}/brooklyn-dist-${version}-dist.tar.gz"+
             "</#if>");

--- a/software/base/src/test/java/brooklyn/entity/brooklynnode/BrooklynNodeIntegrationTest.java
+++ b/software/base/src/test/java/brooklyn/entity/brooklynnode/BrooklynNodeIntegrationTest.java
@@ -93,7 +93,7 @@ import com.google.common.io.Files;
  * The following commands may be useful:
  * <p>
  * <code>
- * cp ~/.m2/repository/io/brooklyn/brooklyn-dist/0.7.0-SNAPSHOT/brooklyn-dist-0.7.0-SNAPSHOT-dist.tar.gz ~/.brooklyn/repository/BrooklynNode/0.7.0-SNAPSHOT/BrooklynNode-0.7.0-SNAPSHOT.tar.gz
+ * cp ~/.m2/repository/org/apache/brooklyn/brooklyn-dist/0.7.0-SNAPSHOT/brooklyn-dist-0.7.0-SNAPSHOT-dist.tar.gz ~/.brooklyn/repository/BrooklynNode/0.7.0-SNAPSHOT/BrooklynNode-0.7.0-SNAPSHOT.tar.gz
  * rm -rf /tmp/brooklyn-`whoami`/installs/BrooklynNode*
  * </code>
  */

--- a/software/base/src/test/java/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
+++ b/software/base/src/test/java/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
@@ -58,8 +58,8 @@ public class BrooklynNodeTest {
     
     @Test
     public void testGeneratesCorrectSnapshotDownload() throws Exception {
-        String version = "0.6.0-SNAPSHOT";
-        String expectedUrl = "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.brooklyn&v="+version+"&a=brooklyn-dist&c=dist&e=tar.gz";
+        String version = "0.7.0-SNAPSHOT"; // BROOKLYN_VERSION
+        String expectedUrl = "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&v="+version+"&a=brooklyn-dist&c=dist&e=tar.gz";
         runTestGeneratesCorrectDownloadUrl(version, expectedUrl);
     }
     

--- a/usage/dist/src/main/dist/conf/catalog.xml
+++ b/usage/dist/src/main/dist/conf/catalog.xml
@@ -28,10 +28,10 @@
       <description>Deploys a demonstration web application to JBoss clusters around the world</description>
       <iconUrl>http://releng3.cloudsoftcorp.com/downloads/brooklyn/img/JBoss_by_Red_Hat.png</iconUrl>
     </template>
-    
+
     <classpath>
-      <entry>https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&amp;g=io.brooklyn.example&amp;a=brooklyn-example-simple-web-cluster&amp;v=0.7.0-SNAPSHOT&amp;e=jar</entry> <!-- BROOKLYN_VERSION -->
-      <entry>https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&amp;g=io.brooklyn.example&amp;a=brooklyn-example-global-web-fabric&amp;v=0.7.0-SNAPSHOT&amp;e=jar</entry> <!-- BROOKLYN_VERSION -->
+      <entry>https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&amp;g=org.apache.brooklyn.example&amp;a=brooklyn-example-simple-web-cluster&amp;v=0.7.0-SNAPSHOT&amp;e=jar</entry> <!-- BROOKLYN_VERSION -->
+      <entry>https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&amp;g=org.apache.brooklyn.example&amp;a=brooklyn-example-global-web-fabric&amp;v=0.7.0-SNAPSHOT&amp;e=jar</entry> <!-- BROOKLYN_VERSION -->
     </classpath>
 </catalog>
 

--- a/utils/common/src/test/java/brooklyn/util/maven/MavenArtifactTest.java
+++ b/utils/common/src/test/java/brooklyn/util/maven/MavenArtifactTest.java
@@ -39,7 +39,7 @@ public class MavenArtifactTest {
     // only *integration* tests require these to be *installed*;
     // note this may vary from machine to machine so version should be aligned with that in parent pom
     final static String MAVEN_JAR_PLUGIN_COORDINATE = "org.apache.maven.plugins:maven-jar-plugin:jar:2.3.2";
-    final static String THIS_PROJECT_COORDINATE = "io.brooklyn:brooklyn-utils-common:jar:0.7.0-SNAPSHOT";  // BROOKLYN_VERSION
+    final static String THIS_PROJECT_COORDINATE = "org.apache.brooklyn:brooklyn-utils-common:jar:0.7.0-SNAPSHOT";  // BROOKLYN_VERSION
 
     // Don't need to be installed, only used as examples
     final static String RELEASED_SOURCES_COORDINATE = "io.brooklyn:brooklyn-core:jar:sources:0.6.0";
@@ -116,7 +116,7 @@ public class MavenArtifactTest {
         
         String localPath = new MavenRetriever().getLocalPath(m);
         Assert.assertTrue(localPath.contains(
-                "/repository/io/brooklyn"));
+                "/repository/org/apache/brooklyn"));
     }
 
     @Test(groups="Integration")
@@ -161,7 +161,7 @@ public class MavenArtifactTest {
     @Test(groups="Integration")
     public void testRetrievalHostedSnapshotIntegration() {
         MavenArtifact m = MavenArtifact.fromCoordinate(
-                "io.brooklyn:brooklyn-utils-common:jar:0.7.0-SNAPSHOT");  // BROOKLYN_VERSION
+                "org.apache.brooklyn:brooklyn-utils-common:jar:0.7.0-SNAPSHOT");  // BROOKLYN_VERSION
         
         String localPath = new MavenRetriever().getLocalPath(m);
         File f = new File(localPath);


### PR DESCRIPTION
Should be merged once the _org.apache.brooklyn_ artifacts are available on the OSS Sonatype Nexus server:
- https://oss.sonatype.org/#nexus-search;quick~org.apache.brooklyn
