### PR TITLE
Disable SSLv3

### DIFF
--- a/software/webapp/src/main/resources/brooklyn/entity/webapp/jboss/jboss7-standalone.xml
+++ b/software/webapp/src/main/resources/brooklyn/entity/webapp/jboss/jboss7-standalone.xml
@@ -257,7 +257,7 @@
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http" enabled="${entity.httpEnabled?string}"/>
             [#if entity.httpsEnabled]
             <connector name="https" protocol="HTTP/1.1" scheme="https" socket-binding="https" secure="true" enabled="${entity.httpsEnabled?string}">
-                <ssl key-alias="${entity.httpsSslKeyAlias}" password="${entity.httpsSslKeystorePassword}" certificate-key-file="${entity.httpsSslKeystoreFile}"/>
+                <ssl key-alias="${entity.httpsSslKeyAlias}" password="${entity.httpsSslKeystorePassword}" certificate-key-file="${entity.httpsSslKeystoreFile}" protocol="TLSv1,TLSv1.1,TLSv1.2"/>
             </connector>
             [/#if]
             <virtual-server name="default-host" enable-welcome-root="${entity.welcomeRootEnabled?string}">

--- a/software/webapp/src/main/resources/brooklyn/entity/webapp/tomcat/server.xml
+++ b/software/webapp/src/main/resources/brooklyn/entity/webapp/tomcat/server.xml
@@ -93,7 +93,7 @@
     <Connector port="${driver.httpsPort?c}" protocol="org.apache.coyote.http11.Http11Protocol"
                maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
                keystoreFile="${driver.httpsSslKeystoreFile}" keystorePass="${entity.httpsSslKeystorePassword}"
-               clientAuth="false" sslProtocol="TLS" />
+               clientAuth="false" sslEnabledProtocols="TLSv1.2,TLSv1.1,TLSv1" />
     [/#if]
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->

--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
@@ -417,6 +417,8 @@ public class BrooklynWebServer {
                 sslContextFactory.setTrustStorePassword(trustStorePassword);
             }
 
+            sslContextFactory.addExcludeProtocols("SSLv3");
+
             SslSocketConnector sslSocketConnector = new SslSocketConnector(sslContextFactory);
             sslSocketConnector.setPort(actualPort);
             server.addConnector(sslSocketConnector);

--- a/usage/launcher/src/test/java/brooklyn/launcher/BrooklynWebServerTest.java
+++ b/usage/launcher/src/test/java/brooklyn/launcher/BrooklynWebServerTest.java
@@ -58,7 +58,7 @@ public class BrooklynWebServerTest {
     
     @BeforeMethod(alwaysRun=true)
     public void setUp(){
-        brooklynProperties = BrooklynProperties.Factory.newDefault();
+        brooklynProperties = BrooklynProperties.Factory.newEmpty();
     }
 
     @AfterMethod(alwaysRun=true)

--- a/usage/launcher/src/test/java/brooklyn/launcher/WebAppRunnerTest.java
+++ b/usage/launcher/src/test/java/brooklyn/launcher/WebAppRunnerTest.java
@@ -145,6 +145,7 @@ public class WebAppRunnerTest {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/hello-world.war");
 
         BrooklynLauncher launcher = BrooklynLauncher.newInstance()
+                .globalBrooklynPropertiesFile(null)
                 .brooklynProperties("brooklyn.webconsole.security.provider","brooklyn.rest.security.provider.AnyoneSecurityProvider")
                 .webapp("/hello", "hello-world.war")
                 .start();


### PR DESCRIPTION
Also enable `$brooklyn:object` to use TypeCoercions enabled objects (i.e. for objects that don't have setters). This allows one to use:

```
services:
- type: brooklyn.entity.webapp.jboss.JBoss7Server
  brooklyn.config:
    webapp.enabledProtocols: ["https"]
    webapp.https.ssl:
      $brooklyn:object:
        objectType: brooklyn.entity.webapp.HttpsSslConfig
        object.fields:
          keystoreUrl: https://artifactory:AP5QT5YLhmBu3ET9Qe8wwkrNs3r@artifactory.mms.ibmcloud.com/artifactory/thirdparty/certs/faisalssaph1_keystore
          keystorePassword: changeit
          keyAlias: amm
```