### PR TITLE
Fix MariaDB (bump version to 5.5.40 from 5.5.33a)

### DIFF
--- a/software/database/src/main/java/brooklyn/entity/database/mariadb/MariaDbNode.java
+++ b/software/database/src/main/java/brooklyn/entity/database/mariadb/MariaDbNode.java
@@ -42,12 +42,13 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
 
     @SetFromFlag("version")
     public static final ConfigKey<String> SUGGESTED_VERSION =
-        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.33a");
+        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.40");
 
     // https://downloads.mariadb.org/interstitial/mariadb-5.5.33a/kvm-bintar-hardy-amd64/mariadb-5.5.33a-linux-x86_64.tar.gz/from/http://mirrors.coreix.net/mariadb
-    // above link points to a "donate" page, then ultimately downloads the artifact from:
-    // 64-bit: http://mirrors.coreix.net/mariadb/mariadb-5.5.33a/kvm-bintar-hardy-amd64/mariadb-5.5.33a-linux-x86_64.tar.gz
-    // 32-bit: http://mirrors.coreix.net/mariadb/mariadb-5.5.33a/kvm-bintar-hardy-x86/mariadb-5.5.33a-linux-i686.tar.gz
+    // above redirects to download the artifactd from the URLs below.
+    // Use `curl -sL -w "%{http_code} %{url_effective}\n" "http://..." -o target.tar.gz` to find out redirect URL.
+    //     64-bit: http://mirrors.coreix.net/mariadb/mariadb-5.5.40/bintar-linux-x86_64/mariadb-5.5.40-linux-x86_64.tar.gz
+    //     32-bit: http://mirrors.coreix.net/mariadb/mariadb-5.5.40/bintar-linux-x86/mariadb-5.5.40-linux-i686.tar.gz
 
     @SetFromFlag("downloadUrl")
     public static final BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(

--- a/software/database/src/main/java/brooklyn/entity/database/mariadb/MariaDbSshDriver.java
+++ b/software/database/src/main/java/brooklyn/entity/database/mariadb/MariaDbSshDriver.java
@@ -19,7 +19,9 @@
 package brooklyn.entity.database.mariadb;
 
 import static brooklyn.util.JavaGroovyEquivalents.groovyTruth;
-import static brooklyn.util.ssh.BashCommands.*;
+import static brooklyn.util.ssh.BashCommands.commandsToDownloadUrlsAs;
+import static brooklyn.util.ssh.BashCommands.installPackage;
+import static brooklyn.util.ssh.BashCommands.ok;
 import static java.lang.String.format;
 
 import java.io.InputStream;
@@ -72,17 +74,17 @@ public class MariaDbSshDriver extends AbstractSoftwareProcessSshDriver implement
         if (os == null) return "linux-i686";
         if (os.isWindows() || os.isMac())
             throw new UnsupportedOperationException("only support linux versions just now; OS details: " + os);
-        return "linux-" + (os.is64bit() ? "x86_64" : "i686");
+        return (os.is64bit() ? "linux-x86_64" : "linux-i686");
     }
 
     public String getDownloadParentDir() {
         // NOTE: cannot rely on OsDetails.isLinux() to return true for all linux flavours, so
         // explicitly test for unsupported OSes, otherwise assume generic linux.
         OsDetails os = getLocation().getOsDetails();
-        if (os == null) return "kvm-bintar-hardy-x86";
+        if (os == null) return "bintar-linux-x86";
         if (os.isWindows() || os.isMac())
             throw new UnsupportedOperationException("only support linux versions just now; OS details: " + os);
-        return "kvm-bintar-hardy-" + (os.is64bit() ? "amd64" : "x86");
+        return (os.is64bit() ? "bintar-linux-x86_64" : "bintar-linux-x86");
     }
 
     public String getMirrorUrl() {

--- a/software/database/src/test/java/brooklyn/entity/database/mariadb/MariaDbLiveEc2Test.java
+++ b/software/database/src/test/java/brooklyn/entity/database/mariadb/MariaDbLiveEc2Test.java
@@ -25,6 +25,7 @@ import brooklyn.entity.database.DatastoreMixins.DatastoreCommon;
 import brooklyn.entity.database.VogellaExampleAccess;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.location.Location;
+import brooklyn.location.jclouds.JcloudsLocation;
 
 import com.google.common.collect.ImmutableList;
 
@@ -33,9 +34,11 @@ public class MariaDbLiveEc2Test extends AbstractEc2LiveTest {
 
     @Override
     protected void doTest(Location loc) throws Exception {
-
+        // TODO For some CentOS VMs (e.g. in AWS 6.3, us-east-1/ami-a96b01c0), currently need to turn off iptables unfortunately.
+        // Should really just open the ports in iptables.
         MariaDbNode mariadb = app.createAndManageChild(EntitySpec.create(MariaDbNode.class)
-                .configure(DatastoreCommon.CREATION_SCRIPT_CONTENTS, MariaDbIntegrationTest.CREATION_SCRIPT));
+                .configure(DatastoreCommon.CREATION_SCRIPT_CONTENTS, MariaDbIntegrationTest.CREATION_SCRIPT)
+                .configure(MariaDbNode.PROVISIONING_PROPERTIES.subKey(JcloudsLocation.STOP_IPTABLES.getName()), true));
 
         app.start(ImmutableList.of(loc));
 


### PR DESCRIPTION
- fix download URLs
- uploaded artifacts to http://developers.cloudsoftcorp.com/brooklyn/repository/MariaDbNode/5.5.40, so will not break next time mirror removes this version
- live-test stops iptables
