### PR TITLE
DETECT_MACHINE_DETAILS SshMachineLocation config

### DIFF
--- a/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
@@ -135,6 +135,9 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
             MachineDetails.class,
             "machineDetails");
 
+    public static final ConfigKey<Boolean> DETECT_MACHINE_DETAILS = ConfigKeys.newBooleanConfigKey("detectMachineDetails",
+            "Attempt to detect machine details automatically. Works with SSH-accessible Linux instances.", true);
+
     @SetFromFlag
     protected String user;
 
@@ -896,6 +899,10 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
     }
 
     protected MachineDetails inferMachineDetails() {
+        boolean detectionEnabled = getConfig(DETECT_MACHINE_DETAILS);
+        if (!detectionEnabled)
+            return new BasicMachineDetails(new BasicHardwareDetails(-1, -1), new BasicOsDetails("UNKNOWN", "UNKNOWN", "UNKNOWN"));
+
         Tasks.setBlockingDetails("Waiting for machine details");
         try {
             return BasicMachineDetails.forSshMachineLocation(this);

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1588,7 +1588,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     .configure("node", node)
                     .configureIfNotNull(CLOUD_AVAILABILITY_ZONE_ID, nodeAvailabilityZone)
                     .configureIfNotNull(CLOUD_REGION_ID, nodeRegion)
-                    .configure(CALLER_CONTEXT, setup.get(CALLER_CONTEXT)));
+                    .configure(CALLER_CONTEXT, setup.get(CALLER_CONTEXT))
+                    .configure(SshMachineLocation.DETECT_MACHINE_DETAILS, setup.get(SshMachineLocation.DETECT_MACHINE_DETAILS)));
         } else {
             LOG.warn("Using deprecated JcloudsSshMachineLocation constructor because "+this+" is not managed");
             return new JcloudsSshMachineLocation(MutableMap.builder()


### PR DESCRIPTION
Adds new configkey for controlling automatic detection of machine details. Defaults to true (matching previous behaviour); setting to false stops SshMachineLocation opening up an SSH channel and running commands. Useful in situations where the application requires strict control over the use of SSH.