### PR TITLE
service_process_is_running absence will not trump service_up even on rebind

### DIFF
--- a/software/database/src/main/java/brooklyn/entity/database/mysql/MySqlNodeImpl.java
+++ b/software/database/src/main/java/brooklyn/entity/database/mysql/MySqlNodeImpl.java
@@ -108,7 +108,7 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
                                     return Double.parseDouble(q);
                                 }})
                             .setOnFailureOrException(null) )
-                    .poll(new SshPollConfig<Boolean>(SERVICE_UP)
+                    .poll(new SshPollConfig<Boolean>(SERVICE_PROCESS_IS_RUNNING)
                             .command(cmd)
                             .setOnSuccess(true)
                             .setOnFailureOrException(false))


### PR DESCRIPTION
modify service_process_is_running enricher to be better about respecting entities which manually set service_up;
previously it did not change service_up _except_ on a rebind; now it should not even change them on a rebind

also switch mysql to support service_process_is_running
