### PR TITLE
Add configuration to skip start if entity already running

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
+++ b/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
@@ -21,8 +21,10 @@ package brooklyn.entity.basic;
 import static brooklyn.entity.basic.ConfigKeys.*;
 import brooklyn.config.BrooklynServerConfig;
 import brooklyn.config.ConfigKey;
+import brooklyn.entity.trait.Startable;
 import brooklyn.event.basic.AttributeSensorAndConfigKey;
 import brooklyn.event.basic.TemplatedStringAttributeSensorAndConfigKey;
+import brooklyn.location.Location;
 import brooklyn.util.internal.ssh.ShellTool;
 import brooklyn.util.internal.ssh.SshTool;
 import brooklyn.util.time.Duration;
@@ -55,8 +57,35 @@ public class BrooklynConfigKeys {
             "this should include something readable, and must include a hash of all data which differentiates an installation " +
             "(e.g. version, plugins, etc), but should be the same where install dirs can be shared to allow for re-use");
 
+    /**
+     * Set this configuration value to true if the entity installation, customization and launch process is to be skipped entirely.
+     * <p>
+     * This is usually because the process or service the entity represents is already present and started, as part of the image
+     * being used. The {@link Startable#SERVICE_UP} attribute will be set in the usual manner.
+     * <p>
+     * If this key is set on a {@link Location} then all entities in that location will be treated in this way. This is useful
+     * when the location is configured with a particular image containing installed and running services.
+     *
+     * @see #ENTITY_RUNNING
+     */
     public static final ConfigKey<Boolean> ENTITY_STARTED = newBooleanConfigKey("entity.started", "Skip the startup process entirely, for running services");
+
+    /**
+     * Set this configuration value to true to skip the entity startup process as with {@link #ENTITY_STARTED} if the process or
+     * service represented by the entity is already running, otherwise proceed normally. This is determined using the driver's
+     * {@code isRunning()} method.
+     * <p>
+     * If this key is set on a {@link Location} then all entities in that location will be treated in this way, again as with {@link #ENTITY_STARTED}.
+     *
+     * @see #ENTITY_STARTED
+     */
     public static final ConfigKey<Boolean> ENTITY_RUNNING = newBooleanConfigKey("entity.running", "Skip the startup process entirely, if service already running");
+
+    /**
+     * Set this configuration value to true if the entity installation, customization and launch process is to be skipped entirely.
+     * <p>
+     * This will skip the installation phase of the lifecycle, and move directl;y to customization and launching of the entity.
+     */
     public static final ConfigKey<Boolean> SKIP_INSTALLATION = newBooleanConfigKey("install.skip", "Skip the driver install commands entirely, for pre-installed software");
 
     // The implementation in AbstractSoftwareSshDriver runs this command as an SSH command 

--- a/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
+++ b/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
@@ -55,8 +55,9 @@ public class BrooklynConfigKeys {
             "this should include something readable, and must include a hash of all data which differentiates an installation " +
             "(e.g. version, plugins, etc), but should be the same where install dirs can be shared to allow for re-use");
 
-    public static final ConfigKey<Boolean> ENTITY_STARTED = newBooleanConfigKey("entity.started", "Skip the startup process entirely, for running services", Boolean.FALSE);
-    public static final ConfigKey<Boolean> SKIP_INSTALLATION = newBooleanConfigKey("install.skip", "Skip the driver install commands entirely, for pre-installed software", Boolean.FALSE);
+    public static final ConfigKey<Boolean> ENTITY_STARTED = newBooleanConfigKey("entity.started", "Skip the startup process entirely, for running services");
+    public static final ConfigKey<Boolean> ENTITY_RUNNING = newBooleanConfigKey("entity.running", "Skip the startup process entirely, if service already running");
+    public static final ConfigKey<Boolean> SKIP_INSTALLATION = newBooleanConfigKey("install.skip", "Skip the driver install commands entirely, for pre-installed software");
 
     // The implementation in AbstractSoftwareSshDriver runs this command as an SSH command 
     public static final ConfigKey<String> PRE_INSTALL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.command",

