### PR TITLE
Fix restart software process

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -251,6 +251,15 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         // TODO feels like that confusion could be eliminated with a single place for pre/post logic!)
         log.debug("disconnecting sensors for "+this+" in entity.preStop");
         disconnectSensors();
+        
+        // Must set the serviceProcessIsRunning explicitly to false - we've disconnected the sensors
+        // so nothing else will.
+        // Otherwise, if restarted, there will be no change to serviceProcessIsRunning, so the
+        // serviceUpIndicators will not change, so serviceUp will not be reset.
+        // TODO Is there a race where disconnectSensors could leave a task of the feeds still running
+        // which could set serviceProcessIsRunning to true again before the task completes and the feed
+        // is fully terminated?
+        setAttribute(SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, false);
     }
 
     /**

--- a/software/database/src/test/java/brooklyn/entity/database/mysql/MySqlRestartIntegrationTest.java
+++ b/software/database/src/test/java/brooklyn/entity/database/mysql/MySqlRestartIntegrationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.database.mysql;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import brooklyn.entity.BrooklynAppLiveTestSupport;
+import brooklyn.entity.Effector;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.basic.Lifecycle;
+import brooklyn.entity.basic.ServiceStateLogic;
+import brooklyn.entity.basic.SoftwareProcess.RestartSoftwareParameters;
+import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.location.basic.LocalhostMachineProvisioningLocation;
+import brooklyn.test.EntityTestUtils;
+import brooklyn.util.collections.CollectionFunctionals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests restart of the software *process* (as opposed to the VM).
+ */
+public class MySqlRestartIntegrationTest extends BrooklynAppLiveTestSupport {
+    
+    // TODO Remove duplication from TomcatServerRestartIntegrationTest
+    
+    @SuppressWarnings("unused")
+    private static final Logger LOG = LoggerFactory.getLogger(MySqlRestartIntegrationTest.class);
+
+    @Test(groups="Integration")
+    public void testStopProcessAndRestart() throws Exception {
+        runStopProcessAndRestart(
+                MySqlNode.RESTART, 
+                ImmutableMap.of(RestartSoftwareParameters.RESTART_MACHINE.getName(), RestartSoftwareParameters.RestartMachineMode.FALSE));
+    }
+    
+    @Test(groups="Integration")
+    public void testStopProcessAndStart() throws Exception {
+        runStopProcessAndRestart(
+                MySqlNode.START, 
+                ImmutableMap.of("locations", ImmutableList.of()));
+    }
+    
+    protected void runStopProcessAndRestart(Effector<?> restartEffector, Map<String, ?> args) throws Exception {
+        LocalhostMachineProvisioningLocation loc = app.newLocalhostProvisioningLocation();
+        MySqlNode entity = app.createAndManageChild(EntitySpec.create(MySqlNode.class));
+        app.start(ImmutableList.of(loc));
+        
+        Entities.invokeEffector(app, entity, MySqlNode.STOP, ImmutableMap.of(
+                StopSoftwareParameters.STOP_MACHINE.getName(), false))
+                .get();
+        EntityTestUtils.assertAttributeEqualsEventually(entity, MySqlNode.SERVICE_UP, false);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, MySqlNode.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, MySqlNode.SERVICE_PROCESS_IS_RUNNING, false);
+        EntityTestUtils.assertAttributeEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, CollectionFunctionals.<String>mapSizeEquals(1));
+        
+        Entities.invokeEffector(app, entity, restartEffector, args).get();
+        EntityTestUtils.assertAttributeEqualsEventually(entity, MySqlNode.SERVICE_UP, true);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, MySqlNode.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, MySqlNode.SERVICE_PROCESS_IS_RUNNING, true);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, ImmutableMap.<String, Object>of());
+
+        EntityTestUtils.assertAttributeEqualsEventually(app, MySqlNode.SERVICE_UP, true);
+        EntityTestUtils.assertAttributeEqualsEventually(app, MySqlNode.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+    }
+}

--- a/software/webapp/src/main/java/brooklyn/entity/webapp/tomcat/Tomcat7SshDriver.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/tomcat/Tomcat7SshDriver.java
@@ -28,9 +28,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
-
 import brooklyn.entity.basic.Entities;
 import brooklyn.entity.webapp.JavaWebAppSshDriver;
 import brooklyn.location.basic.SshMachineLocation;
