### PR TITLE
Release the underlying machine when stopping BrooklynNode

### DIFF
--- a/core/src/main/java/brooklyn/management/internal/EffectorUtils.java
+++ b/core/src/main/java/brooklyn/management/internal/EffectorUtils.java
@@ -340,7 +340,7 @@ public class EffectorUtils {
                 .put("displayName", effector.getName())
                 .put("tags", MutableList.of(
                         BrooklynTaskTags.EFFECTOR_TAG, 
-                        BrooklynTaskTags.tagForEffectorCall(entity, effector.getName()), 
+                        BrooklynTaskTags.tagForEffectorCall(entity, effector.getName(), parameters), 
                         BrooklynTaskTags.tagForTargetEntity(entity)))
                 .build();
     }

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -162,6 +162,13 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     }
     
     @Override
+    protected void preStopConfirmCustom() {
+        super.preStopConfirmCustom();
+        
+        entity().preStopConfirmCustom();
+    }
+    
+    @Override
     protected void preStopCustom() {
         super.preStopCustom();
         

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -244,6 +244,9 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     protected void postStart() {
     }
     
+    protected void preStopConfirmCustom() {
+    }
+    
     protected void preStop() {
         // note asymmetry that disconnectSensors is done in the entity not the driver
         // whereas on start the *driver* calls connectSensors, before calling postStart,
@@ -568,5 +571,5 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     protected final void doRestart() {
         doRestart(ConfigBag.EMPTY);
     }
-    
+
 }

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -111,7 +111,15 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
     protected void preStart() {
         ServiceNotUpLogic.clearNotUpIndicator(this, SHUTDOWN.getName());
     }
-    
+
+    @Override
+    protected void preStopConfirmCustom() {
+        super.preStopConfirmCustom();
+        if (Boolean.TRUE.equals(getAttribute(BrooklynNode.WEB_CONSOLE_ACCESSIBLE))) {
+            Preconditions.checkState(getChildren().isEmpty(), "Can't stop instance with running applications.");
+        }
+    }
+
     @Override
     protected void preStop() {
         super.preStop();
@@ -119,7 +127,6 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
         // Shutdown only if accessible: any of stop_* could have already been called.
         // Don't check serviceUp=true because stop() will already have set serviceUp=false && expectedState=stopping
         if (Boolean.TRUE.equals(getAttribute(BrooklynNode.WEB_CONSOLE_ACCESSIBLE))) {
-            Preconditions.checkState(getChildren().isEmpty(), "Can't stop instance with running applications.");
             DynamicTasks.queue(Effectors.invocation(this, SHUTDOWN, MutableMap.of(ShutdownEffector.REQUEST_TIMEOUT, Duration.ONE_MINUTE)));
         } else {
             log.info("Skipping children.isEmpty check and shutdown call, because web-console not up for {}", this);

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/effector/BrooklynNodeUpgradeEffectorBody.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/effector/BrooklynNodeUpgradeEffectorBody.java
@@ -30,6 +30,7 @@ import brooklyn.entity.basic.Entities;
 import brooklyn.entity.basic.EntityInternal;
 import brooklyn.entity.basic.EntityTasks;
 import brooklyn.entity.basic.SoftwareProcess;
+import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters;
 import brooklyn.entity.brooklynnode.BrooklynCluster;
 import brooklyn.entity.brooklynnode.BrooklynNode;
 import brooklyn.entity.brooklynnode.BrooklynNodeDriver;
@@ -132,9 +133,11 @@ public class BrooklynNodeUpgradeEffectorBody extends EffectorBody<Void> {
 
         // 3 stop new version
         // 4 stop old version
+        ConfigBag stopParameters = ConfigBag.newInstance();
+        stopParameters.put(StopSoftwareParameters.STOP_MACHINE, Boolean.FALSE);
         DynamicTasks.queue(Tasks.builder().name("shutdown original and transient nodes")
-            .add(Effectors.invocation(dryRunChild, BrooklynNode.SHUTDOWN, ConfigBag.EMPTY))
-            .add(Effectors.invocation(entity(), BrooklynNode.SHUTDOWN, ConfigBag.EMPTY))
+            .add(Effectors.invocation(dryRunChild, BrooklynNode.STOP_NODE_BUT_LEAVE_APPS, stopParameters))
+            .add(Effectors.invocation(entity(), BrooklynNode.STOP_NODE_BUT_LEAVE_APPS, stopParameters))
             .build());
 
         // 5 move old files, and move new files

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -533,6 +533,8 @@ public abstract class MachineLifecycleEffectorTasks {
      * {@link #stopAnyProvisionedMachines()} and sets state {@link Lifecycle#STOPPED}
      */
     public void stop(ConfigBag parameters) {
+        preStopConfirmCustom();
+
         log.info("Stopping {} in {}", entity(), entity().getLocations());
 
         Boolean isStopMachine = parameters.get(StopSoftwareParameters.STOP_MACHINE);
@@ -612,6 +614,14 @@ public abstract class MachineLifecycleEffectorTasks {
         ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPED);
 
         if (log.isDebugEnabled()) log.debug("Stopped software process entity "+entity());
+    }
+
+    /** 
+     * Override to check whether stop can be executed.
+     * Throw if stop should be aborted.
+     */
+    protected void preStopConfirmCustom() {
+        // nothing needed here
     }
 
     protected void preStopCustom() {


### PR DESCRIPTION
The shutdown effector was setting a STOP state which prevented the machine from being released.
Changes:
  * Convert the shutdown effector as a utility functionality - just call the remote shutdown endpoint with the passed parameters
  * Store effector parameters in the EffectorCallTag, methods calls to fetch them. Passing the parameters along the call chain would cause backwards incompatible changes.
  * Pass stop parameters to the shutdown effector so that it's functionality can be fine tuned by calling stop directly
  * Don't unamange the node if the machine is not released.
  * Add logic to wait for the graceful shutdown of the process before killing it forcibly (the java process will take some time to shut down cleanly after closing the rest connection)

Depends on https://github.com/apache/incubator-brooklyn/pull/389.