### PR TITLE
Mark tests in NetworkingUtilsTest as integration

### DIFF
--- a/utils/common/src/test/java/brooklyn/util/net/NetworkingUtilsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/net/NetworkingUtilsTest.java
@@ -107,8 +107,11 @@ public class NetworkingUtilsTest {
         if (numFree<=5)
             fail("This test requires that at least some ports near 58769+ not be in use.");
     }
-    
-    @Test
+
+    // Integration because fails in apache jenkins sometimes with "could not get a port".
+    // Could all the ports between 58767 and 60000 be in use (!) or is there a restriction in
+    // the environment?
+    @Test(groups="Integration")
     public void testIsPortAvailableReportsFalseWhenPortIsInUse() throws Exception {
         int port = 58767;
         ServerSocket ss = null;
@@ -135,8 +138,9 @@ public class NetworkingUtilsTest {
                 assertTrue(Networking.isPortAvailable(portF), "port "+portF+" not made available afterwards");
             }});
     }
-    
-    @Test
+
+    // See comment on {@link #testIsPortAvailableReportsFalseWhenPortIsInUse()} for why this is integration.
+    @Test(groups="Integration")
     public void testIsPortAvailableReportsPromptly() throws Exception {
         // repeat until we can get an available port
         int port = 58767;


### PR DESCRIPTION
- For tests that open a port, mark them as integration because failing on apache jenkins.

e.g. see failure in https://builds.apache.org/job/incubator-brooklyn-master-build/org.apache.brooklyn$brooklyn-utils-common/271/testReport/junit/brooklyn.util.net/NetworkingUtilsTest/testIsPortAvailableReportsFalseWhenPortIsInUse/

```
Error Message

could not get a port expected object to not be null
Stacktrace

java.lang.AssertionError: could not get a port expected object to not be null
    at org.testng.Assert.fail(Assert.java:94)
    at org.testng.Assert.assertNotNull(Assert.java:404)
    at brooklyn.util.net.NetworkingUtilsTest.testIsPortAvailableReportsFalseWhenPortIsInUse(NetworkingUtilsTest.java:130)
Standard Output

2014-11-26 01:16:37,299 INFO  TESTNG INVOKING: "Surefire test" - brooklyn.util.net.NetworkingUtilsTest.testIsPortAvailableReportsFalseWhenPortIsInUse()
2014-11-26 01:16:37,931 INFO  TESTNG FAILED: "Surefire test" - brooklyn.util.net.NetworkingUtilsTest.testIsPortAvailableReportsFalseWhenPortIsInUse() finished in 631 ms
java.lang.AssertionError: could not get a port expected object to not be null
    at brooklyn.util.net.NetworkingUtilsTest.testIsPortAvailableReportsFalseWhenPortIsInUse(NetworkingUtilsTest.java:130)
```
