### PR TITLE
Adds "None" location to arguments of start effector

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/js/view/effector-invoke.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/effector-invoke.js
@@ -88,6 +88,11 @@ define([
                         rowId : 0
                     }))
                     var $selectLocations = container.find('#select-location')
+                        .append(this.locationOptionTemplate({
+                                id: "",
+                                name: "None"
+                            }))
+                        .append("<option disabled>------</option>");
                     this.locations.each(function(aLocation) {
                         var $option = that.locationOptionTemplate({
                             id:aLocation.id,

--- a/usage/jsgui/src/test/javascript/specs/view/effector-invoke-spec.js
+++ b/usage/jsgui/src/test/javascript/specs/view/effector-invoke-spec.js
@@ -43,6 +43,11 @@ define([
     describe("view/effector-invoke", function () {
         // render and keep the reference to the view
         modalView.render()
+
+        // Select the third item in the option list rather than the "None" and
+        // horizontal bar placeholders.
+        modalView.$("#select-location option:eq(2)").attr("selected", "selected");
+
         it("must render a bootstrap modal", function () {
             expect(modalView.$(".modal-header").length).toBe(1)
             expect(modalView.$(".modal-body").length).toBe(1)


### PR DESCRIPTION
Means that entities that were stopped but whose resources were not released can be started in the same location.

Not sure "None" is the best term. It doesn't explain what will happen. Happy to take suggestions.
