### PR TITLE
Adds boolean ConfigKey.isNonNull() method

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/AbstractEntity.java
+++ b/core/src/main/java/brooklyn/entity/basic/AbstractEntity.java
@@ -949,7 +949,9 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
 
     @SuppressWarnings("unchecked")
     private <T> T setConfigInternal(ConfigKey<T> key, Object val) {
-        if (!inConstruction && getManagementSupport().isDeployed()) {
+        if (key.isNonNull() && val == null) {
+            throw new IllegalArgumentException("Null value for required key " + key);
+        } else if (!inConstruction && getManagementSupport().isDeployed()) {
             // previously we threw, then warned, but it is still quite common;
             // so long as callers don't expect miracles, it should be fine.
             // i (Alex) think the way to be stricter about this (if that becomes needed) 

--- a/core/src/main/java/brooklyn/event/basic/BasicConfigKey.java
+++ b/core/src/main/java/brooklyn/event/basic/BasicConfigKey.java
@@ -64,7 +64,8 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         private String description;
         private T defaultValue;
         private boolean reconfigurable;
-        
+        private boolean nonNull;
+
         public Builder<T> name(String val) {
             this.name = val; return this;
         }
@@ -83,6 +84,17 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         public Builder<T> reconfigurable(boolean val) {
             this.reconfigurable = val; return this;
         }
+        public Builder<T> reconfigurable() {
+            return reconfigurable(true);
+        }
+        @Beta
+        public Builder<T> nonNull(boolean val) {
+            this.nonNull = val; return this;
+        }
+        @Beta
+        public Builder<T> nonNull() {
+            return nonNull(true);
+        }
         public BasicConfigKey<T> build() {
             return new BasicConfigKey<T>(this);
         }
@@ -94,6 +106,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     private String description;
     private T defaultValue;
     private boolean reconfigurable;
+    private boolean nonNull;
 
     // FIXME In groovy, fields were `public final` with a default constructor; do we need the gson?
     public BasicConfigKey() { /* for gson */ }
@@ -127,6 +140,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         
         this.defaultValue = defaultValue;
         this.reconfigurable = false;
+        this.nonNull = false;
     }
 
     protected BasicConfigKey(Builder<T> builder) {
@@ -136,6 +150,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         this.description = builder.description;
         this.defaultValue = builder.defaultValue;
         this.reconfigurable = builder.reconfigurable;
+        this.nonNull = builder.nonNull;
     }
     
     /** @see ConfigKey#getName() */
@@ -165,7 +180,12 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     public boolean isReconfigurable() {
         return reconfigurable;
     }
-    
+
+    @Override
+    public boolean isNonNull() {
+        return nonNull;
+    }
+
     /** @see ConfigKey#getNameParts() */
     @Override public Collection<String> getNameParts() {
         return Lists.newArrayList(dots.split(name));

--- a/core/src/test/java/brooklyn/entity/basic/EntityConfigTest.java
+++ b/core/src/test/java/brooklyn/entity/basic/EntityConfigTest.java
@@ -149,7 +149,7 @@ public class EntityConfigTest {
         assertEquals(child.getAllConfigBag().getAllConfig(), ImmutableMap.of("mychildentity.myconfigwithflagname", "overrideMyval"));
         assertEquals(child.getLocalConfigBag().getAllConfig(), ImmutableMap.of("mychildentity.myconfigwithflagname", "overrideMyval"));
     }
-    
+
     public static class MyEntity extends AbstractEntity {
         public static final ConfigKey<String> MY_CONFIG = ConfigKeys.newStringConfigKey("myentity.myconfig");
 

--- a/core/src/test/java/brooklyn/entity/basic/NonNullConfigTest.java
+++ b/core/src/test/java/brooklyn/entity/basic/NonNullConfigTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.basic;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.management.ManagementContext;
+import brooklyn.test.entity.LocalManagementContextForTests;
+import brooklyn.test.entity.RequiredConfigEntity;
+import brooklyn.test.entity.RequiredConfigEntitySuper;
+import brooklyn.test.entity.TestApplication;
+import brooklyn.util.exceptions.Exceptions;
+
+public class NonNullConfigTest {
+
+    private ManagementContext managementContext;
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        managementContext = LocalManagementContextForTests.newInstance();
+    }
+
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() {
+        if (managementContext != null) Entities.destroyAll(managementContext);
+    }
+
+    @Test
+    public void testSanity() {
+        TestApplication app = TestApplication.Factory.newManagedInstanceForTests(managementContext);
+        // NON_NULL_CONFIG_WITH_DEFAULT_VALUE should not need to be set
+        app.createAndManageChild(EntitySpec.create(RequiredConfigEntity.class)
+                .configure(RequiredConfigEntity.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE, new Object())
+                .configure(RequiredConfigEntitySuper.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER, new Object()));
+    }
+
+    @Test
+    public void testCreateSpecFailsWhenRequiredConfigKeyWithDefaultValueIsSetToNull() {
+        TestApplication app = TestApplication.Factory.newManagedInstanceForTests(managementContext);
+        try {
+            app.createAndManageChild(EntitySpec.create(RequiredConfigEntity.class)
+                    .configure(RequiredConfigEntity.NON_NULL_CONFIG_WITH_DEFAULT_VALUE, (Object) null)
+                    .configure(RequiredConfigEntity.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE, new Object())
+                    .configure(RequiredConfigEntitySuper.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER, new Object()));
+            fail("Creation of entity should have failed because " + RequiredConfigEntity.NON_NULL_CONFIG_WITH_DEFAULT_VALUE +
+                    " was set to null");
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstInteresting(e);
+            assertEquals(t.getClass(), IllegalArgumentException.class);
+            assertTrue(t.getMessage().contains(RequiredConfigEntity.NON_NULL_CONFIG_WITH_DEFAULT_VALUE.getName()),
+                    "exception=" + t);
+        }
+    }
+
+    @Test
+    public void testCreateSpecFailsWhenRequiredConfigKeyWithoutDefaultValueIsNotSet() {
+        TestApplication app = TestApplication.Factory.newManagedInstanceForTests(managementContext);
+        try {
+            app.createAndManageChild(EntitySpec.create(RequiredConfigEntity.class)
+                    .configure(RequiredConfigEntitySuper.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER, new Object()));
+            fail("Creation of entity should have failed because " + RequiredConfigEntity.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE +
+                    " was not set.");
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstInteresting(e);
+            assertEquals(t.getClass(), IllegalArgumentException.class);
+            assertTrue(t.getMessage().contains(RequiredConfigEntity.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE.getName()),
+                    "exception=" + t);
+        }
+    }
+
+    @Test
+    public void testNullValueOnRequiredConfigInSuperclassCaught() {
+        TestApplication app = TestApplication.Factory.newManagedInstanceForTests(managementContext);
+        try {
+            // Missing a value for NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER.
+            app.createAndManageChild(EntitySpec.create(RequiredConfigEntity.class)
+                    .configure(RequiredConfigEntity.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE, new Object()));
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstInteresting(e);
+            assertEquals(t.getClass(), IllegalArgumentException.class);
+            assertTrue(t.getMessage().contains(RequiredConfigEntity.NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER.getName()),
+                    "exception=" + t);
+        }
+    }
+
+}

--- a/core/src/test/java/brooklyn/test/entity/RequiredConfigEntity.java
+++ b/core/src/test/java/brooklyn/test/entity/RequiredConfigEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.test.entity;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.proxying.ImplementedBy;
+import brooklyn.util.flags.SetFromFlag;
+
+@ImplementedBy(RequiredConfigEntityImpl.class)
+public interface RequiredConfigEntity extends RequiredConfigEntitySuper {
+
+    @SetFromFlag("nonNullDefault")
+    ConfigKey<Object> NON_NULL_CONFIG_WITH_DEFAULT_VALUE = ConfigKeys.builder(Object.class)
+            .name("test.conf.non-null.with-default")
+            .description("Configuration key that must not be null")
+            .defaultValue(new Object())
+            .nonNull()
+            .build();
+
+    @SetFromFlag("nonNullNoDefault")
+    ConfigKey<Object> NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE = ConfigKeys.builder(Object.class)
+            .name("test.conf.non-null.without-default")
+            .description("Configuration key that must not be null")
+            .nonNull()
+            .build();
+
+
+    @SetFromFlag("nullable")
+    ConfigKey<Object> NULLABLE_CONFIG = ConfigKeys.builder(Object.class)
+            .name("test.conf.nullable")
+            .description("Nullable configuration key with no default value")
+            .build();
+}

--- a/core/src/test/java/brooklyn/test/entity/RequiredConfigEntityImpl.java
+++ b/core/src/test/java/brooklyn/test/entity/RequiredConfigEntityImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.test.entity;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class RequiredConfigEntityImpl extends TestEntityImpl implements RequiredConfigEntity {
+
+    @Override
+    public void init() {
+        super.init();
+        checkNotNull(getConfig(NON_NULL_CONFIG_WITH_DEFAULT_VALUE),
+                "Require non-null value for " + NON_NULL_CONFIG_WITH_DEFAULT_VALUE);
+        checkNotNull(getConfig(NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE),
+                "Require non-null value for " + NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE);
+        checkNotNull(getConfig(NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER),
+                "Require non-null value for " + NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER);
+    }
+
+}

--- a/core/src/test/java/brooklyn/test/entity/RequiredConfigEntitySuper.java
+++ b/core/src/test/java/brooklyn/test/entity/RequiredConfigEntitySuper.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.test.entity;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.util.flags.SetFromFlag;
+
+/**
+ * Provides a config key that must be non-null but does not specify a default value.
+ */
+public interface RequiredConfigEntitySuper extends TestEntity {
+
+    @SetFromFlag("nonNullNoDefaultSuper")
+    ConfigKey<Object> NON_NULL_CONFIG_WITHOUT_DEFAULT_VALUE_IN_SUPER = ConfigKeys.builder(Object.class)
+            .name("test.conf.non-null.super.without-default")
+            .description("Configuration key that must not be null")
+            .nonNull()
+            .build();
+
+}

--- a/core/src/test/java/brooklyn/test/entity/TestEntity.java
+++ b/core/src/test/java/brooklyn/test/entity/TestEntity.java
@@ -71,7 +71,7 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
     public static final SetConfigKey<Object> CONF_SET_OBJ_THING = new SetConfigKey<Object>(Object.class, "test.confSetObjThing", "Configuration key that's a set thing, of objects");
     public static final BasicConfigKey<Object> CONF_OBJECT = new BasicConfigKey<Object>(Object.class, "test.confObject", "Configuration key that's an object");
     public static final ConfigKey<EntitySpec<? extends Entity>> CHILD_SPEC = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<? extends Entity>>() {}, "test.childSpec", "Spec to be used for creating children");
-    
+
     public static final AttributeSensor<Integer> SEQUENCE = Sensors.newIntegerSensor("test.sequence", "Test Sequence");
     public static final AttributeSensor<String> NAME = Sensors.newStringSensor("test.name", "Test name");
     public static final BasicNotificationSensor<Integer> MY_NOTIF = new BasicNotificationSensor<Integer>(Integer.class, "test.myNotif", "Test notification");

--- a/software/network/src/main/java/brooklyn/entity/network/bind/BindDnsServer.java
+++ b/software/network/src/main/java/brooklyn/entity/network/bind/BindDnsServer.java
@@ -70,8 +70,11 @@ public interface BindDnsServer extends SoftwareProcess {
             "bind.access.cidr", "Subnet CIDR or ACL allowed to access DNS", "0.0.0.0/0");
 
     @SetFromFlag("hostnameSensor")
-    ConfigKey<AttributeSensor<String>> HOSTNAME_SENSOR = ConfigKeys.newConfigKey(new TypeToken<AttributeSensor<String>>() {},
-            "bind.sensor.hostname", "Sensor on managed entities that reports the hostname");
+    ConfigKey<AttributeSensor<String>> HOSTNAME_SENSOR = ConfigKeys.builder(new TypeToken<AttributeSensor<String>>() {})
+            .name("bind.sensor.hostname")
+            .description("Sensor on managed entities that reports the hostname")
+            .nonNull()
+            .build();
 
     PortAttributeSensorAndConfigKey DNS_PORT =
             new PortAttributeSensorAndConfigKey("bind.port", "BIND DNS port for TCP and UDP", PortRanges.fromString("53"));

--- a/software/network/src/main/java/brooklyn/entity/network/bind/BindDnsServerImpl.java
+++ b/software/network/src/main/java/brooklyn/entity/network/bind/BindDnsServerImpl.java
@@ -135,7 +135,6 @@ public class BindDnsServerImpl extends SoftwareProcessImpl implements BindDnsSer
     @Override
     public void init() {
         super.init();
-        checkNotNull(getConfig(HOSTNAME_SENSOR), "{} requires value for {}", getClass().getName(), HOSTNAME_SENSOR);
         DynamicGroup entities = addChild(EntitySpec.create(DynamicGroup.class)
                 .configure("entityFilter", getConfig(ENTITY_FILTER)));
         setAttribute(ENTITIES, entities);

--- a/software/network/src/test/java/brooklyn/entity/network/bind/BindDnsServerIntegrationTest.java
+++ b/software/network/src/test/java/brooklyn/entity/network/bind/BindDnsServerIntegrationTest.java
@@ -19,6 +19,8 @@
 package brooklyn.entity.network.bind;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,7 @@ import brooklyn.entity.rebind.RebindTestFixture;
 import brooklyn.policy.EnricherSpec;
 import brooklyn.test.EntityTestUtils;
 import brooklyn.test.entity.TestApplication;
+import brooklyn.util.exceptions.Exceptions;
 
 public class BindDnsServerIntegrationTest extends RebindTestFixture<TestApplication> {
 
@@ -89,6 +92,19 @@ public class BindDnsServerIntegrationTest extends RebindTestFixture<TestApplicat
         e.setAttribute(PrefixAndIdEnricher.SENSOR, Strings.repeat("a", 171));
         EntityTestUtils.assertAttributeEqualsEventually(dns, BindDnsServer.A_RECORDS,
                 ImmutableMap.of(Strings.repeat("a", 63), e.getAttribute(Attributes.ADDRESS)));
+    }
+
+    @Test(groups = "Integration")
+    public void testInitFailsIfHostnameSensorUnset() {
+        try {
+            origApp.createAndManageChild(EntitySpec.create(BindDnsServer.class));
+            fail("Expected exception when BindDnsServer is missing " + BindDnsServer.HOSTNAME_SENSOR);
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstInteresting(e);
+            LOG.info("exception", e);
+            assertTrue(t.getMessage().contains(BindDnsServer.HOSTNAME_SENSOR.getName()),
+                    "exception=" + t);
+        }
     }
 
     @Test(groups = "Integration")
@@ -166,3 +182,4 @@ public class BindDnsServerIntegrationTest extends RebindTestFixture<TestApplicat
     }
 
 }
+

--- a/utils/common/src/main/java/brooklyn/config/ConfigKey.java
+++ b/utils/common/src/main/java/brooklyn/config/ConfigKey.java
@@ -20,6 +20,7 @@ package brooklyn.config;
 
 import java.util.Collection;
 
+import com.google.common.annotations.Beta;
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -77,6 +78,12 @@ public interface ConfigKey<T> {
      * @return True if the configuration can be changed at runtime.
      */
     boolean isReconfigurable();
+
+    /**
+     * @return True if the configuration must be non-null.
+     */
+    @Beta
+    boolean isNonNull();
 
     /** Interface for elements which want to be treated as a config key without actually being one
      * (e.g. config attribute sensors).


### PR DESCRIPTION
Use to enforce non-null values for particular config keys.

Validity checks are made in `AbstractEntity.setConfigInternal`, so `setConfig(required, null)` should fail, and in `InternalEntityFactory` after setting config values on a newly-created entity, so forgetting to set a value on a required key should also fail. 

The `InternalEntityFactory` check will only work for `ConfigKeys` defined on the interfaces implemented by the entity. I think the combination of the two checks is sufficient.