### PR TITLE
Persistence fix for removing and adding same ID catalog item

### DIFF
--- a/core/src/main/java/brooklyn/entity/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/brooklyn/entity/rebind/PeriodicDeltaChangeListener.java
@@ -106,6 +106,9 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
         public void add(BrooklynObject instance) {
             BrooklynObjectType type = BrooklynObjectType.of(instance);
             getUnsafeCollectionOfType(type).add(instance);
+            if (type==BrooklynObjectType.CATALOG_ITEM) {
+                removedCatalogItemIds.remove(instance.getId());
+            }
         }
         
         public void addIfNotRemoved(BrooklynObject instance) {

--- a/core/src/main/java/brooklyn/entity/rebind/persister/FileBasedStoreObjectAccessor.java
+++ b/core/src/main/java/brooklyn/entity/rebind/persister/FileBasedStoreObjectAccessor.java
@@ -22,6 +22,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.io.FileUtil;
 import brooklyn.util.text.Strings;
@@ -38,6 +41,7 @@ import com.google.common.io.Files;
  * @author aled
  */
 public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.StoreObjectAccessor {
+    private static final Logger LOG = LoggerFactory.getLogger(FileBasedStoreObjectAccessor.class);
 
     public FileBasedStoreObjectAccessor(File file, String tmpExtension) {
         this.file = file;
@@ -92,8 +96,12 @@ public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.Stor
 
     @Override
     public void delete() {
-        file.delete();
-        tmpFile.delete();
+        if (!file.delete()) {
+            LOG.error("Unable to delete " + file.getAbsolutePath() + ". Probably still locked.");
+        }
+        if (!tmpFile.delete()) {
+            LOG.error("Unable to delete " + tmpFile.getAbsolutePath() + ". Probably still locked.");
+        }
     }
 
     @Override


### PR DESCRIPTION
If a catalog item with the same ID is removed and then added back the delta persister will first update the stored item and then delete it, regardless of the initial order of removal-addition. This may result in the catalog items disappearing from store even though they were just added.

Explicitly remove catalog item with same ID from the removed set if new object is added.
