### PR TITLE
Move character set info with first 1024 bytes.

### DIFF
--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -22,8 +22,8 @@ under the License.
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-  <title>{{ page.title }}</title>
   <meta http-equiv="content-type" content="text/html; charset=iso-8859-1" />
+  <title>{{ page.title }}</title>
 
   <link rel="stylesheet" href="{{ site.url }}/style/style.css" type="text/css" media="screen" />
   <link rel="stylesheet" href="{{ site.url }}/style/toc.css" type="text/css" media="screen" />


### PR DESCRIPTION
Firefox expects the header within the first 1K. See https://bugzilla.mozilla.org/show_bug.cgi?id=672453.

Fixes the following warning from FF console:

```
The page was reloaded, because the character encoding declaration of the HTML document was not found when prescanning the first 1024 bytes of the file. The encoding declaration needs to be moved to be within the first 1024 bytes of the file.
```
