### PR TITLE
Catalog libs - fail if user specified symbolicName and version don't match bundle

### DIFF
--- a/core/src/test/resources/brooklyn/camp/lite/test-app-service-blueprint.yaml
+++ b/core/src/test/resources/brooklyn/camp/lite/test-app-service-blueprint.yaml
@@ -33,6 +33,6 @@ brooklyn.catalog:
   type: io.camp.mock.MyApplication
   version: 0.9
   libraries:
-  - name: lib1
+  - name: org.apache.brooklyn.test.resources.osgi.brooklyn-test-osgi-entities
     version: 0.1.0
     url: classpath:/brooklyn/osgi/brooklyn-test-osgi-entities.jar

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -297,37 +297,27 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_PATH);
 
         String firstItemId = "my.catalog.app.id.register_bundle";
-        String secondItemId = "my.catalog.app.id.reference_bundle";
         String nonExistentId = "non_existent_id";
         String nonExistentVersion = "9.9.9";
-        addCatalogItem(
-            "brooklyn.catalog:",
-            "  id: " + firstItemId,
-            "  version: " + TEST_VERSION,
-            "  libraries:",
-            "  - name: " + nonExistentId,
-            "    version: " + nonExistentVersion,
-            "    url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
-            "",
-            "services:",
-            "- type: " + SIMPLE_ENTITY_TYPE);
-        deleteCatalogEntity(firstItemId);
-
         try {
             addCatalogItem(
                 "brooklyn.catalog:",
-                "  id: " + secondItemId,
+                "  id: " + firstItemId,
                 "  version: " + TEST_VERSION,
                 "  libraries:",
                 "  - name: " + nonExistentId,
                 "    version: " + nonExistentVersion,
+                "    url: " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL,
                 "",
                 "services:",
                 "- type: " + SIMPLE_ENTITY_TYPE);
             fail();
         } catch (IllegalStateException e) {
-            assertEquals(e.getMessage(), "Bundle CatalogBundleDto{symbolicName=" + nonExistentId + ", version=" + nonExistentVersion + ", url=null} " +
-                    "not previously registered, but URL is empty.");
+            assertEquals(e.getMessage(), "Bundle from " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL + " already " +
+                    "installed as " + OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_NAME + ":" +
+                    OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_VERSION + " but user explicitly requested " +
+                    "CatalogBundleDto{symbolicName=" + nonExistentId + ", version=" + nonExistentVersion + ", url=" +
+                    OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL + "}");
         }
     }
     


### PR DESCRIPTION
Bundles are always matched by their symbolicName and version, not by the user specified alternatives, so allowing them to diverge will lead to unexpected behaviour. So far the logic was to fail only if the bundle is already installed which was inconsistent with first-time install when it would pass.