### PR TITLE
Adds "None" location to arguments of start effector

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/js/view/effector-invoke.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/effector-invoke.js
@@ -88,6 +88,11 @@ define([
                         rowId : 0
                     }))
                     var $selectLocations = container.find('#select-location')
+                        .append(this.locationOptionTemplate({
+                                id: "",
+                                name: "None"
+                            }))
+                        .append("<option disabled>------</option>");
                     this.locations.each(function(aLocation) {
                         var $option = that.locationOptionTemplate({
                             id:aLocation.id,


### PR DESCRIPTION
Means that entities that were stopped but whose resources were not released can be started in the same location.

Not sure "None" is the best term. It doesn't explain what will happen. Happy to take suggestions.
