### PR TITLE
Updates monit test to explicitly start process (vi) rather than assume '...

### DIFF
--- a/software/monitoring/src/main/java/brooklyn/entity/monitoring/monit/MonitNodeImpl.java
+++ b/software/monitoring/src/main/java/brooklyn/entity/monitoring/monit/MonitNodeImpl.java
@@ -93,8 +93,7 @@ public class MonitNodeImpl extends SoftwareProcessImpl implements MonitNode {
                     .onSuccess(new Function<SshPollValue, String>() {
                         @Override
                         public String apply(SshPollValue input) {
-                            String status = Strings.getFirstWordAfter(input.getStdout(), "status");
-                            return status;
+                            return Strings.trim(Strings.getRemainderOfLineAfter(input.getStdout(), "status"));
                         }
                     })
                     .setOnFailureOrException(null))

--- a/software/monitoring/src/test/resources/brooklyn/entity/monitoring/monit/monit.monitrc
+++ b/software/monitoring/src/test/resources/brooklyn/entity/monitoring/monit/monit.monitrc
@@ -24,7 +24,7 @@ set daemon 5
 set pidfile ${driver.runDir}/pid.txt
 set logfile ${driver.runDir}/monit.log
 
-check process cron
-	matching "cron"
+check process vi
+	matching "vi monittest"
 	group test
 	

--- a/utils/common/src/main/java/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/brooklyn/util/text/Strings.java
@@ -537,6 +537,22 @@ public class Strings {
         return getFirstWord(context.substring(index + phrase.length()));
     }
 
+   /**
+    * searches in context for the given phrase, and returns the <b>untrimmed</b> remainder of the first line
+    * on which the phrase is found
+    */
+    public static String getRemainderOfLineAfter(String context, String phrase) {
+        if (context == null || phrase == null) return null;
+        int index = context.indexOf(phrase);
+        if (index < 0) return null;
+        int lineEndIndex = context.indexOf("\n", index);
+        if (lineEndIndex <= 0) {
+            return context.substring(index + phrase.length());
+        } else {
+            return context.substring(index + phrase.length(), lineEndIndex);
+        }
+    }
+
     /** @deprecated use {@link Time#makeTimeStringRounded(long)} */
     @Deprecated
     public static String makeTimeString(long utcMillis) {

--- a/utils/common/src/test/java/brooklyn/util/text/StringsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/text/StringsTest.java
@@ -339,4 +339,20 @@ public class StringsTest extends FixedLocaleTest {
         Assert.assertEquals(Strings.maxlenWithEllipsis("hello world", 7, "--"), "hello--");
     }
 
+    @Test
+    public void testGetRemainderOfLineAfter() {
+        // Basic test (also tests start is trimmed)
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("the message is hello", "is"), " hello");
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("the message is is hello", "is"), " is hello");
+        // Trim spaces from end
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("the message is is hello    ", "is"), " is hello    ");
+        // Trim non-matching lines from start
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("one\ntwo\nthree\nthe message is is hello    ", "is"), " is hello    ");
+        // Trim lines from end
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("one\ntwo\nthree\nthe message is is hello    \nfour\nfive\nsix\nis not seven", "is"), " is hello    ");
+        // Play nicely with null / non-match
+        Assert.assertEquals(Strings.getRemainderOfLineAfter(null, "is"), null);
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("the message is hello", null), null);
+        Assert.assertEquals(Strings.getRemainderOfLineAfter("the message is hello", "foo"), null);
+    }
 }


### PR DESCRIPTION
...cron' is running, uses 'rest of line' for status, rather than next word
