### PR TITLE
BrooklynNode - unmanage on stop, fix abort logic

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -162,6 +162,13 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     }
     
     @Override
+    protected void preStopConfirmCustom() {
+        super.preStopConfirmCustom();
+        
+        entity().preStopConfirmCustom();
+    }
+    
+    @Override
     protected void preStopCustom() {
         super.preStopCustom();
         

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -244,6 +244,9 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     protected void postStart() {
     }
     
+    protected void preStopConfirmCustom() {
+    }
+    
     protected void preStop() {
         // note asymmetry that disconnectSensors is done in the entity not the driver
         // whereas on start the *driver* calls connectSensors, before calling postStart,
@@ -568,5 +571,5 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     protected final void doRestart() {
         doRestart(ConfigBag.EMPTY);
     }
-    
+
 }

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -111,7 +111,15 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
     protected void preStart() {
         ServiceNotUpLogic.clearNotUpIndicator(this, SHUTDOWN.getName());
     }
-    
+
+    @Override
+    protected void preStopConfirmCustom() {
+        super.preStopConfirmCustom();
+        if (Boolean.TRUE.equals(getAttribute(BrooklynNode.WEB_CONSOLE_ACCESSIBLE))) {
+            Preconditions.checkState(getChildren().isEmpty(), "Can't stop instance with running applications.");
+        }
+    }
+
     @Override
     protected void preStop() {
         super.preStop();
@@ -119,7 +127,6 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
         // Shutdown only if accessible: any of stop_* could have already been called.
         // Don't check serviceUp=true because stop() will already have set serviceUp=false && expectedState=stopping
         if (Boolean.TRUE.equals(getAttribute(BrooklynNode.WEB_CONSOLE_ACCESSIBLE))) {
-            Preconditions.checkState(getChildren().isEmpty(), "Can't stop instance with running applications.");
             DynamicTasks.queue(Effectors.invocation(this, SHUTDOWN, MutableMap.of(ShutdownEffector.REQUEST_TIMEOUT, Duration.ONE_MINUTE)));
         } else {
             log.info("Skipping children.isEmpty check and shutdown call, because web-console not up for {}", this);

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -533,6 +533,8 @@ public abstract class MachineLifecycleEffectorTasks {
      * {@link #stopAnyProvisionedMachines()} and sets state {@link Lifecycle#STOPPED}
      */
     public void stop(ConfigBag parameters) {
+        preStopConfirmCustom();
+
         log.info("Stopping {} in {}", entity(), entity().getLocations());
 
         Boolean isStopMachine = parameters.get(StopSoftwareParameters.STOP_MACHINE);
@@ -612,6 +614,14 @@ public abstract class MachineLifecycleEffectorTasks {
         ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPED);
 
         if (log.isDebugEnabled()) log.debug("Stopped software process entity "+entity());
+    }
+
+    /** 
+     * Override to check whether stop can be executed.
+     * Throw if stop should be aborted.
+     */
+    protected void preStopConfirmCustom() {
+        // nothing needed here
     }
 
     protected void preStopCustom() {


### PR DESCRIPTION
* Allow entities to be able to abort their stop effector. If pre-stop is aborted the machine will still be released.
* Unmanage BrooklynNode on stop

WARNING: Turns out that postStop wasn't wired up, it was never called. Nevertheless some entities (i.e. CouchDBNode, NginxController, JavaWebAppSoftwareProcess) override it which might introduce unwanted behaviour. Shall I remove the override in existing entities?
