### PR TITLE
Couchbase SyncGateway should support cluster of ONE node

### DIFF
--- a/software/nosql/src/main/java/brooklyn/entity/nosql/couchbase/CouchbaseSyncGatewaySshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/couchbase/CouchbaseSyncGatewaySshDriver.java
@@ -92,10 +92,10 @@ public class CouchbaseSyncGatewaySshDriver extends AbstractSoftwareProcessSshDri
 
                 @Override
                 public boolean apply(@Nullable Entity entity) {
-                    if (entity instanceof CouchbaseNode && Boolean.TRUE.equals(entity.getAttribute(CouchbaseNode.IS_IN_CLUSTER))) {
-                        return true;
-                    }
-                    return false;
+                    // Must either be recognised by a cluster as added, or be the primary node in a cluster of ONE.
+                    return entity instanceof CouchbaseNode
+                      && (Boolean.TRUE.equals(entity.getAttribute(entity.IS_IN_CLUSTER)) || Boolean.TRUE.equals(entity.getAttribute(entity.IS_PRIMARY_NODE))
+                    );
                 }
             });
             if (cbClusterNode.isPresent()) {


### PR DESCRIPTION
`IS_IN_CLUSTER` [is ONLY set when a server is explicitly added into a cluster](https://github.com/apache/incubator-brooklyn/blob/59208f56a264d85d68ccc51bc9f2acf457dc1107/software/nosql/src/main/java/brooklyn/entity/nosql/couchbase/CouchbaseClusterImpl.java#L461-L462).

The original logic checks for 'IS_IN_CLUSTER'; this means that the sole primary node of a single-node cluster will never be eligible to be used with sync gateway (even though it actually is...!).

We extend the boolean condition to check for this condition.
