### PR TITLE
Added location definition attribute to location owner

### DIFF
--- a/core/src/main/java/brooklyn/location/dynamic/LocationOwner.java
+++ b/core/src/main/java/brooklyn/location/dynamic/LocationOwner.java
@@ -27,6 +27,7 @@ import brooklyn.event.AttributeSensor;
 import brooklyn.event.basic.BasicAttributeSensorAndConfigKey;
 import brooklyn.event.basic.Sensors;
 import brooklyn.location.Location;
+import brooklyn.location.LocationDefinition;
 import brooklyn.util.flags.SetFromFlag;
 
 import com.google.common.annotations.Beta;
@@ -69,6 +70,9 @@ public interface LocationOwner<L extends Location & DynamicLocation<E, L>, E ext
 
     AttributeSensor<Boolean> DYNAMIC_LOCATION_STATUS = Sensors.newBooleanSensor(
             "entity.dynamicLocation.status", "The status of the location owned by this entity");
+
+    AttributeSensor<LocationDefinition> LOCATION_DEFINITION = Sensors.newSensor(
+        LocationDefinition.class, "entity.dynamicLocation.definition", "The location definition for the location owned by this entity");
 
     L getDynamicLocation();
 


### PR DESCRIPTION
Added the location definition as an attribute to the location owner. This is may be needed to fix brooklyncentral/clocker#57. There are a couple of alternatives to this either the location definition ID could be used instead of the entire location definition or the attribute could be added to the DockerInfrastructure in Clocker but I suspect that other LocationOwners will need to unregister the location definition when deleting the location.
