### PR TITLE
Fixes SERVICE_UP timeout error in tests

### DIFF
--- a/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
@@ -350,6 +350,11 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         public MyServiceImpl(Entity parent) { super(parent); }
 
         @Override
+        protected void initEnrichers() {
+            // Don't add enrichers messing with the SERVICE_UP state - we are setting it manually
+        }
+
+        @Override
         public Class<?> getDriverInterface() { return SimulatedDriver.class; }
     }
 

--- a/software/base/src/test/java/brooklyn/entity/basic/lifecycle/ScriptHelperTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/lifecycle/ScriptHelperTest.java
@@ -72,14 +72,9 @@ public class ScriptHelperTest extends BrooklynAppUnitTestSupport {
     public void testCheckRunningForcesInessential() {
         MyService entity = app.createAndManageChild(EntitySpec.create(MyService.class, MyServiceInessentialDriverImpl.class));
         
-        // is set false on mgmt starting (probably shouldn't be though)
-        Assert.assertFalse(entity.getAttribute(Startable.SERVICE_UP));
-        
         entity.start(ImmutableList.of(loc));
         SimulatedInessentialIsRunningDriver driver = (SimulatedInessentialIsRunningDriver) entity.getDriver();
         Assert.assertTrue(driver.isRunning());
-        // currently, is initially set true after successful start
-        Assert.assertTrue(entity.getAttribute(Startable.SERVICE_UP));
         
         EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
         EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
@@ -88,16 +83,14 @@ public class ScriptHelperTest extends BrooklynAppUnitTestSupport {
         
         driver.setFailExecution(true);
         EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, false);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, false);
         
         log.debug("caught failure, now clear");
         driver.setFailExecution(false);
         EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
     }
     
     public static class MyServiceInessentialDriverImpl extends MyServiceImpl {
-        
+
         @Override public Class<?> getDriverInterface() {
             return SimulatedInessentialIsRunningDriver.class;
         }


### PR DESCRIPTION
Fixes "Caused by: java.lang.IllegalStateException: Timeout waiting for SERVICE_UP from MyServiceImpl" frequently sabotaging the windows CI build.
MyServiceImpl is setting SERVICE_UP manually while the enrichers toggle it in parallel in response to the SERVICE_STATE_ACTUAL changes. Sometimes the enricher will trigger in the window between MyServiceImpl setting the value to true and calling waitForServiceUp, leading to the timeout error.