### PR TITLE
Documentation link check improvements

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'therubyracer'
-gem 'link-checker'
+gem 'html-proofer'
 gem 'json'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,9 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    anemone (0.7.2)
-      nokogiri (>= 1.3.0)
-      robotex (>= 1.0.0)
+    addressable (2.3.6)
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -14,11 +12,21 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colorator (0.1)
-    colorize (0.5.8)
+    colored (1.2)
+    ethon (0.7.2)
+      ffi (>= 1.3.0)
     execjs (2.2.2)
     fast-stemmer (1.0.2)
     ffi (1.9.6)
     hitimes (1.2.2)
+    html-proofer (1.6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.6.7)
+      yell (~> 2.0)
     jekyll (2.5.2)
       classifier-reborn (~> 2.0)
       colorator (~> 0.1)
@@ -45,11 +53,6 @@ GEM
     json (1.8.1)
     kramdown (1.5.0)
     libv8 (3.16.14.7)
-    link-checker (0.7.2)
-      anemone (~> 0.7.2)
-      colorize (~> 0.5.8)
-      nokogiri (~> 1.5.5)
-      trollop (~> 2.0)
     liquid (2.6.1)
     listen (2.8.3)
       celluloid (>= 0.15.2)
@@ -57,6 +60,7 @@ GEM
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
     nokogiri (1.5.11)
+    parallel (1.3.3)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.8)
@@ -68,7 +72,6 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (3.2.2)
     ref (1.0.5)
-    robotex (1.0.0)
     safe_yaml (1.0.4)
     sass (3.4.9)
     therubyracer (0.12.1)
@@ -78,14 +81,16 @@ GEM
       hitimes
     toml (0.1.2)
       parslet (~> 1.5.0)
-    trollop (2.0)
+    typhoeus (0.6.9)
+      ethon (>= 0.7.1)
     yajl-ruby (1.1.0)
+    yell (2.0.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll
   json
-  link-checker
   therubyracer

--- a/docs/_build/build.sh
+++ b/docs/_build/build.sh
@@ -29,6 +29,7 @@ function help() {
   echo "* --quick-javadoc : to do a quick javadoc build (for testing)"
   echo "* --serve : serve files from _site after building (for testing)"
   echo "* --install : install files from _site to the appropriate place in "'$'"BROOKLYN_SITE_DIR (or ../../incubator-brooklyn-site-public)"
+  echo "* --skip-test : skip the HTML Proof run on _site"
   echo ""
 }
 
@@ -130,12 +131,27 @@ function parse_arguments() {
       INSTALL_AFTERWARDS=true
       shift
       ;;
+    "--skip-test")
+      SKIP_TEST=true
+      shift
+      ;;
     *)
       echo "ERROR: invalid argument '"$1"'"
       exit 1
       ;;
     esac
   done
+}
+
+# Runs htmlproof against _site
+function test_site() {
+  if [ "$SKIP_TEST" == "true" ]; then
+    return
+  fi
+  echo "Running htmlproof on _site"
+  mkdir -p target
+  LOG="target/htmlproof.log"
+  htmlproof _site 2>&1 | tee $LOG
 }
 
 function make_jekyll() {
@@ -227,6 +243,8 @@ parse_arguments $@
 make_jekyll || { echo ERROR: failed jekyll docs build in `pwd` ; exit 1 ; }
 
 make_javadoc || { echo ERROR: failed javadoc build ; exit 1 ; }
+
+test_site
 
 # TODO build catalog
 


### PR DESCRIPTION
Swaps the link-checker gem for html-proofer, which can check [quite a lot more](https://github.com/gjtorikian/html-proofer#whats-tested). Incorporated the tool into `build.sh` and added option to skip with `--skip-tests`.

Also replaces all uses of "brooklyn" with "Brooklyn".