### PR TITLE
Don't create enrichers (i.e. quorum check) for quarantine entity.

### DIFF
--- a/core/src/main/java/brooklyn/entity/group/QuarantineGroupImpl.java
+++ b/core/src/main/java/brooklyn/entity/group/QuarantineGroupImpl.java
@@ -45,6 +45,11 @@ public class QuarantineGroupImpl extends AbstractGroupImpl implements Quarantine
     private static final Logger LOG = LoggerFactory.getLogger(AbstractEntity.class);
 
     @Override
+    protected void initEnrichers() {
+        //don't want enrichers (i.e. quorum checks)
+    }
+
+    @Override
     public void expungeMembers(boolean stopFirst) {
         Set<Entity> members = ImmutableSet.copyOf(getMembers());
         RuntimeException exception = null;


### PR DESCRIPTION
Fixes the following problems:
- If the items in the quarantine entity are removed (either unmanaged or no longer on fire) the quarantine gets {running: false, ON_FIRE: true} state due to the enrichers.
- If the Clear Problems from UI is executed on quarantine in gets {running: true} state.
