### PR TITLE
fixed BROOKLYN-128: ArchiveUtils ignores destFile, prefers optionalDestFile during deploy

### DIFF
--- a/core/src/main/java/brooklyn/util/file/ArchiveUtils.java
+++ b/core/src/main/java/brooklyn/util/file/ArchiveUtils.java
@@ -272,8 +272,8 @@ public class ArchiveUtils {
             }
 
             // extract, now using task if available
-            MutableList<String> commands = MutableList.copyOf(installCommands(optionalDestFile))
-                    .appendAll(extractCommands(optionalDestFile, optionalTmpDir, destDir, false, keepArchiveAfterUnpacking));
+            MutableList<String> commands = MutableList.copyOf(installCommands(destFile))
+                    .appendAll(extractCommands(destFile, optionalTmpDir, destDir, false, keepArchiveAfterUnpacking));
             if (DynamicTasks.getTaskQueuingContext()!=null) {
                 result = DynamicTasks.queue(SshTasks.newSshExecTaskFactory(machine, commands.toArray(new String[0])).summary("extracting archive").requiringExitCodeZero()).get();
             } else {


### PR DESCRIPTION
Fix for [BROOKLYN-129](https://issues.apache.org/jira/browse/BROOKLYN-129): issue install commands with guarded destFile instead of optionalDestFile.