### PR TITLE
Public site fixes

### DIFF
--- a/docs/guide/use/guide/locations/index.md
+++ b/docs/guide/use/guide/locations/index.md
@@ -71,7 +71,7 @@ brooklyn.location.named.AWS\ Virginia\ Large\ Centos.minRam=4096
 
 This will  appear as 'AWS Virginia Large Centos' in the web console, but will need to be escaped on the command line as:  `AWS\ Virginia\ Large\ Centos`.
 
-See the Getting Started [template brooklyn.properties](/use/guide/quickstart/brooklyn.properties) for more examples of using cloud endpoints.
+See the Getting Started [template brooklyn.properties](../quickstart/brooklyn.properties) for more examples of using cloud endpoints.
 
 
 ## Fixed Infrastructure

--- a/docs/style/css/base.scss
+++ b/docs/style/css/base.scss
@@ -23,6 +23,13 @@ img {border: 0;}
 a {color: $a_color;}
 a:hover {text-decoration: none; color: $a_hover_color;}
 
+/* Offset link anchors so they are not hidden by the header */
+a[id]:empty, a[name]:empty {
+    padding-top: 60px;
+    margin-top: -60px;
+    display: block;
+}
+
 
 /* WEBSITE MENUS
    ----------------------------------------------------------------------- */

--- a/usage/archetypes/quickstart/src/brooklyn-sample/src/main/assembly/files/README.txt
+++ b/usage/archetypes/quickstart/src/brooklyn-sample/src/main/assembly/files/README.txt
@@ -18,7 +18,7 @@ can be done in `~/.brooklyn/brooklyn.properties`.
 
 A recommended starting point is the file at:
 
-    http://brooklyncentral.github.io/use/guide/quickstart/brooklyn.properties
+    https://brooklyn.incubator.apache.org/v/latest/use/guide/quickstart/brooklyn.properties
 
 As a quick-start, you can specify:
 
@@ -34,7 +34,7 @@ Many other clouds are supported also, as well as pre-existing machines
 ("bring your own nodes"), custom endpoints for private clouds, and specifying 
 custom keys and passphrases. For more information see:
 
-    http://brooklyncentral.github.io/use/guide/defining-applications/common-usage#locations
+    https://brooklyn.incubator.apache.org/v/latest/use/guide/defining-applications/common-usage#locations
 
 
 ### Run
@@ -48,7 +48,7 @@ Usage:
 The optional port argument specifies the port where the Brooklyn console 
 will be running, such as localhost:8081. (The console is only bound to 
 localhost, unless you set up users and security, as described at
-http://brooklyncentral.github.io/use/guide/management/ .)
+https://brooklyn.incubator.apache.org/v/latest/use/guide/management/ .)
 
 In the console, you can access the catalog and deploy applications to
 configured locations.


### PR DESCRIPTION
  * Update links
  * Offset anchors so they are visible below the fixed header

There is still some problem with the breadcrumbs (i.e. https://brooklyn.incubator.apache.org/v/latest/use/examples/webcluster/index.html), though locally they work fine, so couldn't troubleshoot it - could it be just a problem with the last generation?
