### PR TITLE
Return null SubscriptionContext when management stopped

### DIFF
--- a/api/src/main/java/brooklyn/management/SubscriptionContext.java
+++ b/api/src/main/java/brooklyn/management/SubscriptionContext.java
@@ -31,31 +31,34 @@ import brooklyn.event.SensorEventListener;
  * This is the context through which an {@link Entity} can manage its subscriptions.
  */
 public interface SubscriptionContext {
+
     /**
      * As {@link SubscriptionManager#subscribe(Map, Entity, Sensor, SensorEventListener)} with default subscription parameters for this context
      */
     <T> SubscriptionHandle subscribe(Map<String, Object> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);
- 
+
     /** @see #subscribe(Map, Entity, Sensor, SensorEventListener) */
     <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);
-    
+
     /** @see #subscribe(Map, Entity, Sensor, SensorEventListener) */
     <T> SubscriptionHandle subscribeToChildren(Map<String, Object> flags, Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener);
- 
+
     /** @see #subscribe(Map, Entity, Sensor, SensorEventListener) */
     <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener);
-    
+
     /** @see #subscribe(Map, Entity, Sensor, SensorEventListener) */
     <T> SubscriptionHandle subscribeToMembers(Map<String, Object> flags, Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener);
- 
+
     /** @see #subscribe(Map, Entity, Sensor, SensorEventListener) */
     <T> SubscriptionHandle subscribeToMembers(Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener);
-    
+
     /** @see SubscriptionManager#unsubscribe(SubscriptionHandle) */
     boolean unsubscribe(SubscriptionHandle subscriptionId);
-    
-    /** causes all subscriptions to be deregistered
-     * @return number of subscriptions removed */
+
+    /**
+     * Causes all subscriptions to be deregistered
+     * @return number of subscriptions removed
+     */
     int unsubscribeAll();
 
     /** @see SubscriptionManager#publish(SensorEvent) */
@@ -63,4 +66,5 @@ public interface SubscriptionContext {
 
     /** Return the subscriptions associated with this context */
     Set<SubscriptionHandle> getSubscriptions();
+
 }

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
@@ -227,7 +227,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     @Override
     public synchronized SubscriptionContext getSubscriptionContext(Entity entity) {
         if (!this.entity.equals(entity)) throw new IllegalStateException("Non-deployment context "+this+" can only use a single Entity: has "+this.entity+", but passed "+entity);
-        if (mode==NonDeploymentManagementContextMode.MANAGEMENT_STOPPED) return null;
+        if (mode==NonDeploymentManagementContextMode.MANAGEMENT_STOPPED) return new NonDeploymentSubscriptionContext(entity);
         return subscriptionContext;
     }
 

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
@@ -227,8 +227,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     @Override
     public synchronized SubscriptionContext getSubscriptionContext(Entity entity) {
         if (!this.entity.equals(entity)) throw new IllegalStateException("Non-deployment context "+this+" can only use a single Entity: has "+this.entity+", but passed "+entity);
-        if (mode==NonDeploymentManagementContextMode.MANAGEMENT_STOPPED)
-            throw new IllegalStateException("Entity "+entity+" is no longer managed; subscription context not available");
+        if (mode==NonDeploymentManagementContextMode.MANAGEMENT_STOPPED) return null;
         return subscriptionContext;
     }
 

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
@@ -227,7 +227,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     @Override
     public synchronized SubscriptionContext getSubscriptionContext(Entity entity) {
         if (!this.entity.equals(entity)) throw new IllegalStateException("Non-deployment context "+this+" can only use a single Entity: has "+this.entity+", but passed "+entity);
-        if (mode==NonDeploymentManagementContextMode.MANAGEMENT_STOPPED) return new NonDeploymentSubscriptionContext(entity);
+        if (mode==NonDeploymentManagementContextMode.MANAGEMENT_STOPPED) return new NonDeploymentSubscriptionContext(initialManagementContext, entity);
         return subscriptionContext;
     }
 

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentSubscriptionContext.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentSubscriptionContext.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.management.internal;
+
+import java.util.Map;
+import java.util.Set;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.Group;
+import brooklyn.event.Sensor;
+import brooklyn.event.SensorEvent;
+import brooklyn.event.SensorEventListener;
+import brooklyn.management.SubscriptionContext;
+import brooklyn.management.SubscriptionHandle;
+import brooklyn.management.SubscriptionManager;
+import brooklyn.management.internal.NonDeploymentManagementContext.NonDeploymentManagementContextMode;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * A {@link SubscriptionContext} to be used when management has benn
+ * {@link NonDeploymentManagementContextMode#MANAGEMENT_STOPPED stopped}.
+ */
+public class NonDeploymentSubscriptionContext implements SubscriptionContext {
+
+    private final Object subscriber;
+
+    public NonDeploymentSubscriptionContext(Object subscriber) {
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        throw nonDeploymentContextError();
+    }
+
+    @Override
+    public <T> SubscriptionHandle subscribe(Map<String, Object> newFlags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        throw nonDeploymentContextError();
+    }
+
+    @Override
+    public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        throw nonDeploymentContextError();
+    }
+
+    @Override
+    public <T> SubscriptionHandle subscribeToChildren(Map<String, Object> newFlags, Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        throw nonDeploymentContextError();
+    }
+
+    @Override
+    public <T> SubscriptionHandle subscribeToMembers(Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        throw nonDeploymentContextError();
+    }
+
+    @Override
+    public <T> SubscriptionHandle subscribeToMembers(Map<String, Object> newFlags, Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        throw nonDeploymentContextError();
+    }
+
+    private IllegalStateException nonDeploymentContextError() {
+        return new IllegalStateException(String.format("Non-deployment subscription context for %s; Management stopped", subscriber));
+    }
+
+    @Override
+    public boolean unsubscribe(SubscriptionHandle subscriptionId) {
+        return false;
+    }
+
+    /** @see SubscriptionManager#publish(SensorEvent) */
+    @Override
+    public <T> void publish(SensorEvent<T> event) {
+        throw nonDeploymentContextError();
+    }
+
+    /** Return the subscriptions associated with this context */
+    @Override
+    public Set<SubscriptionHandle> getSubscriptions() {
+        return ImmutableSet.<SubscriptionHandle>of();
+    }
+
+    @Override
+    public int unsubscribeAll() {
+        return 0;
+    }
+
+}

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentSubscriptionContext.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentSubscriptionContext.java
@@ -26,6 +26,7 @@ import brooklyn.entity.Group;
 import brooklyn.event.Sensor;
 import brooklyn.event.SensorEvent;
 import brooklyn.event.SensorEventListener;
