### PR TITLE
Fixes to make_javadoc.sh script

### DIFF
--- a/docs/_build/make-javadoc.sh
+++ b/docs/_build/make-javadoc.sh
@@ -16,11 +16,19 @@ else
   export SOURCE_PATHS=$BROOKLYN_JAVADOC_SOURCE_PATHS
 fi
 
+mkdir -p target
 rm -rf target/$JAVADOC_TARGET1_SUBPATH/
 
 export DATESTAMP=`date "+%Y-%m-%d"`
 # BROOKLYN_VERSION_BELOW
 export BROOKLYN_JAVADOC_CLASSPATH=../../usage/all/target/brooklyn-all-0.7.0-SNAPSHOT-with-dependencies.jar
+
+if [ \! -f ${BROOKLYN_JAVADOC_CLASSPATH} ]; then
+  echo "Expected to find ${BROOKLYN_JAVADOC_CLASSPATH}"
+  echo "Please run a full Maven build in the project root"
+  exit 1
+fi
+
 echo "building javadoc at $DATESTAMP from:
 $SOURCE_PATHS"
 
@@ -33,7 +41,7 @@ javadoc -sourcepath $SOURCE_PATHS \
   -windowtitle "Apache Brooklyn" \
   -header "Apache Brooklyn" \
   -footer '<b>Apache Brooklyn - Multi-Cloud Application Management</b> <br/> <a href="http://brooklyn.io/" target="_top">brooklyn.io</a>. Apache License. &copy; '$DATESTAMP'.' \
- | tee target/javadoc.log
+2>&1 1>/dev/null | tee target/javadoc.log
 
 if ((${PIPESTATUS[0]})) ; then echo ; echo ; echo "ERROR: javadoc process exited non-zero" ; exit 1 ; fi
 echo ; echo


### PR DESCRIPTION
Three changes:

1. `BROOKLYN_VERSION` annotation to ensure that 0.7.0-SNAPSHOT reference is updated.
2. Javadoc output spews out a lot of noise to stdout and errors/warnings to stderr, but use of `tee` saves only stdout noise and not the useful error messages - changed to send errors to stdout, and what was stdout goes to /dev/null.
3. Abort if the required brooklyn-all-dependencies jar file has not been built.