--- a/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
+++ b/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
@@ -68,7 +68,7 @@ public class BrooklynConfigKeys {
      *
      * @see #ENTITY_RUNNING
      */
-    public static final ConfigKey<Boolean> ENTITY_STARTED = newBooleanConfigKey("entity.started", "Skip the startup process entirely, for running services");
+    public static final ConfigKey<Boolean> SKIP_ENTITY_START = newBooleanConfigKey("entity.started", "Skip the startup process entirely, for running services");
 
     /**
      * Set this configuration value to true to skip the entity startup process as with {@link #ENTITY_STARTED} if the process or
@@ -79,14 +79,14 @@ public class BrooklynConfigKeys {
      *
      * @see #ENTITY_STARTED
      */
-    public static final ConfigKey<Boolean> ENTITY_RUNNING = newBooleanConfigKey("entity.running", "Skip the startup process entirely, if service already running");
+    public static final ConfigKey<Boolean> SKIP_ENTITY_START_IF_RUNNING = newBooleanConfigKey("entity.running", "Skip the startup process entirely, if service already running");
 
     /**
      * Set this configuration value to true if the entity installation, customization and launch process is to be skipped entirely.
      * <p>
      * This will skip the installation phase of the lifecycle, and move directl;y to customization and launching of the entity.
      */
-    public static final ConfigKey<Boolean> SKIP_INSTALLATION = newBooleanConfigKey("install.skip", "Skip the driver install commands entirely, for pre-installed software");
+    public static final ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = newBooleanConfigKey("install.skip", "Skip the driver install commands entirely, for pre-installed software");
 
     // The implementation in AbstractSoftwareSshDriver runs this command as an SSH command 
     public static final ConfigKey<String> PRE_INSTALL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.command",

--- a/core/src/main/java/brooklyn/event/basic/PortAttributeSensorAndConfigKey.java
+++ b/core/src/main/java/brooklyn/event/basic/PortAttributeSensorAndConfigKey.java
@@ -93,11 +93,11 @@ public class PortAttributeSensorAndConfigKey extends AttributeSensorAndConfigKey
             }
             if (lo.isPresent()) {
                 Location l = lo.get();
-                Optional<Boolean> locationRunning = Optional.fromNullable(l.getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
-                Optional<Boolean> entityRunning = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
-                Optional<Boolean> locationInstalled = Optional.fromNullable(l.getConfig(BrooklynConfigKeys.SKIP_INSTALLATION));
-                Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_INSTALLATION));
-                Optional<Boolean> entityStarted = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_STARTED));
+                Optional<Boolean> locationRunning = Optional.fromNullable(l.getConfig(BrooklynConfigKeys.SKIP_ENTITY_START_IF_RUNNING));
+                Optional<Boolean> entityRunning = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_START_IF_RUNNING));
+                Optional<Boolean> locationInstalled = Optional.fromNullable(l.getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
+                Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
+                Optional<Boolean> entityStarted = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_START));
                 boolean skipCheck = locationRunning.or(entityRunning).or(locationInstalled).or(entityInstalled).or(entityStarted).or(false);
                 if (l instanceof PortSupplier) {
                     int p = ((PortSupplier) l).obtainPort(value);

--- a/core/src/main/java/brooklyn/event/basic/PortAttributeSensorAndConfigKey.java
+++ b/core/src/main/java/brooklyn/event/basic/PortAttributeSensorAndConfigKey.java
@@ -93,8 +93,12 @@ public class PortAttributeSensorAndConfigKey extends AttributeSensorAndConfigKey
             }
             if (lo.isPresent()) {
                 Location l = lo.get();
-                Boolean skip = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_INSTALLATION)).or(false);
-                Boolean started = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_STARTED)).or(false);
+                Optional<Boolean> locationRunning = Optional.fromNullable(l.getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
+                Optional<Boolean> entityRunning = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
+                Optional<Boolean> locationInstalled = Optional.fromNullable(l.getConfig(BrooklynConfigKeys.SKIP_INSTALLATION));
+                Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_INSTALLATION));
+                Optional<Boolean> entityStarted = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_STARTED));
+                boolean skipCheck = locationRunning.or(entityRunning).or(locationInstalled).or(entityInstalled).or(entityStarted).or(false);
                 if (l instanceof PortSupplier) {
                     int p = ((PortSupplier) l).obtainPort(value);
                     if (p != -1) {
@@ -102,7 +106,7 @@ public class PortAttributeSensorAndConfigKey extends AttributeSensorAndConfigKey
                         return p;
                     }
                     // If we are not skipping install or already started, fail now
-                    if (!(skip || started)) {
+                    if (!skipCheck) {
                         int rangeSize = Iterables.size(value);
                         if (rangeSize == 0) {
                             LOG.warn("{}: no port available for {} (empty range {})", new Object[] { entity, getName(), value });

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
@@ -90,10 +90,11 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
         boolean skipStart = false;
         Optional<Boolean> locationRunning = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
         Optional<Boolean> entityRunning = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
+        Optional<Boolean> entityStarted = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_STARTED));
         if (locationRunning.or(entityRunning).or(false)) {
             skipStart = isRunning();
         } else {
-            skipStart = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_STARTED)).or(false);
+            skipStart = entityStarted.or(false);
         }
         if (!skipStart) {
             DynamicTasks.queue("pre-install", new Runnable() { public void run() {

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
@@ -78,8 +78,8 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
      * The {@link BrooklynConfigKeys#ENTITY_RUNNING} key can be set on the location
      * or the entity to skip the startup process if the entity is already running,
      * according to the {@link #isRunning()} method. To force the startup to be
-     * skipped, {@link BrooklynConfigKeys#ENTITY_STARTED} can be set on the entity.
-     * The {@link BrooklynConfigKeys#SKIP_INSTALLATION} key can also be used to
+     * skipped, {@link BrooklynConfigKeys#SKIP_ENTITY_START} can be set on the entity.
+     * The {@link BrooklynConfigKeys#SKIP_ENTITY_INSTALLATION} key can also be used to
      * skip the {@link #setup()}, {@link #copyInstallResources()} and
      * {@link #install()} methods if set on the entity or location. 
      *
@@ -88,9 +88,9 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
     @Override
     public void start() {
         boolean skipStart = false;
-        Optional<Boolean> locationRunning = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
-        Optional<Boolean> entityRunning = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_RUNNING));
-        Optional<Boolean> entityStarted = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.ENTITY_STARTED));
+        Optional<Boolean> locationRunning = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.SKIP_ENTITY_START_IF_RUNNING));
+        Optional<Boolean> entityRunning = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_START_IF_RUNNING));
+        Optional<Boolean> entityStarted = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_START));
         if (locationRunning.or(entityRunning).or(false)) {
             skipStart = isRunning();
         } else {
@@ -107,8 +107,8 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 }});
             };
 
