### PR TITLE
Added a predicate that can correctly match the type of a spec

### DIFF
--- a/core/src/main/java/brooklyn/catalog/CatalogPredicates.java
+++ b/core/src/main/java/brooklyn/catalog/CatalogPredicates.java
@@ -29,6 +29,7 @@ import brooklyn.policy.PolicySpec;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 
 public class CatalogPredicates {
 
@@ -98,6 +99,28 @@ public class CatalogPredicates {
             @Override
             public boolean apply(@Nullable CatalogItem<T,SpecT> item) {
                 return (item != null) && filter.apply(item.toXmlString());
+            }
+        };
+    }
+
+    /**
+     * Returns a predicate that matches the type of an application or entity. This is a string composed of the Java class
+     * name and the version separated by a colon.
+     *
+     * @param typeName The type
+     * @return The predicate
+     */
+    public static <T,SpecT> Predicate<CatalogItem<T,SpecT>> typeName(final String typeName) {
+        final int javaClassEnd = typeName.lastIndexOf(':');
+        final String javaClassName = typeName.substring(0, javaClassEnd);
+        final String version = typeName.substring(javaClassEnd + 1);
+        final Predicate<? super String> javaClassPredicate = Predicates.equalTo(javaClassName);
+        final Predicate<? super String> versionPredicate = Predicates.equalTo(version);
+
+        return new Predicate<CatalogItem<T,SpecT>>() {
+            @Override
+            public boolean apply(@Nullable CatalogItem<T,SpecT> item) {
+                return (item != null) && javaClassPredicate.apply(item.getJavaType()) && versionPredicate.apply(item.getVersion());
             }
         };
     }

--- a/core/src/main/java/brooklyn/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/brooklyn/catalog/internal/BasicBrooklynCatalog.java
@@ -402,7 +402,16 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     /** @deprecated since 0.7.0 use {@link #createSpec(CatalogItem)} */
     @Deprecated
     public <T> Class<? extends T> loadClassByType(String typeName, Class<T> typeClass) {
-        Iterable<CatalogItem<Object,Object>> resultL = getCatalogItems(CatalogPredicates.javaType(Predicates.equalTo(typeName)));
+        // Automated tests and manual tests suggests that typeName is either symbolic-name or symbolic-name:version so
+        // detect which has been passed in.
+        final Iterable<CatalogItem<Object,Object>> resultL;
+        if (typeName.indexOf(':') == -1) {
+            resultL = getCatalogItems(CatalogPredicates.javaType(Predicates.equalTo(typeName)));
+        }
+        else {
+            resultL = getCatalogItems(CatalogPredicates.typeName(typeName));
+        }
+
         if (Iterables.isEmpty(resultL)) throw new NoSuchElementException("Unable to find catalog item for type "+typeName);
         CatalogItem<?,?> resultI = resultL.iterator().next();
         if (log.isDebugEnabled() && Iterables.size(resultL)>1) {


### PR DESCRIPTION
A new predicate has been added that correctly detect the format of the type passed to the BasicBrooklynCatalog.loadClassByType method and uses the correct predicate.

This fixes issue [BROOKLYN-89](https://issues.apache.org/jira/browse/BROOKLYN-89).
