### PR TITLE
Fix BrooklynMementoPersisterToMultiFileTest.tearDown

### DIFF
--- a/core/src/test/java/brooklyn/entity/rebind/persister/BrooklynMementoPersisterToMultiFileTest.java
+++ b/core/src/test/java/brooklyn/entity/rebind/persister/BrooklynMementoPersisterToMultiFileTest.java
@@ -54,8 +54,8 @@ public class BrooklynMementoPersisterToMultiFileTest extends BrooklynMementoPers
 
     @AfterMethod(alwaysRun=true)
     public void tearDown() throws Exception {
-        mementoDir = Os.deleteRecursively(mementoDir).asNullOrThrowing();
         super.tearDown();
+        mementoDir = Os.deleteRecursively(mementoDir).asNullOrThrowing();
     }
 
     // to have this picked up in the IDE


### PR DESCRIPTION
- stop management context before deleting mementoDir, otherwise the management context can be reading/writing to dir at same time as we are trying to delete its contents.

See https://builds.apache.org/job/incubator-brooklyn-pull-requests/org.apache.brooklyn$brooklyn-core/407/consoleFull

```
2014-11-25 23:37:18,300 INFO  TESTNG PASSED CONFIGURATION: "Surefire test" - @BeforeMethod brooklyn.entity.rebind.persister.BrooklynMementoPersisterTestFixture.setUp() finished in 214 ms
2014-11-25 23:37:18,300 INFO  TESTNG INVOKING: "Surefire test" - brooklyn.entity.rebind.persister.BrooklynMementoPersisterTestFixture.testLoadAndCheckpointRawMemento()
2014-11-25 23:37:18,301 INFO  TESTNG SKIPPED: "Surefire test" - brooklyn.entity.rebind.persister.BrooklynMementoPersisterTestFixture.testLoadAndCheckpointRawMemento() finished in 1 ms
org.testng.SkipException: Persister brooklyn.entity.rebind.persister.BrooklynMementoPersisterToMultiFile@f2fee1 not a BrooklynMementoPersisterToObjectStore
    at brooklyn.entity.rebind.persister.BrooklynMementoPersisterTestFixture.testLoadAndCheckpointRawMemento(BrooklynMementoPersisterTestFixture.java:163)
2014-11-25 23:37:18,302 INFO  TESTNG INVOKING CONFIGURATION: "Surefire test" - @AfterMethod brooklyn.entity.rebind.persister.BrooklynMementoPersisterToMultiFileTest.tearDown()
2014-11-25 23:37:18,318 INFO  TESTNG FAILED CONFIGURATION: "Surefire test" - @AfterMethod brooklyn.entity.rebind.persister.BrooklynMementoPersisterToMultiFileTest.tearDown() finished in 0 ms
brooklyn.util.exceptions.PropagatedRuntimeException: java.io.IOException: Unable to delete '/tmp/BrooklynMementoPersisterToMultiFileTest-OAJF': delete returned false
    at brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:91)
    at brooklyn.util.os.Os$DeletionResult.throwIfFailed(Os.java:278)
    at brooklyn.util.os.Os$DeletionResult.asNullOrThrowing(Os.java:285)
    at brooklyn.entity.rebind.persister.BrooklynMementoPersisterToMultiFileTest.tearDown(BrooklynMementoPersisterToMultiFileTest.java:57)
Caused by: java.io.IOException: Unable to delete '/tmp/BrooklynMementoPersisterToMultiFileTest-OAJF': delete returned false
    ... 33 more
Caused by: java.io.FileNotFoundException: File does not exist: /tmp/BrooklynMementoPersisterToMultiFileTest-OAJF/enrichers/IE5jOu72.tmp
    at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2275)
    at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
    at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1535)
    at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2270)
    at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1653)
    at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1535)
    at brooklyn.util.os.Os.deleteRecursively(Os.java:239)
    at brooklyn.util.os.Os.deleteRecursively(Os.java:225)
    ... 31 more
```
