### PR TITLE
Swift object store - don't use application/directory markers

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsUtil.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsUtil.java
@@ -282,7 +282,8 @@ public class JcloudsUtil implements JcloudsLocationConfig {
 
         ContextBuilder contextBuilder = ContextBuilder.newBuilder(provider).credentials(identity, credential);
         contextBuilder.modules(MutableList.copyOf(JcloudsUtil.getCommonModules())
-            .appendIfNotNull(fix));
+            .appendIfNotNull(fix)
+            .append(new MkDirStrategyCustomModule()));
         if (!brooklyn.util.text.Strings.isBlank(endpoint)) {
             contextBuilder.endpoint(endpoint);
         }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/MkDirStrategyCustomModule.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/MkDirStrategyCustomModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import org.jclouds.blobstore.strategy.MkdirStrategy;
+
+import com.google.inject.AbstractModule;
+
+public class MkDirStrategyCustomModule extends AbstractModule  {
+
+    @Override
+    protected void configure() {
+        bind(MkdirStrategy.class).to(SuffixFileMkdirStrategy.class);
+    }
+
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/NoopMkdirStrategy.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/NoopMkdirStrategy.java
@@ -18,31 +18,15 @@
  */
 package brooklyn.location.jclouds;
 
-import static org.jclouds.io.Payloads.newByteArrayPayload;
+import javax.inject.Singleton;
 
-import org.jclouds.blobstore.BlobStore;
-import org.jclouds.blobstore.domain.StorageType;
-import org.jclouds.blobstore.reference.BlobStoreConstants;
 import org.jclouds.blobstore.strategy.MkdirStrategy;
 
-import com.google.inject.Inject;
+@Singleton
+public class NoopMkdirStrategy implements MkdirStrategy {
 
-public class SuffixFileMkdirStrategy implements MkdirStrategy {
-
-    protected String directorySuffix = "";
-    private final BlobStore blobStore;
-
-    @Inject
-    SuffixFileMkdirStrategy(BlobStore blobStore) {
-       this.blobStore = blobStore;
-       directorySuffix = BlobStoreConstants.DIRECTORY_SUFFIX_FOLDER;
-    }
-
+    @Override
     public void execute(String containerName, String directory) {
-       blobStore.putBlob(
-             containerName,
-             blobStore.blobBuilder(directory + directorySuffix).type(StorageType.RELATIVE_PATH)
-                   .payload(newByteArrayPayload(new byte[] {})).build());
     }
 
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/ObjectInfoOrSubdirImpl.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/ObjectInfoOrSubdirImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import java.beans.ConstructorProperties;
+import java.net.URI;
+import java.util.Date;
+
+import org.jclouds.openstack.swift.domain.internal.ObjectInfoImpl;
+
+public class ObjectInfoOrSubdirImpl extends ObjectInfoImpl {
+
+    @ConstructorProperties({
+        "name", "container", "uri", "hash", "bytes", "content_type", "last_modified", "subdir"
+    })
+    protected ObjectInfoOrSubdirImpl(String name, String container, URI uri,
+            byte[] hash, Long bytes, String contentType, Date lastModified, String subdir) {
+        super(subdir != null ? subdir : name, container, uri, hash, bytes, subdir != null ? "application/directory" : contentType, lastModified);
+    }
+
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/ParseList.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/ParseList.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.SortedSet;
+
+import javax.inject.Inject;
+
+import org.jclouds.blobstore.domain.PageSet;
+import org.jclouds.json.Json;
+import org.jclouds.openstack.swift.domain.ObjectInfo;
+import org.jclouds.openstack.swift.functions.ParseObjectInfoListFromJsonResponse;
+
+import com.google.gson.reflect.TypeToken;
+
+public class ParseList extends ParseObjectInfoListFromJsonResponse {
+
+    @Inject
+    public ParseList(Json json) {
+        super(json);
+    }
+
+    @Override
+    public PageSet<ObjectInfo> apply(InputStream stream) {
+        return super.apply(stream);
+    }
+
+    @Override
+    public <V> V apply(InputStream stream, Type type) throws IOException {
+        Type listType = new TypeToken<SortedSet<ObjectInfoOrSubdirImpl>>() {
+        }.getType();
+        return super.apply(stream, listType);
+    }
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/SoftlayerListContainerOptions.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/SoftlayerListContainerOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Singleton;
+
+import org.jclouds.openstack.swift.blobstore.functions.BlobStoreListContainerOptionsToListContainerOptions;
+import org.jclouds.openstack.swift.options.ListContainerOptions;
+
+@Singleton
+public class SoftlayerListContainerOptions extends
+        BlobStoreListContainerOptionsToListContainerOptions {
+
+    @Override
+    public ListContainerOptions apply(
+            org.jclouds.blobstore.options.ListContainerOptions from) {
+        checkNotNull(from, "set options to instance NONE instead of passing null");
+        org.jclouds.openstack.swift.options.ListContainerOptions options = new org.jclouds.openstack.swift.options.ListContainerOptions();
+        if ((from.getDir() == null) && (from.isRecursive())) {
+           options.withPrefix("");
+        }
+        if ((from.getDir() == null) && (!from.isRecursive())) {
+           options.buildQueryParameters().put("delimiter", "/");
+        }
+        if ((from.getDir() != null) && (from.isRecursive())) {
+           options.withPrefix(from.getDir().endsWith("/") ? from.getDir() : from.getDir() + "/");
+        }
+        if ((from.getDir() != null) && (!from.isRecursive())) {
+           options.withPrefix(from.getDir().endsWith("/") ? from.getDir() : from.getDir() + "/");
+           options.buildQueryParameters().put("delimiter", "/");
+        }
+        if (from.getMarker() != null) {
+           options.afterMarker(from.getMarker());
+        }
+        if (from.getMaxResults() != null) {
+           options.maxResults(from.getMaxResults());
+        }
+
+        return options;
+    }
+
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/SuffixFileMkdirStrategy.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/SuffixFileMkdirStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import static org.jclouds.io.Payloads.newByteArrayPayload;
+
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.StorageType;
+import org.jclouds.blobstore.reference.BlobStoreConstants;
+import org.jclouds.blobstore.strategy.MkdirStrategy;
+
+import com.google.inject.Inject;
+
+public class SuffixFileMkdirStrategy implements MkdirStrategy {
+
+    protected String directorySuffix = "";
+    private final BlobStore blobStore;
+
+    @Inject
+    SuffixFileMkdirStrategy(BlobStore blobStore) {
+       this.blobStore = blobStore;
+       directorySuffix = BlobStoreConstants.DIRECTORY_SUFFIX_FOLDER;
+    }
+
+    public void execute(String containerName, String directory) {
+       blobStore.putBlob(
+             containerName,
+             blobStore.blobBuilder(directory + directorySuffix).type(StorageType.RELATIVE_PATH)
+                   .payload(newByteArrayPayload(new byte[] {})).build());
+    }
+
+}


### PR DESCRIPTION
Softlayer object store doesn't like the content type - can't delete the folders even from its own UI.

The PR is meant to trigger a discussion on the problem more than for merging right away.