### PR TITLE
Support scriptDir location config

### DIFF
--- a/core/src/test/java/brooklyn/util/internal/ssh/SshToolAbstractIntegrationTest.java
+++ b/core/src/test/java/brooklyn/util/internal/ssh/SshToolAbstractIntegrationTest.java
@@ -285,4 +285,17 @@ public abstract class SshToolAbstractIntegrationTest extends ShellToolAbstractTe
         Assert.assertEquals(CONTENTS.trim(), contents.trim());
     }
 
+    @Test(groups = {"Integration"})
+    public void testScriptDirPropertiesIsRespected() {
+        // For explanation of (some of) the magic behind this command, see http://stackoverflow.com/a/229606/68898
+        final String command = "if [[ \"$0\" == \"/var/tmp/\"* ]]; then true; else false; fi";
+
+        SshTool sshTool = newTool(ImmutableMap.<String, Object>builder()
+                .put(SshTool.PROP_HOST.getName(), "localhost")
+                .build());
+        int rc = sshTool.execScript(ImmutableMap.<String, Object>builder()
+                .put(SshTool.PROP_SCRIPT_DIR.getName(), "/var/tmp")
+                .build(), ImmutableList.of(command));
+        assertEquals(rc, 0);
+    }
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1694,6 +1694,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     .configureIfNotNull(CLOUD_REGION_ID, nodeRegion)
                     .configure(CALLER_CONTEXT, setup.get(CALLER_CONTEXT))
                     .configure(SshMachineLocation.DETECT_MACHINE_DETAILS, setup.get(SshMachineLocation.DETECT_MACHINE_DETAILS))
+                    .configure(SshMachineLocation.SCRIPT_DIR, setup.get(SshMachineLocation.SCRIPT_DIR))
                     .configureIfNotNull(USE_PORT_FORWARDING, setup.get(USE_PORT_FORWARDING))
                     .configureIfNotNull(PORT_FORWARDER, setup.get(PORT_FORWARDER))
                     .configureIfNotNull(PORT_FORWARDING_MANAGER, setup.get(PORT_FORWARDING_MANAGER)));


### PR DESCRIPTION
This modifies `SshMachineLocation` to propagate certain config keys to flags on `SshTool.execCommand()` and `.execScript()` invocations; the first use of this is to propagate the `scriptDir` config. `JcloudsLocation` is also modified to propagate this configuration. The result is that `scriptDir` can be specified in the configuration for a jclouds-based location, and the value of this property will be passed to every invocation of `SshTool.execScript()`.

The use case for this is to allow Brooklyn to be usable on locations where the VM image mounts `/tmp` with `noexec`.

Also adds some integration tests to verify the correct operation of the `scriptDir` flag.