+import brooklyn.management.ManagementContext;
 import brooklyn.management.SubscriptionContext;
 import brooklyn.management.SubscriptionHandle;
 import brooklyn.management.SubscriptionManager;
@@ -39,66 +40,92 @@ import com.google.common.collect.ImmutableSet;
  */
 public class NonDeploymentSubscriptionContext implements SubscriptionContext {
 
-    private final Object subscriber;
+    private final ManagementContext initialManagementContext;
+    private final Entity subscriber;
 
-    public NonDeploymentSubscriptionContext(Object subscriber) {
+    public NonDeploymentSubscriptionContext(ManagementContext initialManagementContext, Entity subscriber) {
+        this.initialManagementContext = initialManagementContext;
         this.subscriber = subscriber;
     }
 
     @Override
     public <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        throw nonDeploymentContextError();
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).subscribe(producer, sensor, listener);
+        } else throw nonDeploymentContextError();
     }
 
     @Override
     public <T> SubscriptionHandle subscribe(Map<String, Object> newFlags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        throw nonDeploymentContextError();
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).subscribe(newFlags, producer, sensor, listener);
+        } else throw nonDeploymentContextError();
     }
 
     @Override
     public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        throw nonDeploymentContextError();
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).subscribeToChildren(parent, sensor, listener);
+        } else throw nonDeploymentContextError();
     }
 
     @Override
     public <T> SubscriptionHandle subscribeToChildren(Map<String, Object> newFlags, Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        throw nonDeploymentContextError();
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).subscribeToChildren(newFlags, parent, sensor, listener);
+        } else throw nonDeploymentContextError();
     }
 
     @Override
     public <T> SubscriptionHandle subscribeToMembers(Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        throw nonDeploymentContextError();
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).subscribeToMembers(parent, sensor, listener);
+        } else throw nonDeploymentContextError();
     }
 
     @Override
     public <T> SubscriptionHandle subscribeToMembers(Map<String, Object> newFlags, Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        throw nonDeploymentContextError();
-    }
-
-    private IllegalStateException nonDeploymentContextError() {
-        return new IllegalStateException(String.format("Non-deployment subscription context for %s; Management stopped", subscriber));
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).subscribeToMembers(newFlags, parent, sensor, listener);
+        } else throw nonDeploymentContextError();
     }
 
     @Override
     public boolean unsubscribe(SubscriptionHandle subscriptionId) {
-        return false;
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).unsubscribe(subscriptionId);
+        } else return false;
     }
 
     /** @see SubscriptionManager#publish(SensorEvent) */
     @Override
     public <T> void publish(SensorEvent<T> event) {
-        throw nonDeploymentContextError();
+        if (isInitialManagementContextReal()) {
+            initialManagementContext.getSubscriptionContext(subscriber).publish(event);
+        } else throw nonDeploymentContextError();
     }
 
     /** Return the subscriptions associated with this context */
     @Override
     public Set<SubscriptionHandle> getSubscriptions() {
-        return ImmutableSet.<SubscriptionHandle>of();
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).getSubscriptions();
+        } else return ImmutableSet.<SubscriptionHandle>of();
     }
 
     @Override
     public int unsubscribeAll() {
-        return 0;
+        if (isInitialManagementContextReal()) {
+            return initialManagementContext.getSubscriptionContext(subscriber).unsubscribeAll();
+        } else return 0;
+    }
+
+    private IllegalStateException nonDeploymentContextError() {
+        throw new IllegalStateException(String.format("Non-deployment subscription context for %s; Management stopped", subscriber));
+    }
+
+    private boolean isInitialManagementContextReal() {
+        return (initialManagementContext != null && !(initialManagementContext instanceof NonDeploymentManagementContext));
     }
 
 }

