### PR TITLE
Skip dry run on node upgrade.

### DIFF
--- a/core/src/main/java/brooklyn/management/internal/AbstractManagementContext.java
+++ b/core/src/main/java/brooklyn/management/internal/AbstractManagementContext.java
@@ -188,8 +188,8 @@ public abstract class AbstractManagementContext implements ManagementContextInte
 
     @Override
     public void terminate() {
-        running = false;
         highAvailabilityManager.stop();
+        running = false;
         rebindManager.stop();
         storage.terminate();
         // Don't unmanage everything; different entities get given their events at different times 


### PR DESCRIPTION
Add parameter to choose whether to launch a dry run node or to upgrade directly.
Allow extending classes to customize the effector parameters by overriding a method.

Depends on https://github.com/apache/incubator-brooklyn/pull/413