### PR TITLE
Improve recursion checks for catalog items

### DIFF
--- a/core/src/main/java/brooklyn/camp/brooklyn/api/AssemblyTemplateSpecInstantiator.java
+++ b/core/src/main/java/brooklyn/camp/brooklyn/api/AssemblyTemplateSpecInstantiator.java
@@ -21,11 +21,16 @@ package brooklyn.camp.brooklyn.api;
 import io.brooklyn.camp.CampPlatform;
 import io.brooklyn.camp.spi.AssemblyTemplate;
 import io.brooklyn.camp.spi.instantiate.AssemblyTemplateInstantiator;
+
+import java.util.Set;
+
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.management.classloading.BrooklynClassLoadingContext;
 
 public interface AssemblyTemplateSpecInstantiator extends AssemblyTemplateInstantiator {
 
     EntitySpec<?> createSpec(AssemblyTemplate template, CampPlatform platform, BrooklynClassLoadingContext loader, boolean autoUnwrapIfAppropriate);
+    EntitySpec<?> createNestedSpec(AssemblyTemplate template, CampPlatform platform, BrooklynClassLoadingContext itemLoader, Set<String> encounteredCatalogTypes);
+
     
 }

--- a/core/src/test/java/brooklyn/camp/lite/TestAppAssemblyInstantiator.java
+++ b/core/src/test/java/brooklyn/camp/lite/TestAppAssemblyInstantiator.java
@@ -27,6 +27,7 @@ import io.brooklyn.camp.spi.collection.ResolvableLink;
 import io.brooklyn.camp.spi.instantiate.BasicAssemblyTemplateInstantiator;
 
 import java.util.Map;
+import java.util.Set;
 
 import brooklyn.camp.brooklyn.api.AssemblyTemplateSpecInstantiator;
 import brooklyn.camp.brooklyn.api.HasBrooklynManagementContext;
@@ -80,6 +81,11 @@ public class TestAppAssemblyInstantiator extends BasicAssemblyTemplateInstantiat
         Object bc = template.getCustomAttributes().get("brooklyn.config");
         if (bc instanceof Map)
             app.configure(ConfigBag.newInstance().putAll((Map)bc).getAllConfigAsConfigKeyMap());
+    }
+
+    @Override
+    public EntitySpec<?> createNestedSpec(AssemblyTemplate template, CampPlatform platform, BrooklynClassLoadingContext itemLoader, Set<String> encounteredCatalogTypes) {
+        return createSpec(template, platform, itemLoader, true);
     }
 
 }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -217,19 +217,7 @@ public class BrooklynComponentTemplateResolver {
     
     /** tries to load the Java entity class */
     public Maybe<Class<? extends Entity>> tryLoadEntityClass() {
-        CatalogItem<Entity, EntitySpec<?>> item = getCatalogItem();
-        String typeName = getBrooklynType();
-        
-        if (item!=null) {
-            // add additional bundles
-            loader = new BrooklynClassLoadingContextSequential(mgmt, CatalogUtils.newClassLoadingContext(mgmt, item), loader);
-            
-            if (item.getJavaType() != null) {
-                typeName = item.getJavaType();
-            }
-        }
-        
-        return loader.tryLoadClass(typeName, Entity.class);
+        return loader.tryLoadClass(getBrooklynType(), Entity.class);
     }
 
     /** resolves the spec, updating the loader if a catalog item is loaded */

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -421,6 +421,23 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         }
     }
 
+    @Test
+    public void testOsgiNotLeakingToParent() {
+        addCatalogOSGiEntity(SIMPLE_ENTITY_TYPE);
+        try {
+            addCatalogItem(
+                    "brooklyn.catalog:",
+                    "  id: " + SIMPLE_ENTITY_TYPE,
+                    "  version: " + TEST_VERSION + "-update",
+                    "",
+                    "services:",
+                    "- type: " + SIMPLE_ENTITY_TYPE);
+            fail("Catalog addition expected to fail due to non-existent java type " + SIMPLE_ENTITY_TYPE);
+        } catch (IllegalStateException e) {
+            assertEquals(e.getMessage(), "Recursive reference to " + SIMPLE_ENTITY_TYPE + " (and cannot be resolved as a Java type)");
+        }
+    }
+    
     private void registerAndLaunchAndAssertSimpleEntity(String symbolicName, String serviceType) throws Exception {
         addCatalogOSGiEntity(symbolicName, serviceType);
         String yaml = "name: simple-app-yaml\n" +


### PR DESCRIPTION
* `catalog.createSpec` now passes the symbolicName of the item so resolving to items with the same symbolicName already in the catalogue is prevented (fallback to java types only).
* the recursion check was using the type as is, thus making it possible to recurse into items with the same symbolicName where version is explicitly specified. Explicitly forbid catalog items referencing same symbolicName items, even if with another version.
* stop catalog items whose symbolicName matches the java type they export leaking their bundles to callers. 