### PR TITLE
Show effector param scroll bars only when necessary.

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/css/base.css
+++ b/usage/jsgui/src/main/webapp/assets/css/base.css
@@ -1427,3 +1427,8 @@ the element's children, who probably want to control their opacity separately. *
     /* matches Bootstrap */
     margin-bottom: 9px;
 }
+
+textarea.param-value {
+    height: 18px;
+    overflow: auto;
+}

--- a/usage/jsgui/src/main/webapp/assets/tpl/apps/param.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/apps/param.html
@@ -28,7 +28,7 @@ under the License.
     <td><div id="selector-container" class="input-medium param-value"></div></td>
     <% } else { %>
     <td><!--  use 1 line textarea so it can be resized -->
-      <textarea class="input-medium param-value" style="height: 18px;"><%- defaultValue %></textarea>
+      <textarea class="input-medium param-value"><%- defaultValue %></textarea>
     </td>
     <% } %>    
 </tr>


### PR DESCRIPTION
Previously the scroll bars were always visible making the forms unusable. It's still the case when there is a lot of content in the field.
