### PR TITLE
Cobertura to use maven plugin rather than ant-run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Testing -->
-        <cobertura.plugin.version>2.5.2</cobertura.plugin.version>
+        <cobertura.plugin.version>2.6</cobertura.plugin.version>
         <surefire.version>2.18</surefire.version>
         <plantuml.version>6121</plantuml.version>
         <ant.version>1.8.4</ant.version>
@@ -200,7 +200,6 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <maxmind.version>0.8.1</maxmind.version>
         <jna.version>4.0.0</jna.version>
-        <coverage.target>${working.dir}</coverage.target>
 
         <!-- Release -->
         <!-- no passphrase by default, so we can do automated deploy builds;
@@ -823,11 +822,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>1.7</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura</artifactId>
-                    <version>${cobertura.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.google.code.maven-replacer-plugin</groupId>
@@ -1656,196 +1650,58 @@
         </profile>
         <profile>
             <id>Coverage</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>${cobertura.plugin.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-source-plugin</artifactId>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <inherited>true</inherited>
-                        <executions>
-                            <execution>
-                                <id>run-tests</id>
-                            </execution>
-                            <execution>
-                                <id>instrument classes</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>process-test-classes</phase>
-                                <configuration>
-                                    <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                        <taskdef resource="tasks.properties" classpathref="maven.plugin.classpath" />
-                                        <if>
-                                            <available property="gogocobertura" file="target/test-classes" />
-                                            <then>
-                                                <echo message="INSTRUMENTING CLASSES FOR COBERTURA" />
-                                                <!-- Ensure any and all bits of our project are copied in first -->
-                                                <copy todir="target/cobertura/coverage-classes">
-                                                    <fileset erroronmissingdir="false" dir="target/classes" />
-                                                </copy>
-                                                <cobertura-instrument datafile="target/cobertura/cobertura.ser" todir="target/test-classes">
-                                                    <fileset erroronmissingdir="false" dir="target/classes">
-                                                        <include name="brooklyn/**/*.class" />
-                                                        <exclude name="brooklyn/**/*Test.class" />
-                                                    </fileset>
-                                                    <fileset erroronmissingdir="false" dir="target/cobertura/dependency-classes">
-                                                        <include name="brooklyn/**/*.class" />
-                                                        <exclude name="brooklyn/**/*Test.class" />
-                                                    </fileset>
-                                                </cobertura-instrument>
-                                            </then>
-                                        </if>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>coverage report</id>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <phase>post-integration-test</phase>
-                                <configuration>
-                                    <target>
-                                        <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                        <taskdef resource="tasks.properties" classpathref="maven.plugin.classpath" />
-                                        <if>
-                                            <available property="gogocobertura" file="target/cobertura/cobertura.ser" />
-                                            <then>
-                                                <echo message="GENERATING COBERTURA COVERAGE REPORT" />
-                                                <cobertura-report format="xml" destdir="target/site/cobertura" datafile="target/cobertura/cobertura.ser">
-                                                    <fileset erroronmissingdir="false" dir="src/main/java" />
-                                                    <fileset erroronmissingdir="false" dir="target/cobertura/dependency-sources" />
-                                                </cobertura-report>
-                                                <cobertura-report format="html" destdir="target/site/cobertura" datafile="target/cobertura/cobertura.ser">
-                                                    <fileset erroronmissingdir="false" dir="src/main/java" />
-                                                    <fileset erroronmissingdir="false" dir="target/cobertura/dependency-sources" />
-                                                </cobertura-report>
-                                            </then>
-                                        </if>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>ant-contrib</groupId>
-                                <artifactId>ant-contrib</artifactId>
-                                <version>1.0b3</version>
-                                <exclusions>
-                                    <exclusion>
-                                        <groupId>ant</groupId>
-                                        <artifactId>ant</artifactId>
-                                    </exclusion>
-                                </exclusions>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.apache.ant</groupId>
-                                <artifactId>ant-launcher</artifactId>
-                                <version>${ant.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.apache.ant</groupId>
-                                <artifactId>ant</artifactId>
-                                <version>${ant.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.testng</groupId>
-                                <artifactId>testng</artifactId>
-                                <version>${testng.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>cobertura-maven-plugin</artifactId>
-                                <version>${cobertura.plugin.version}</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-coverage-sources</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>unpack-dependencies</goal>
-                                </goals>
-                                <configuration>
-                                    <classifier>sources</classifier>
-                                    <includeScope>compile</includeScope>
-                                    <includeGroupIds>brooklyn</includeGroupIds>
-                                    <outputDirectory>
-                                        ${project.build.directory}/cobertura/dependency-sources
-                                    </outputDirectory>
-                                    <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>unpack-coverage-classes</id>
-                                <phase>compile</phase>
-                                <goals>
-                                    <goal>unpack-dependencies</goal>
-                                </goals>
-                                <configuration>
-                                    <type>jar</type>
-                                    <includeScope>compile</includeScope>
-                                    <includeGroupIds>brooklyn</includeGroupIds>
-                                    <outputDirectory>
-                                        ${project.build.directory}/cobertura/dependency-classes
-                                    </outputDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire.version}</version>
-                        <inherited>true</inherited>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <version>${cobertura.plugin.version}</version>
                         <configuration>
-                            <reportFormat>xml</reportFormat>
-                            <classesDirectory>${project.build.directory}/cobertura/coverage-classes</classesDirectory>
-                            <systemProperties>
-                                <property>
-                                    <name>net.sourceforge.cobertura.datafile</name>
-                                    <value>${project.build.directory}/cobertura/cobertura.ser
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>cobertura.user.java.nio</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
+                            <aggregate>true</aggregate>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>test-jar-creation</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>cobertura</goal>
+                                </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
+                        <version>2.3.1</version>
+                        <configuration>
+                            <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
+                            <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>cobertura-maven-plugin</artifactId>
+                        <version>${cobertura.plugin.version}</version>
+                        <configuration>
+                            <check/>
+                            <formats>
+                                <format>html</format>
+                                <format>xml</format>
+                            </formats>
+                        </configuration>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>cobertura</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
 
         <!-- build sources jars by default, it's quick -->


### PR DESCRIPTION
PLEASE DON'T MERGE YET
Seems to lose ability to output xml but does give us an aggregated report.

Also when run it seems to compile twice (presumably once without and then once with instrumentation) and you get warnings of the form:
WARNING: Duplicate name in Manifest: Manifest-Version.                                                                                  Ensure that the manifest does not have duplicate entries, and                                                                           
that blank lines separate individual sections in both your                                                                              
manifest and in the META-INF/MANIFEST.MF entry in the jar file.                                                                         

You seem to also get these warnings if you try to do an incremental build so I don't know if they're important.