--- a/core/src/main/java/brooklyn/management/internal/SubscriptionTracker.java
+++ b/core/src/main/java/brooklyn/management/internal/SubscriptionTracker.java
@@ -37,7 +37,7 @@ import com.google.common.collect.SetMultimap;
  */
 public class SubscriptionTracker {
 
-    // This class is thread-safe. All modifications to subscriptions are synchronized on the 
+    // This class is thread-safe. All modifications to subscriptions are synchronized on the
     // "subscriptions" field. However, calls to alien code (i.e. context.subscribe etc) is
     // done without holding the lock.
     //
@@ -46,15 +46,15 @@ public class SubscriptionTracker {
     // is guaranteed that the internal state of the SubscriptionTracker will be consistent: if
     // the "subscriptions" includes the new subscription then that subscription will really exist,
     // and vice versa.
-    
+
     protected SubscriptionContext context;
-    
+
     private final SetMultimap<Entity, SubscriptionHandle> subscriptions = HashMultimap.create();
 
     public SubscriptionTracker(SubscriptionContext subscriptionContext) {
         this.context = subscriptionContext;
     }
-    
+
     /** @see SubscriptionContext#subscribe(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
         SubscriptionHandle handle = context.subscribe(producer, sensor, listener);
@@ -63,7 +63,7 @@ public class SubscriptionTracker {
         }
         return handle;
     }
-    
+
     /** @see SubscriptionContext#subscribeToChildren(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
         SubscriptionHandle handle = context.subscribeToChildren(parent, sensor, listener);
@@ -82,7 +82,7 @@ public class SubscriptionTracker {
             subscriptions.put(parent, handle);
         }
         return handle;
-    }    
+    }
 
     /**
      * Unsubscribes the given producer.

--- a/core/src/main/java/brooklyn/management/internal/SubscriptionTracker.java
+++ b/core/src/main/java/brooklyn/management/internal/SubscriptionTracker.java
@@ -27,7 +27,6 @@ import brooklyn.event.SensorEventListener;
 import brooklyn.management.SubscriptionContext;
 import brooklyn.management.SubscriptionHandle;
 
-import com.google.api.client.repackaged.com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.SetMultimap;
@@ -58,7 +57,6 @@ public class SubscriptionTracker {
     
     /** @see SubscriptionContext#subscribe(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        Preconditions.checkState(context != null, "Invalid subscription context; Management stopped");
         SubscriptionHandle handle = context.subscribe(producer, sensor, listener);
         synchronized (subscriptions) {
             subscriptions.put(producer, handle);
@@ -68,7 +66,6 @@ public class SubscriptionTracker {
     
     /** @see SubscriptionContext#subscribeToChildren(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        Preconditions.checkState(context != null, "Invalid subscription context; Management stopped");
         SubscriptionHandle handle = context.subscribeToChildren(parent, sensor, listener);
         synchronized (subscriptions) {
             subscriptions.put(parent, handle);
@@ -80,7 +77,6 @@ public class SubscriptionTracker {
      * @see SubscriptionContext#subscribeToMembers(Group, Sensor, SensorEventListener)
      */
     public <T> SubscriptionHandle subscribeToMembers(Group parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        Preconditions.checkState(context != null, "Invalid subscription context; Management stopped");
         SubscriptionHandle handle = context.subscribeToMembers(parent, sensor, listener);
         synchronized (subscriptions) {
             subscriptions.put(parent, handle);
@@ -94,7 +90,6 @@ public class SubscriptionTracker {
      * @see SubscriptionContext#unsubscribe(SubscriptionHandle)
      */
     public boolean unsubscribe(Entity producer) {
-        if (context == null) return false;
         Collection<SubscriptionHandle> handles;
         synchronized (subscriptions) {
             handles = subscriptions.removeAll(producer);
@@ -114,7 +109,6 @@ public class SubscriptionTracker {
      * @see SubscriptionContext#unsubscribe(SubscriptionHandle)
      */
     public boolean unsubscribe(Entity producer, SubscriptionHandle handle) {
-        if (context == null) return false;
         synchronized (subscriptions) {
             subscriptions.remove(producer, handle);
         }
@@ -125,14 +119,12 @@ public class SubscriptionTracker {
      * @return an ordered list of all subscription handles
      */
     public Collection<SubscriptionHandle> getAllSubscriptions() {
-        Preconditions.checkState(context != null, "Invalid subscription context; Management stopped");
         synchronized (subscriptions) {
             return ImmutableList.copyOf(subscriptions.values());
         }
     }
 
     public void unsubscribeAll() {
-        if (context == null) return;
         Collection<SubscriptionHandle> subscriptionsSnapshot;
         synchronized (subscriptions) {
             subscriptionsSnapshot = ImmutableList.copyOf(subscriptions.values());


### PR DESCRIPTION
Check for null conext when calling `SubscriptionTracker` methods and allow unsubscribes with null context (harmless) but error otherwise.