### PR TITLE
Standalone console dependency

### DIFF
--- a/usage/jsgui/pom.xml
+++ b/usage/jsgui/pom.xml
@@ -147,6 +147,23 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble-jsgui</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
             <!--
                  run js tests with: $ mvn clean process-resources jasmine:test
                  run tests in the browser with: $ mvn jasmine:bdd

--- a/usage/jsgui/src/main/assembly/assembly.xml
+++ b/usage/jsgui/src/main/assembly/assembly.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<assembly>
+    <id>war</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <files>
+        <file>
+            <source>target/${artifactId}-${version}.war</source>
+            <outputDirectory />
+            <destName>brooklyn.war</destName>
+        </file>
+    </files>
+</assembly>

--- a/usage/launcher/pom.xml
+++ b/usage/launcher/pom.xml
@@ -77,6 +77,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-jsgui</artifactId>
+            <version>${project.version}</version>
+            <classifier>war</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
         </dependency>
@@ -216,39 +222,10 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <!-- copy the WAR so it is available on the classpath for programmatic deployment -->
-                <executions>
-                    <execution>
-                        <id>copy</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <!-- this can fail in eclipse trying to copy _from_ target/classes.
-                                         see http://jira.codehaus.org/browse/MDEP-259 -->
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>brooklyn-jsgui</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>war</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>target/classes</outputDirectory>
-                                    <destFileName>brooklyn.war</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Include-Resource>{maven-resources}, target/classes/brooklyn.war</Include-Resource>
                         <Bundle-Activator>brooklyn.launcher.Activator</Bundle-Activator>
                         <Main-class>brooklyn.launcher.Main</Main-class>
                     </instructions>


### PR DESCRIPTION
Wrap the console war in a standalone jar so it can easiliy be excluded from downstream projects (and overriden with custom build) without needing to customize the launcher.

In a downstream project to use custom jsgui:

```
    <dependency>
      <groupId>io.apache.brooklyn</groupId>
      <artifactId>brooklyn-all</artifactId>
      <version>${brooklyn.version}</version>
      <exclusions>
        <exclusion>
          <artifactId>brooklyn-jsgui</artifactId>
          <groupId>org.apache.brooklyn</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>io.downstream</groupId>
      <artifactId>custom-jsgui</artifactId>
      <version>0.1.0-SNAPSHOT</version>
      <classifier>war</classifier>
      <exclusions>
        <exclusion>
          <artifactId>brooklyn-jsgui</artifactId>
          <groupId>org.apache.brooklyn</groupId>
        </exclusion>
      </exclusions>
    </dependency>
```