### PR TITLE
ActiveMQ version is now 5.10.1.

### DIFF
--- a/software/messaging/src/main/java/brooklyn/entity/messaging/activemq/ActiveMQBroker.java
+++ b/software/messaging/src/main/java/brooklyn/entity/messaging/activemq/ActiveMQBroker.java
@@ -45,7 +45,7 @@ public interface ActiveMQBroker extends SoftwareProcess, MessageBroker, UsesJmx,
     ConfigKey<Duration> START_TIMEOUT = SoftwareProcess.START_TIMEOUT;
     
     @SetFromFlag("version")
-    public static final ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.10.0");
+    public static final ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.10.1");
 
     @SetFromFlag("downloadUrl")
     public static final AttributeSensorAndConfigKey<String,String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(


### PR DESCRIPTION
All tests in `ActiveMQIntegrationTest` pass.