### PR TITLE
BROOKLYN-72: Fix deletion of OSGi cache dir

### DIFF
--- a/utils/common/src/main/java/brooklyn/util/os/Os.java
+++ b/utils/common/src/main/java/brooklyn/util/os/Os.java
@@ -231,13 +231,18 @@ public class Os {
      */
     @Beta
     public static DeletionResult deleteRecursively(File dir, boolean skipSafetyChecks) {
+        if (dir==null) return new DeletionResult(null, true, null);
+        
         try {
-            if (dir==null) return new DeletionResult(null, true, null);
-            
             if (!skipSafetyChecks) checkSafe(dir);
 
             FileUtils.deleteDirectory(dir);
             return new DeletionResult(dir, true, null);
+        } catch (IllegalArgumentException e) {
+            // See exception reported in https://issues.apache.org/jira/browse/BROOKLYN-72
+            // If another thread is changing the contents of the directory at the same time as
+            // we delete it, then can get this exception.
+            return new DeletionResult(dir, false, e);
         } catch (IOException e) {
             return new DeletionResult(dir, false, e);
         }

--- a/utils/common/src/test/java/brooklyn/util/os/OsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/os/OsTest.java
@@ -19,6 +19,8 @@
 package brooklyn.util.os;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -30,8 +32,11 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.os.Os.DeletionResult;
+import brooklyn.util.text.Identifiers;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
 
 @Test
 public class OsTest {
@@ -133,4 +138,30 @@ public class OsTest {
         }
     }
 
+    @Test
+    public void testDeleteRecursivelyNonExistantDir() throws Exception {
+        DeletionResult result = Os.deleteRecursively(Os.mergePaths(Os.tmp(), Identifiers.makeRandomId(8)));
+        assertTrue(result.wasSuccessful());
+    }
+    
+    @Test
+    public void testDeleteRecursivelyEmptyDir() throws Exception {
+        File dir = Os.newTempDir(OsTest.class);
+        DeletionResult result = Os.deleteRecursively(dir);
+        assertTrue(result.wasSuccessful());
+        assertFalse(dir.exists());
+    }
+    
+    @Test
+    public void testDeleteRecursivelySubDirs() throws Exception {
+        File dir = Os.newTempDir(OsTest.class);
+        File subdir = new File(dir, "mysubdir");
+        File subfile = new File(subdir, "mysubfile");
+        subdir.mkdirs();
+        Files.write("abc".getBytes(), subfile);
+        
+        DeletionResult result = Os.deleteRecursively(dir);
+        assertTrue(result.wasSuccessful());
+        assertFalse(dir.exists());
+    }
 }


### PR DESCRIPTION
- Previously stopping Brooklyn almost always resulted in an `IllegalArgumentException` at `log.info`, caused by a concurrent modification when trying to delete the dir.
- Now will catch that to log.debug, and will also retry for one second.
