### PR TITLE
Fix - legacy catalog items versioning

### DIFF
--- a/api/src/main/java/brooklyn/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/brooklyn/catalog/BrooklynCatalog.java
@@ -79,6 +79,8 @@ public interface BrooklynCatalog {
     /** @deprecated since 0.7.0 use {@link #createSpec(CatalogItem)} */
     @Deprecated
     <T> Class<? extends T> loadClassByType(String typeName, Class<T> typeClass);
+    /** @deprecated since 0.7.0 use {@link #createSpec(CatalogItem)} */
+    CatalogItem<?,?> getCatalogItemForType(String typeName);
 
     /**
      * Adds an item (represented in yaml) to the catalog.

--- a/core/src/main/java/brooklyn/catalog/CatalogPredicates.java
+++ b/core/src/main/java/brooklyn/catalog/CatalogPredicates.java
@@ -29,7 +29,6 @@ import brooklyn.policy.PolicySpec;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 
 public class CatalogPredicates {
 
@@ -99,28 +98,6 @@ public class CatalogPredicates {
             @Override
             public boolean apply(@Nullable CatalogItem<T,SpecT> item) {
                 return (item != null) && filter.apply(item.toXmlString());
-            }
-        };
-    }
-
-    /**
-     * Returns a predicate that matches the type of an application or entity. This is a string composed of the Java class
-     * name and the version separated by a colon.
-     *
-     * @param typeName The type
-     * @return The predicate
-     */
-    public static <T,SpecT> Predicate<CatalogItem<T,SpecT>> typeName(final String typeName) {
-        final int javaClassEnd = typeName.lastIndexOf(':');
-        final String javaClassName = typeName.substring(0, javaClassEnd);
-        final String version = typeName.substring(javaClassEnd + 1);
-        final Predicate<? super String> javaClassPredicate = Predicates.equalTo(javaClassName);
-        final Predicate<? super String> versionPredicate = Predicates.equalTo(version);
-
-        return new Predicate<CatalogItem<T,SpecT>>() {
-            @Override
-            public boolean apply(@Nullable CatalogItem<T,SpecT> item) {
-                return (item != null) && javaClassPredicate.apply(item.getJavaType()) && versionPredicate.apply(item.getVersion());
             }
         };
     }

--- a/core/src/main/java/brooklyn/catalog/internal/CatalogItemComparator.java
+++ b/core/src/main/java/brooklyn/catalog/internal/CatalogItemComparator.java
@@ -32,13 +32,18 @@ import brooklyn.util.text.NaturalOrderComparator;
  * When using the comparator to sort - first using symbolicName
  * and if equal puts larger versions first, snapshots at the back.
  */
-public class CatalogItemComparator implements Comparator<CatalogItem<?, ?>> {
+public class CatalogItemComparator<T,SpecT> implements Comparator<CatalogItem<T, SpecT>> {
     private static final String SNAPSHOT = "SNAPSHOT";
 
-    public static final CatalogItemComparator INSTANCE = new CatalogItemComparator();
+    public static final CatalogItemComparator<?, ?> INSTANCE = new CatalogItemComparator<Object, Object>();
+
+    @SuppressWarnings("unchecked")
+    public static <T,SpecT> CatalogItemComparator<T,SpecT> getInstance() {
+        return (CatalogItemComparator<T, SpecT>) INSTANCE;
+    }
 
     @Override
-    public int compare(CatalogItem<?, ?> o1, CatalogItem<?, ?> o2) {
+    public int compare(CatalogItem<T, SpecT> o1, CatalogItem<T, SpecT> o2) {
         int symbolicNameComparison = o1.getSymbolicName().compareTo(o2.getSymbolicName());
         if (symbolicNameComparison != 0) {
             return symbolicNameComparison;

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-summary.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-summary.js
@@ -37,6 +37,7 @@ define([
             this.$el.html(this.template({
                 entity:this.model,
                 application:this.options.application,
+                isApp: this.isApp()
             }));
             if (this.model.get('catalogItemId'))
                 this.$("div.catalogItemId").show();
@@ -58,8 +59,13 @@ define([
             // however if we only use external objects we must either subscribe to their errors also
             // or do our own polling against the server, so we know when to disable ourselves
 //            ViewUtils.fetchRepeatedlyWithDelay(this, this.model, { period: 10*1000 })
-            
+
             this.loadSpec();
+        },
+        isApp: function() {
+            var id = this.model.get('id');
+            var selfLink = this.model.get('links').self;
+            return selfLink.indexOf("/applications/" + id) != -1;
         },
         render:function () {
             return this;

--- a/usage/jsgui/src/main/webapp/assets/tpl/apps/summary.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/apps/summary.html
@@ -68,7 +68,7 @@ under the License.
         </div>
         <div class="info-name-value catalogItemId hide">
             <div class="name">Catalog Item</div>
-            <div class="value"><a href="#v1/catalog/entities/<%= entity.get('catalogItemId') %>"><%= entity.get('catalogItemId') %></a></div>
+            <div class="value"><a href="#v1/catalog/<%= (isApp ? "applications" : "entities") %>/<%= entity.get('catalogItemId') %>"><%= entity.get('catalogItemId') %></a></div>
         </div>
 
         <div class="additional-info-on-problem hide" style="margin-top: 12px;">

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/CatalogResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/CatalogResource.java
@@ -241,7 +241,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         ImmutableList<CatalogItem<Object, Object>> sortedItems =
                 FluentIterable.from(brooklyn().getCatalog().getCatalogItems())
                     .filter(Predicates.and(filters))
-                    .toSortedList(CatalogItemComparator.INSTANCE);
+                    .toSortedList(CatalogItemComparator.getInstance());
         return Lists.transform(sortedItems, TO_CATALOG_ITEM_SUMMARY);
     }
 

--- a/usage/rest-server/src/main/java/brooklyn/rest/transform/EntityTransformer.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/transform/EntityTransformer.java
@@ -33,6 +33,7 @@ import brooklyn.entity.Entity;
 import brooklyn.entity.basic.EntityLocal;
 import brooklyn.rest.domain.EntityConfigSummary;
 import brooklyn.rest.domain.EntitySummary;
+import brooklyn.rest.util.WebResourceUtils;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.net.URLParamEncoder;
 
@@ -70,11 +71,15 @@ public class EntityTransformer {
                 .put("activities", URI.create(entityUri + "/activities"))
                 .put("locations", URI.create(entityUri + "/locations"))
                 .put("tags", URI.create(entityUri + "/tags"))
-                .put("catalog", URI.create("/v1/catalog/entities/" + type))
                 .put("expunge", URI.create(entityUri + "/expunge"))
                 .put("rename", URI.create(entityUri + "/name"))
                 .put("spec", URI.create(entityUri + "/spec"))
             ;
+
+        if (entity.getCatalogItemId() != null) {
+            lb.put("catalog", URI.create("/v1/catalog/entities/" + WebResourceUtils.getPathFromVersionedId(entity.getCatalogItemId())));
+        }
+
         if (entity.getIconUrl()!=null)
             lb.put("iconUrl", URI.create(entityUri + "/icon"));
 

--- a/usage/rest-server/src/main/java/brooklyn/rest/util/BrooklynRestResourceUtils.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/util/BrooklynRestResourceUtils.java
@@ -218,19 +218,25 @@ public class BrooklynRestResourceUtils {
 
         // Load the class; first try to use the appropriate catalog item; but then allow anything that is on the classpath
         final Class<? extends Entity> clazz;
+        final String catalogItemId;
         if (Strings.isEmpty(type)) {
             clazz = BasicApplication.class;
+            catalogItemId = null;
         } else {
             Class<? extends Entity> tempclazz;
-            try {
-                tempclazz = getCatalog().loadClassByType(type, Entity.class);
-            } catch (NoSuchElementException e) {
+            BrooklynCatalog catalog = getCatalog();
+            CatalogItem<?, ?> item = catalog.getCatalogItemForType(type);
+            if (item != null) {
+                catalogItemId = item.getId();
+                tempclazz = (Class<? extends Entity>) catalog.loadClass(item);
+            } else {
+                catalogItemId = null;
                 try {
-                    tempclazz = (Class<? extends Entity>) getCatalog().getRootClassLoader().loadClass(type);
+                    tempclazz = (Class<? extends Entity>) catalog.getRootClassLoader().loadClass(type);
                     log.info("Catalog does not contain item for type {}; loaded class directly instead", type);
                 } catch (ClassNotFoundException e2) {
                     log.warn("No catalog item for type {}, and could not load class directly; rethrowing", type);
-                    throw e;
+                    throw new NoSuchElementException("Unable to find catalog item for type "+type);
                 }
             }
             clazz = tempclazz;
@@ -251,7 +257,7 @@ public class BrooklynRestResourceUtils {
                     instance = appBuilder.manage(mgmt);
 
                 } else if (Application.class.isAssignableFrom(clazz)) {
-                    brooklyn.entity.proxying.EntitySpec<?> coreSpec = toCoreEntitySpec(clazz, name, configO);
+                    brooklyn.entity.proxying.EntitySpec<?> coreSpec = toCoreEntitySpec(clazz, name, configO, catalogItemId);
                     configureRenderingMetadata(spec, coreSpec);
                     instance = (Application) mgmt.getEntityManager().createEntity(coreSpec);
                     for (EntitySpec entitySpec : entities) {
@@ -266,13 +272,12 @@ public class BrooklynRestResourceUtils {
                     if (entities.size() > 0)
                         log.warn("Cannot supply additional entities when using a non-application entity; ignoring in spec {}", spec);
 
-                    brooklyn.entity.proxying.EntitySpec<?> coreSpec = toCoreEntitySpec(BasicApplication.class, name, configO);
+                    brooklyn.entity.proxying.EntitySpec<?> coreSpec = toCoreEntitySpec(BasicApplication.class, name, configO, catalogItemId);
                     configureRenderingMetadata(spec, coreSpec);
 
                     instance = (Application) mgmt.getEntityManager().createEntity(coreSpec);
 
-                    final Class<? extends Entity> eclazz = getCatalog().loadClassByType(spec.getType(), Entity.class);
-                    Entity soleChild = mgmt.getEntityManager().createEntity(toCoreEntitySpec(eclazz, name, configO));
+                    Entity soleChild = mgmt.getEntityManager().createEntity(toCoreEntitySpec(clazz, name, configO, catalogItemId));
                     instance.addChild(soleChild);
                     instance.addEnricher(Enrichers.builder()
                             .propagatingAllBut(Attributes.SERVICE_UP, Attributes.SERVICE_NOT_UP_INDICATORS, 
@@ -328,16 +333,21 @@ public class BrooklynRestResourceUtils {
         String name = spec.getName();
         Map<String, String> config = (spec.getConfig() == null) ? Maps.<String,String>newLinkedHashMap() : Maps.newLinkedHashMap(spec.getConfig());
 
+        BrooklynCatalog catalog = getCatalog();
+        CatalogItem<?, ?> item = catalog.getCatalogItemForType(type);
         Class<? extends Entity> tempclazz;
-        try {
-            tempclazz = getCatalog().loadClassByType(type, Entity.class);
-        } catch (NoSuchElementException e) {
+        final String catalogItemId;
+        if (item != null) {
+            tempclazz = (Class<? extends Entity>) catalog.loadClass(item);
+            catalogItemId = item.getId();
+        } else {
+            catalogItemId = null;
             try {
-                tempclazz = (Class<? extends Entity>) getCatalog().getRootClassLoader().loadClass(type);
+                tempclazz = (Class<? extends Entity>) catalog.getRootClassLoader().loadClass(type);
                 log.info("Catalog does not contain item for type {}; loaded class directly instead", type);
             } catch (ClassNotFoundException e2) {
                 log.warn("No catalog item for type {}, and could not load class directly; rethrowing", type);
-                throw e;
+                throw new NoSuchElementException("Unable to find catalog item for type "+type);
             }
         }
         final Class<? extends Entity> clazz = tempclazz;
@@ -347,6 +357,7 @@ public class BrooklynRestResourceUtils {
         } else {
             result = brooklyn.entity.proxying.EntitySpec.create(Entity.class).impl(clazz).additionalInterfaces(Reflections.getAllInterfaces(clazz));
         }
+        result.catalogItemId(catalogItemId);
         if (!Strings.isEmpty(name)) result.displayName(name);
         result.configure( convertFlagsToKeys(result.getType(), config) );
         configureRenderingMetadata(spec, result);
@@ -375,7 +386,7 @@ public class BrooklynRestResourceUtils {
     }
     
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private <T extends Entity> brooklyn.entity.proxying.EntitySpec<?> toCoreEntitySpec(Class<T> clazz, String name, Map<String,String> configO) {
+    private <T extends Entity> brooklyn.entity.proxying.EntitySpec<?> toCoreEntitySpec(Class<T> clazz, String name, Map<String,String> configO, String catalogItemId) {
         Map<String, String> config = (configO == null) ? Maps.<String,String>newLinkedHashMap() : Maps.newLinkedHashMap(configO);
         
         brooklyn.entity.proxying.EntitySpec<? extends Entity> result;
@@ -389,6 +400,7 @@ public class BrooklynRestResourceUtils {
             result = brooklyn.entity.proxying.EntitySpec.create(interfaceclazz).impl(clazz).additionalInterfaces(additionalInterfaceClazzes);
         }
         
+        result.catalogItemId(catalogItemId);
         if (!Strings.isEmpty(name)) result.displayName(name);
         result.configure( convertFlagsToKeys(result.getImplementation(), config) );
         return result;

--- a/usage/rest-server/src/main/java/brooklyn/rest/util/WebResourceUtils.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/util/WebResourceUtils.java
@@ -28,8 +28,10 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import brooklyn.catalog.internal.CatalogUtils;
 import brooklyn.rest.domain.ApiError;
 import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.net.Urls;
 import brooklyn.util.text.StringEscapes.JavaStringEscapes;
 
 import com.google.common.collect.ImmutableMap;
@@ -125,6 +127,16 @@ public class WebResourceUtils {
         } else {
             if (value==null) return "";
             return value.toString();            
+        }
+    }
+
+    public static String getPathFromVersionedId(String versionedId) {
+        if (CatalogUtils.looksLikeVersionedId(versionedId)) {
+            String symbolicName = CatalogUtils.getIdFromVersionedId(versionedId);
+            String version = CatalogUtils.getVersionFromVersionedId(versionedId);
+            return Urls.encode(symbolicName) + "/" + Urls.encode(version);
+        } else {
+            return Urls.encode(versionedId);
         }
     }
 

--- a/usage/rest-server/src/test/java/brooklyn/rest/util/BrooklynRestResourceUtilsTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/util/BrooklynRestResourceUtilsTest.java
@@ -29,8 +29,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import brooklyn.catalog.Catalog;
+import brooklyn.catalog.internal.CatalogItemBuilder;
+import brooklyn.catalog.internal.CatalogTemplateItemDto;
+import brooklyn.catalog.internal.CatalogUtils;
 import brooklyn.entity.Application;
+import brooklyn.entity.Entity;
 import brooklyn.entity.basic.AbstractApplication;
+import brooklyn.entity.basic.BasicEntity;
 import brooklyn.entity.basic.Entities;
 import brooklyn.entity.basic.EntityLocal;
 import brooklyn.entity.proxying.EntityProxy;
@@ -38,11 +43,13 @@ import brooklyn.management.internal.LocalManagementContext;
 import brooklyn.policy.Policy;
 import brooklyn.policy.basic.AbstractPolicy;
 import brooklyn.rest.domain.ApplicationSpec;
+import brooklyn.rest.domain.EntitySpec;
 import brooklyn.test.entity.TestEntityImpl;
 import brooklyn.util.collections.MutableMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 public class BrooklynRestResourceUtilsTest {
 
@@ -74,6 +81,93 @@ public class BrooklynRestResourceUtilsTest {
         assertTrue(app instanceof EntityProxy);
         assertTrue(app instanceof MyInterface);
         assertFalse(app instanceof SampleNoOpApplication);
+    }
+
+    @Test
+    public void testCreateAppFromCatalogByType() {
+        createAppFromCatalog(SampleNoOpApplication.class.getName());
+    }
+
+    @Test
+    public void testCreateAppFromCatalogByName() {
+        createAppFromCatalog("app.noop");
+    }
+
+    @Test
+    public void testCreateAppFromCatalogById() {
+        createAppFromCatalog("app.noop:0.0.1");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testCreateAppFromCatalogByTypeMultipleItems() {
+        CatalogTemplateItemDto item = CatalogItemBuilder.newTemplate("app.noop", "0.0.2-SNAPSHOT")
+                .javaType(SampleNoOpApplication.class.getName())
+                .build();
+        managementContext.getCatalog().addItem(item);
+        createAppFromCatalog(SampleNoOpApplication.class.getName());
+    }
+
+    @SuppressWarnings("deprecation")
+    private void createAppFromCatalog(String type) {
+        CatalogTemplateItemDto item = CatalogItemBuilder.newTemplate("app.noop", "0.0.1")
+            .javaType(SampleNoOpApplication.class.getName())
+            .build();
+        managementContext.getCatalog().addItem(item);
+
+        ApplicationSpec spec = ApplicationSpec.builder()
+                .name("myname")
+                .type(type)
+                .locations(ImmutableSet.of("localhost"))
+                .build();
+        Application app = util.create(spec);
+
+        assertEquals(app.getCatalogItemId(), "app.noop:0.0.1");
+    }
+
+    @Test
+    public void testEntityAppFromCatalogByType() {
+        createEntityFromCatalog(BasicEntity.class.getName());
+    }
+
+    @Test
+    public void testEntityAppFromCatalogByName() {
+        createEntityFromCatalog("app.basic");
+    }
+
+    @Test
+    public void testEntityAppFromCatalogById() {
+        createEntityFromCatalog("app.basic:0.0.1");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testEntityAppFromCatalogByTypeMultipleItems() {
+        CatalogTemplateItemDto item = CatalogItemBuilder.newTemplate("app.basic", "0.0.2-SNAPSHOT")
+                .javaType(SampleNoOpApplication.class.getName())
+                .build();
+        managementContext.getCatalog().addItem(item);
+        createEntityFromCatalog(BasicEntity.class.getName());
+    }
+
+    @SuppressWarnings("deprecation")
+    private void createEntityFromCatalog(String type) {
+        String symbolicName = "app.basic";
+        String version = "0.0.1";
+        CatalogTemplateItemDto item = CatalogItemBuilder.newTemplate(symbolicName, version)
+            .javaType(BasicEntity.class.getName())
+            .build();
+        managementContext.getCatalog().addItem(item);
+
+        ApplicationSpec spec = ApplicationSpec.builder()
+                .name("myname")
+                .entities(ImmutableSet.of(new EntitySpec(type)))
+                .locations(ImmutableSet.of("localhost"))
+                .build();
+        Application app = util.create(spec);
+
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(entity.getCatalogItemId(), CatalogUtils.getVersionedId(symbolicName, version));
     }
 
     @Test


### PR DESCRIPTION
* Correctly load java classes from the catalog (legacy mechanism), taking into account versioning precedence.
* Tag the resulting entities with the catalogItemId used for loading.
* Fix the catalog link in rest response.
* Fix the UI link to catalog items for applications.