### PR TITLE
Fix a HA failover bug where the master tries to become a master again and fails.

### DIFF
--- a/core/src/main/java/brooklyn/entity/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/brooklyn/entity/rebind/RebindManagerImpl.java
@@ -916,8 +916,10 @@ public class RebindManagerImpl implements RebindManager {
                 return ManagementTransitionMode.REBINDING_BECOMING_PRIMARY;
             else if (isNowReadOnly)
                 return ManagementTransitionMode.REBINDING_NO_LONGER_PRIMARY;
-            else
-                throw new IllegalStateException("Rebinding master not supported: "+item);
+            else {
+                LOG.warn("Transitioning to master, though never stopped being a master - " + item);
+                return ManagementTransitionMode.REBINDING_BECOMING_PRIMARY;
+            }
         }
     }
 

--- a/core/src/main/java/brooklyn/management/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/brooklyn/management/ha/HighAvailabilityManagerImpl.java
@@ -581,6 +581,8 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             LOG.debug("Master-change for this node only, demoting "+ownNodeRecord.toVerboseString()+" in favour of official master "+newMasterNodeRecord.toVerboseString());
             demoteToStandby(BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_DEFAULT_STANDBY_IS_HOT_PROPERTY));
             return;
+        } else {
+            LOG.debug("Detected master heartbeat timeout. Initiating a new master election. Master was " + currMasterNodeRecord);
         }
         
         // Need to choose a new master

--- a/core/src/test/java/brooklyn/management/ha/TestEntityFailingRebind.java
+++ b/core/src/test/java/brooklyn/management/ha/TestEntityFailingRebind.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.management.ha;
+
+import brooklyn.test.entity.TestApplicationImpl;
+
+public class TestEntityFailingRebind extends TestApplicationImpl {
+    public static class RebindException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public RebindException(String message) {
+            super(message);
+        }
+    }
+    
+    private static boolean throwOnRebind = true;
+    public static void setThrowOnRebind(boolean state) {
+        throwOnRebind = state;
+    }
+
+    @Override
+    public void rebind() {
+        if (throwOnRebind) {
+            throw new RebindException("Intentional exception thrown when rebinding " + this);
+        }
+    }
+
+}


### PR DESCRIPTION
Instead of failing just log a warning, turns out this case can happen in a real-world scenario where the storage delays the writes of the master.

Based on Sam's approach and prototype test, thanks.