-            Optional<Boolean> locationInstalled = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.SKIP_INSTALLATION));
-            Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_INSTALLATION));
+            Optional<Boolean> locationInstalled = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
+            Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
             boolean skipInstall = locationInstalled.or(entityInstalled).or(false);
             if (!skipInstall) {
                 DynamicTasks.queue("setup", new Runnable() { public void run() {

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -66,14 +66,14 @@ public interface SoftwareProcess extends Entity, Startable {
     @SetFromFlag("launchLatch")
     ConfigKey<Boolean> LAUNCH_LATCH = BrooklynConfigKeys.LAUNCH_LATCH;
 
-    @SetFromFlag("entityStarted")
-    ConfigKey<Boolean> ENTITY_STARTED = BrooklynConfigKeys.ENTITY_STARTED;
+    @SetFromFlag("skipStart")
+    ConfigKey<Boolean> ENTITY_STARTED = BrooklynConfigKeys.SKIP_ENTITY_START;
 
-    @SetFromFlag("entityRunning")
-    ConfigKey<Boolean> ENTITY_RUNNING = BrooklynConfigKeys.ENTITY_RUNNING;
+    @SetFromFlag("skipStartIfRunning")
+    ConfigKey<Boolean> SKIP_ENTITY_START_IF_RUNNING = BrooklynConfigKeys.SKIP_ENTITY_START_IF_RUNNING;
 
     @SetFromFlag("skipInstall")
-    ConfigKey<Boolean> SKIP_INSTALLATION = BrooklynConfigKeys.SKIP_INSTALLATION;
+    ConfigKey<Boolean> SKIP_INSTALLATION = BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION;
 
     @SetFromFlag("preInstallCommand")
     ConfigKey<String> PRE_INSTALL_COMMAND = BrooklynConfigKeys.PRE_INSTALL_COMMAND;

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -69,6 +69,9 @@ public interface SoftwareProcess extends Entity, Startable {
     @SetFromFlag("entityStarted")
     ConfigKey<Boolean> ENTITY_STARTED = BrooklynConfigKeys.ENTITY_STARTED;
 
+    @SetFromFlag("entityRunning")
+    ConfigKey<Boolean> ENTITY_RUNNING = BrooklynConfigKeys.ENTITY_RUNNING;
+
     @SetFromFlag("skipInstall")
     ConfigKey<Boolean> SKIP_INSTALLATION = BrooklynConfigKeys.SKIP_INSTALLATION;
 


### PR DESCRIPTION
Add check if entity is already running before skipping startup. Also allows setting the configuration for skip of startup and install on the location, useful when known good images are being used in a fixed IP byon location or an on premises cloud.