### PR TITLE
BROOKLYN-101: avoid recordLocationEvent on rebind

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/AbstractApplication.java
+++ b/core/src/main/java/brooklyn/entity/basic/AbstractApplication.java
@@ -239,7 +239,9 @@ public abstract class AbstractApplication extends AbstractEntity implements Star
     @Override
     public void onManagementStopped() {
         super.onManagementStopped();
-        recordApplicationEvent(Lifecycle.DESTROYED);
+        if (getManagementContext().isRunning()) {
+            recordApplicationEvent(Lifecycle.DESTROYED);
+        }
     }
     
     private void recordApplicationEvent(Lifecycle state) {

--- a/core/src/main/java/brooklyn/entity/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/brooklyn/entity/rebind/RebindManagerImpl.java
@@ -1133,7 +1133,7 @@ public class RebindManagerImpl implements RebindManager {
         if (wasReadOnly==null) {
             // not known
             if (Boolean.TRUE.equals(isNowReadOnly)) return ManagementTransitionMode.REBINDING_READONLY;
-            else return ManagementTransitionMode.CREATING;
+            else return ManagementTransitionMode.REBINDING_CREATING;
         } else {
             if (wasReadOnly && isNowReadOnly)
                 return ManagementTransitionMode.REBINDING_READONLY;

--- a/core/src/main/java/brooklyn/management/internal/LocalLocationManager.java
+++ b/core/src/main/java/brooklyn/management/internal/LocalLocationManager.java
@@ -244,7 +244,11 @@ public class LocalLocationManager implements LocationManagerInternal {
                 it.setManagementContext(managementContext);
                 if (!mode.isReadOnly()) {
                     it.onManagementStarted();
-                    if (!mode.wasReadOnly()) {
+                    if (!mode.wasReadOnly() && !mode.isRebinding()) {
+                        // Never record event on rebind; this isn't the location (e.g. the VM) being "created"
+                        // so don't tell listeners that.
+                        // TODO The location-event history should be persisted; currently it is lost on
+                        // rebind, unless there is a listener that is persisting the state externally itself.
                         recordLocationEvent(it, Lifecycle.CREATED);
                     }
                 }

--- a/core/src/main/java/brooklyn/management/internal/ManagementTransitionInfo.java
+++ b/core/src/main/java/brooklyn/management/internal/ManagementTransitionInfo.java
@@ -32,29 +32,34 @@ public class ManagementTransitionInfo {
 
     public enum ManagementTransitionMode {
         /** Item is being created fresh, for the first time */ 
-        CREATING(false, false),
+        CREATING(false, false, false),
         /** Item is being destroyed / stopping permanently */ 
-        DESTROYING(false, false),
+        DESTROYING(false, false, false),
         
         /** Item is being mirrored (or refreshed) here from a serialized/specified state */
-        REBINDING_READONLY(true, true),
+        REBINDING_READONLY(true, true, true),
         /** Item management is stopping here, going elsewhere */
-        REBINDING_NO_LONGER_PRIMARY(false, true), 
+        REBINDING_NO_LONGER_PRIMARY(false, true, true), 
         /** Item management is starting here, having previously been running elsewhere */
-        REBINDING_BECOMING_PRIMARY(true, false),
+        REBINDING_BECOMING_PRIMARY(true, false, true),
         /** Item was being mirrored but has now been destroyed  */
-        REBINDING_DESTROYED(true, true);
+        REBINDING_DESTROYED(true, true, true),
+        /** Item management is starting here, where not sure what previous running state was */
+        REBINDING_CREATING(false, false, true);
         
-        private boolean wasReadOnly;
-        private boolean isReadOnly;
-
-        ManagementTransitionMode(boolean wasReadOnly, boolean isReadOnly) {
+        private final boolean wasReadOnly;
+        private final boolean isReadOnly;
+        private final boolean isRebinding;
+        
+        ManagementTransitionMode(boolean wasReadOnly, boolean isReadOnly, boolean isRebinding) {
             this.wasReadOnly = wasReadOnly;
             this.isReadOnly = isReadOnly;
+            this.isRebinding = isRebinding;
         }
         
         public boolean wasReadOnly() { return wasReadOnly; }
         public boolean isReadOnly() { return isReadOnly; }
+        public boolean isRebinding() { return isRebinding; }
     }
     
     public ManagementTransitionInfo(ManagementContext mgmtContext, ManagementTransitionMode mode) {


### PR DESCRIPTION
- Previously on rebind we would call recordLocationEvent, which would
  try to get `inferMachineDetails` over ssh in the rebind thread
  (taking a long time).
- Now we don’t recordLocationEvent or recordApplicationEvent on
  startup or shutdown.
