### PR TITLE
brooklyn.util.net.Urls.mergePaths(String... items) mishandles nulls in input path parts

### DIFF
--- a/utils/common/src/main/java/brooklyn/util/net/Urls.java
+++ b/utils/common/src/main/java/brooklyn/util/net/Urls.java
@@ -25,6 +25,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -119,10 +122,18 @@ public class Urls {
     }
     
     /** returns the items with exactly one "/" between items (whether or not the individual items start or end with /),
-     * except where character before the / is a : (url syntax) in which case it will permit multiple (will not remove any) */
+     * except where character before the / is a : (url syntax) in which case it will permit multiple (will not remove any).
+     * Throws a NullPointerException if any elements of 'items' is null.
+     *  */
     public static String mergePaths(String ...items) {
+        List<String> parts = Arrays.asList(items);
+
+        if (parts.contains(null)) {
+            throw new NullPointerException(String.format("Unable to reliably merge path from parts: %s; input contains null values", parts));
+        }
+
         StringBuilder result = new StringBuilder();
-        for (String item: items) {
+        for (String part: parts) {
             boolean trimThisMerge = result.length()>0 && !result.toString().endsWith("://") && !result.toString().endsWith(":///") && !result.toString().endsWith(":");
             if (trimThisMerge) {
                 while (result.length()>0 && result.charAt(result.length()-1)=='/')
@@ -130,7 +141,7 @@ public class Urls {
                 result.append('/');
             }
             int i = result.length();
-            result.append(item);
+            result.append(part);
             if (trimThisMerge) {
                 while (result.length()>i && result.charAt(i)=='/')
                     result.deleteCharAt(i);

--- a/utils/common/src/test/java/brooklyn/util/net/UrlsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/net/UrlsTest.java
@@ -42,6 +42,11 @@ public class UrlsTest {
         assertEquals(Urls.mergePaths("/","a","b","/"), "/a/b/");
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testMergePathsNPEsOnNulls() {
+        Urls.mergePaths(null, "too");
+    }
+
     @Test
     public void testPathEncode() throws Exception {
         assertEquals(Urls.encode("name_with/%!"), "name_with%2F%25%21");


### PR DESCRIPTION
Fix for [BROOKLYN-129](https://issues.apache.org/jira/browse/BROOKLYN-129): filter nulls before iterating through path parts.