### PR TITLE
Bump groovy version to 2.3.4 from 1.8.6

### DIFF
--- a/core/src/test/java/brooklyn/util/internal/RepeaterTest.groovy
+++ b/core/src/test/java/brooklyn/util/internal/RepeaterTest.groovy
@@ -21,6 +21,7 @@ package brooklyn.util.internal
 import static java.util.concurrent.TimeUnit.*
 import static org.testng.Assert.*
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit
 
 import org.testng.annotations.Test
@@ -66,7 +67,7 @@ public class RepeaterTest {
 
     @Test(expectedExceptions = [ NullPointerException.class ])
     public void repeatFailsIfClosureIsNull() {
-        new Repeater("repeatFailsIfClosureIsNull").repeat(null);
+        new Repeater("repeatFailsIfClosureIsNull").repeat((Callable<?>)null);
         fail "Expected exception was not thrown"
     }
 

--- a/docs/dev/build/eclipse.include.md
+++ b/docs/dev/build/eclipse.include.md
@@ -9,7 +9,7 @@
   [dist.springsource.org/release/GRECLIPSE/e4.3](http://dist.springsource.org/release/GRECLIPSE/e4.3) 
   (or for Eclipse [4.2](http://dist.springsource.org/release/GRECLIPSE/e4.2) 
   or [3.7](http://dist.springsource.org/release/GRECLIPSE/e3.7)).
-  Be sure to include Groovy 1.8.6 compiler support and Maven-Eclipse (m2e) support. 
+  Be sure to include Groovy 2.3.4 compiler support and Maven-Eclipse (m2e) support. 
   More details are at the [groovy update site](http://groovy.codehaus.org/Eclipse+Plugin).
 
 - TestNG Plugin: beust TestNG from [beust.com/eclipse](http://beust.com/eclipse)

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <jclouds.groupId>org.apache.jclouds</jclouds.groupId>
         <jclouds.version>1.8.0</jclouds.version>
         <guava.version>17.0</guava.version>
-        <groovy.version>1.8.6</groovy.version>
+        <groovy.version>2.3.4</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.0-Release-Notes -->
         <logback.version>1.0.7</logback.version>
         <testng.version>6.8</testng.version>
         <mockito.version>1.9.5</mockito.version>
@@ -1118,12 +1118,12 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>2.7.0-01</version>
+                        <version>2.9.0-01</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>1.8.6-01</version>
+                        <version>2.3.4-01</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/usage/archetypes/quickstart/src/brooklyn-sample/pom.xml
+++ b/usage/archetypes/quickstart/src/brooklyn-sample/pom.xml
@@ -195,12 +195,12 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-eclipse-compiler</artifactId>
-            <version>2.6.0-01</version>
+            <version>2.9.0-01</version>
           </dependency>
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-eclipse-batch</artifactId>
-            <version>1.8.6-01</version>
+            <version>2.3.4-01</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
- And groovy-eclipse-compiler to 2.9.0-01 from 2.7.0-01
- And groovy-eclipse-batch to 2.3.4-01 from 1.8.6-01

Motivated by https://github.com/apache/incubator-brooklyn/pull/320, which incorrectly has a Java compilation error when compiled with Groovy 1.8.6 compiler.