@@ -40,6 +37,8 @@ import brooklyn.util.net.Networking;
 import brooklyn.util.os.Os;
 import brooklyn.util.ssh.BashCommands;
 import brooklyn.util.text.StringEscapes.BashStringEscapes;
+
+import com.google.common.base.Preconditions;
 
 public class Tomcat7SshDriver extends JavaWebAppSshDriver implements Tomcat7Driver {
 
@@ -75,7 +74,7 @@ public class Tomcat7SshDriver extends JavaWebAppSshDriver implements Tomcat7Driv
     @Override
     public void customize() {
         newScript(CUSTOMIZING)
-                .body.append("mkdir conf logs webapps temp")
+                .body.append("mkdir -p conf logs webapps temp")
                 .failOnNonZeroResultCode()
                 .execute();
 

--- a/software/webapp/src/test/java/brooklyn/entity/webapp/tomcat/TomcatServerRestartIntegrationTest.java
+++ b/software/webapp/src/test/java/brooklyn/entity/webapp/tomcat/TomcatServerRestartIntegrationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.webapp.tomcat;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import brooklyn.entity.BrooklynAppLiveTestSupport;
+import brooklyn.entity.Effector;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.basic.Lifecycle;
+import brooklyn.entity.basic.ServiceStateLogic;
+import brooklyn.entity.basic.SoftwareProcess.RestartSoftwareParameters;
+import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.location.basic.LocalhostMachineProvisioningLocation;
+import brooklyn.test.EntityTestUtils;
+import brooklyn.util.collections.CollectionFunctionals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests restart of the software *process* (as opposed to the VM).
+ */
+public class TomcatServerRestartIntegrationTest extends BrooklynAppLiveTestSupport {
+    
+    // TODO Remove duplication from MySqlRestartIntegrationTest
+    
+    @SuppressWarnings("unused")
+    private static final Logger LOG = LoggerFactory.getLogger(TomcatServerRestartIntegrationTest.class);
+    
+    @Test(groups="Integration")
+    public void testStopProcessAndRestart() throws Exception {
+        runStopProcessAndRestart(
+                TomcatServer.RESTART, 
+                ImmutableMap.of(RestartSoftwareParameters.RESTART_MACHINE.getName(), RestartSoftwareParameters.RestartMachineMode.FALSE));
+    }
+    
+    @Test(groups="Integration")
+    public void testStopProcessAndStart() throws Exception {
+        runStopProcessAndRestart(
+                TomcatServer.START, 
+                ImmutableMap.of("locations", ImmutableList.of()));
+    }
+    
+    protected void runStopProcessAndRestart(Effector<?> restartEffector, Map<String, ?> args) throws Exception {
+        LocalhostMachineProvisioningLocation loc = app.newLocalhostProvisioningLocation();
+        TomcatServer entity = app.createAndManageChild(EntitySpec.create(TomcatServer.class));
+        app.start(ImmutableList.of(loc));
+        
+        Entities.invokeEffector(app, entity, TomcatServer.STOP, ImmutableMap.of(
+                StopSoftwareParameters.STOP_MACHINE.getName(), false))
+                .get();
+        EntityTestUtils.assertAttributeEqualsEventually(entity, TomcatServer.SERVICE_UP, false);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, TomcatServer.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, TomcatServer.SERVICE_PROCESS_IS_RUNNING, false);
+        EntityTestUtils.assertAttributeEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, CollectionFunctionals.<String>mapSizeEquals(1));
+        
+        Entities.invokeEffector(app, entity, restartEffector, args).get();
+        EntityTestUtils.assertAttributeEqualsEventually(entity, TomcatServer.SERVICE_UP, true);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, TomcatServer.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, TomcatServer.SERVICE_PROCESS_IS_RUNNING, true);
+        EntityTestUtils.assertAttributeEqualsEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, ImmutableMap.<String, Object>of());
+
+        EntityTestUtils.assertAttributeEqualsEventually(app, TomcatServer.SERVICE_UP, true);
+        EntityTestUtils.assertAttributeEqualsEventually(app, TomcatServer.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+    }
+}


### PR DESCRIPTION
- Previousy if you stopped the process, and then called restart() or start(), it would sometimes fail to reach service-up. This was because there was no change in serviceUpIndicators on stop+start, so service-up was not re-published as true.

Builds on https://github.com/apache/incubator-brooklyn/pull/375
