### PR TITLE
use env to find bash in scripts

### DIFF
--- a/docs/_build/build.sh
+++ b/docs/_build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # this generates the site in _site
 # override --url /myMountPoint  (as an argument to this script) if you don't like the default set in /_config.yml

--- a/docs/_build/make-javadoc.sh
+++ b/docs/_build/make-javadoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -x make-javadoc.sh ]; then
   echo This command must be run from the _build directory, not its parent.

--- a/docs/_build/quick-make-few-javadoc.sh
+++ b/docs/_build/quick-make-few-javadoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export BROOKLYN_JAVADOC_SOURCE_PATHS="../../api/src/main/java"
 echo LIMITING build to $BROOKLYN_JAVADOC_SOURCE_PATHS for speed

--- a/locations/jclouds/src/main/resources/sample/script/setup-server.sh
+++ b/locations/jclouds/src/main/resources/sample/script/setup-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/usage/all/start-mgmt-web.sh
+++ b/usage/all/start-mgmt-web.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/usage/dist/src/main/dist/bin/brooklyn
+++ b/usage/dist/src/main/dist/bin/brooklyn
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/usage/scripts/change-version.sh
+++ b/usage/scripts/change-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/usage/scripts/grep-in-poms.sh
+++ b/usage/scripts/grep-in-poms.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
expand on b20f45fbbc05950b27004b922182b3390fa7a727 applying to all scripts where relevant

@jimjag thanks for your fix ^^^.  does this make sense, applying it everywhere?