### PR TITLE
CLI better default, port/https control, and version reporting

### DIFF
--- a/core/src/main/java/brooklyn/BrooklynVersion.java
+++ b/core/src/main/java/brooklyn/BrooklynVersion.java
@@ -19,80 +19,218 @@
 package brooklyn;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.String.format;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.jar.Attributes;
+
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.osgi.Osgis;
+import brooklyn.util.osgi.Osgis.ManifestHelper;
+import brooklyn.util.text.Strings;
+
+/**
+ * Wraps the version of Brooklyn.
+ * <p>
+ * Also retrieves the SHA-1 from any OSGi bundle, and checks that the maven and osgi versions match.
+ */
 public class BrooklynVersion {
 
   private static final Logger log = LoggerFactory.getLogger(BrooklynVersion.class);
   
-  private static final String VERSION_RESOURCE_FILE = "META-INF/maven/io.brooklyn/brooklyn-core/pom.properties";
-  private static final String VERSION_PROPERTY_NAME = "version";
+  private static final String MVN_VERSION_RESOURCE_FILE = "META-INF/maven/org.apache.brooklyn/brooklyn-core/pom.properties";
+  private static final String MANIFEST_PATH = "META-INF/MANIFEST.MF";
+  private static final String BROOKLYN_CORE_SYMBOLIC_NAME = "org.apache.brooklyn.core";
+  
+  private static final String MVN_VERSION_PROPERTY_NAME = "version";
+  private static final String OSGI_VERSION_PROPERTY_NAME = Attributes.Name.IMPLEMENTATION_VERSION.toString();
+  private static final String OSGI_SHA1_PROPERTY_NAME = "Implementation-SHA-1";
 
+
+  private final static String VERSION_FROM_STATIC = "0.7.0-SNAPSHOT"; // BROOKLYN_VERSION
+  private static final AtomicReference<Boolean> IS_DEV_ENV = new AtomicReference<Boolean>();
+  
   public static final BrooklynVersion INSTANCE = new BrooklynVersion();
-
-  private final String versionFromClasspath;
-  // static useful when running from the IDE
-  // TODO is the classpath version ever useful? should we always use the static?
-  private final String versionFromStatic = "0.7.0-SNAPSHOT"; // BROOKLYN_VERSION
-  private final String version;
-
+  
+  private final Properties versionProperties = new Properties();
+  
   public BrooklynVersion() {
-    this.versionFromClasspath = readVersionPropertyFromClasspath(BrooklynVersion.class.getClassLoader());
-    if (isValid(versionFromClasspath)) {
-        this.version = versionFromClasspath;
-        if (!this.version.equals(versionFromStatic)) {
-            // should always be the same, and we can drop classpath detection ...
-            log.warn("Version detected from classpath as "+versionFromClasspath+" (preferring that), but in code it is recorded as "+versionFromStatic);
-        }
-    } else {
-        this.version = versionFromStatic;
-    }
+      // we read the maven pom metadata and osgi metadata and make sure it's sensible
+      // everything is put into a single map for now (good enough, but should be cleaned up)
+      readPropertiesFromMavenResource(BrooklynVersion.class.getClassLoader());
+      readPropertiesFromOsgiResource(BrooklynVersion.class.getClassLoader(), "org.apache.brooklyn.core");
+      // TODO there is also build-metadata.properties used in ServerResource /v1/server/version endpoint
+      // see comments on that about folding it into this class instead
+
+      checkVersions();
+  }
+
+  public void checkVersions() {
+      String mvnVersion = getVersionFromMavenProperties();
+      if (mvnVersion!=null && !VERSION_FROM_STATIC.equals(mvnVersion)) {
+          throw new IllegalStateException("Version error: maven "+mvnVersion+" / code "+VERSION_FROM_STATIC);
+      }
+      
+      String osgiVersion = versionProperties.getProperty(OSGI_VERSION_PROPERTY_NAME);
+      // TODO does the OSGi version include other slightly differ gubbins/style ?
+      if (osgiVersion!=null && !VERSION_FROM_STATIC.equals(osgiVersion)) {
+          throw new IllegalStateException("Version error: osgi "+osgiVersion+" / code "+VERSION_FROM_STATIC);
+      }
+  }
+
+  /** Returns version as inferred from classpath/osgi, if possible, or 0.0.0-SNAPSHOT.
+   * See also {@link #getVersionFromMavenProperties()} and {@link #getVersionFromOsgiManifest()}.
+   * @deprecated since 0.7.0, in favour of the more specific methods (and does anyone need that default value?)
+   */
+  @Deprecated
+  public String getVersionFromClasspath() {
+      String v = getVersionFromMavenProperties();
+      if (Strings.isNonBlank(v)) return v;
+      v = getVersionFromOsgiManifest();
+      if (Strings.isNonBlank(v)) return v;
+      return "0.0.0-SNAPSHOT";
   }
   
-  public String getVersionFromClasspath() {
-    return versionFromClasspath;
+  @Nullable
+  public String getVersionFromMavenProperties() {
+      return versionProperties.getProperty(MVN_VERSION_PROPERTY_NAME);
+  }
+
+  @Nullable
+  public String getVersionFromOsgiManifest() {
+      return versionProperties.getProperty(OSGI_VERSION_PROPERTY_NAME);
+  }
+  
+  @Nullable
+  /** SHA1 of the last commit to brooklyn at the time this build was made.
+   * For SNAPSHOT builds of course there may have been further non-committed changes. */
+  public String getSha1FromOsgiManifest() {
+      return versionProperties.getProperty(OSGI_SHA1_PROPERTY_NAME);
   }
   
   public String getVersion() {
-    return version;
+    return VERSION_FROM_STATIC;
   }
   
-  public String getVersionFromStatic() {
-    return versionFromStatic;
-  }
-
   public boolean isSnapshot() {
       return (getVersion().indexOf("-SNAPSHOT")>=0);
   }
-  
-  private static boolean isValid(String v) {
-    if (v==null) return false;
-    if (v.equals("0.0.0") || v.equals("0.0")) return false;
-    if (v.startsWith("0.0.0-") || v.startsWith("0.0-")) return false;
-    return true;
+    
+  private void readPropertiesFromMavenResource(ClassLoader resourceLoader) {
+    try {
+      InputStream versionStream = resourceLoader.getResourceAsStream(MVN_VERSION_RESOURCE_FILE);
+      if (versionStream==null) {
+          if (isDevelopmentEnvironment()) {
+              // allowed for dev env
+              log.trace("No maven resource file "+MVN_VERSION_RESOURCE_FILE+" available");
+          } else {
+              log.warn("No maven resource file "+MVN_VERSION_RESOURCE_FILE+" available");
+          }
+          return;
+      }
+      versionProperties.load(checkNotNull(versionStream));
+    } catch (IOException e) {
+      log.warn("Error reading maven resource file "+MVN_VERSION_RESOURCE_FILE+": "+e, e);
+    }
   }
 
-  private String readVersionPropertyFromClasspath(ClassLoader resourceLoader) {
-    Properties versionProperties = new Properties();
-    try {
-      InputStream versionStream = resourceLoader.getResourceAsStream(VERSION_RESOURCE_FILE);
-      if (versionStream==null) return null;
-      versionProperties.load(checkNotNull(versionStream));
-    } catch (IOException exception) {
-      throw new IllegalStateException(format("Unable to load version resource file '%s'", VERSION_RESOURCE_FILE), exception);
-    }
-    return checkNotNull(versionProperties.getProperty(VERSION_PROPERTY_NAME), VERSION_PROPERTY_NAME);
+  /** reads properties from brooklyn-core's manifest */
+  private void readPropertiesFromOsgiResource(ClassLoader resourceLoader, String symbolicName) {
+      Enumeration<URL> paths;
+      try {
+          paths = BrooklynVersion.class.getClassLoader().getResources(MANIFEST_PATH);
+      } catch (IOException e) {
+          // shouldn't happen
+          throw Exceptions.propagate(e);
+      }
+      while (paths.hasMoreElements()) {
+          URL u = paths.nextElement();
+          try {
+              ManifestHelper mh = Osgis.ManifestHelper.forManifest(u.openStream());
+              if (BROOKLYN_CORE_SYMBOLIC_NAME.equals(mh.getSymbolicName())) {
+                  Attributes attrs = mh.getManifest().getMainAttributes();
+                  for (Object key: attrs.keySet()) {
+                      // key is an Attribute.Name; toString converts to string
+                      versionProperties.put(key.toString(), attrs.getValue(key.toString()));
+                  }
+                  return;
+              }
+          } catch (Exception e) {
+              Exceptions.propagateIfFatal(e);
+              log.warn("Error reading OSGi manifest from "+u+" when determining version properties: "+e, e);
+          }
+      }
+      if (isDevelopmentEnvironment()) {
+          // allowed for dev env
+          log.trace("No OSGi manifest available to determine version properties");
+      } else {
+          log.warn("No OSGi manifest available to determine version properties");
+      }
+  }
+
+  /** 
+   * Returns whether this is a Brooklyn dev environment,
+   * specifically core/target/classes/ is on the classpath for the org.apache.brooklyn.core project.
+   * <p>
+   * In a packaged or library build of Brooklyn (normal usage) this should return false,
+   * and all OSGi components should be available.
+   */
+  public static boolean isDevelopmentEnvironment() {
+      Boolean isDevEnv = IS_DEV_ENV.get();
+      if (isDevEnv!=null) return isDevEnv;
+      synchronized (IS_DEV_ENV) {
+          isDevEnv = computeIsDevelopmentEnvironment();
+          IS_DEV_ENV.set(isDevEnv);
+          return isDevEnv;
+      }
+  }
+  
+  private static boolean computeIsDevelopmentEnvironment() {
+      Enumeration<URL> paths;
+      try {
+          paths = BrooklynVersion.class.getClassLoader().getResources(MANIFEST_PATH);
+      } catch (IOException e) {
+          // shouldn't happen
+          throw Exceptions.propagate(e);
+      }
+      while (paths.hasMoreElements()) {
+          URL u = paths.nextElement();
+          if (u.getPath().endsWith("core/target/classes/META-INF/MANIFEST.MF")) {
+              try {
+                  ManifestHelper mh = Osgis.ManifestHelper.forManifest(u.openStream());
+                  if (BROOKLYN_CORE_SYMBOLIC_NAME.equals(mh.getSymbolicName())) {
+                      log.debug("Brooklyn debug environment detected; core manifest is at: "+u);
+                      return true;
+                  }
+              } catch (Exception e) {
+                  Exceptions.propagateIfFatal(e);
+                  log.warn("Error reading manifest to determine whether this is a development environment: "+e, e);
+              }
+          }
+      }
+      return false;
+  }
+
+  public void logSummary() {
+      log.debug("Brooklyn version "+getVersion()+" (git SHA1 "+getSha1FromOsgiManifest()+")");
+  }
+
+  /** @deprecated since 0.7.0, redundant with {@link #get()} */ @Deprecated
+  public static String getVersionFromStatic() {
+      return VERSION_FROM_STATIC;
   }
 
   public static String get() {
-    return INSTANCE.version;
+    return getVersionFromStatic();
   }
   
 }

--- a/core/src/main/java/brooklyn/util/http/HttpTool.java
+++ b/core/src/main/java/brooklyn/util/http/HttpTool.java
@@ -65,6 +65,7 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import brooklyn.util.crypto.SslTrustUtils;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.net.URLParamEncoder;
 import brooklyn.util.text.Strings;
@@ -80,6 +81,10 @@ public class HttpTool {
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpTool.class);
 
+    /** Apache HTTP commons utility for trusting all.
+     * <p>
+     * For generic java HTTP usage, see {@link SslTrustUtils#trustAll(java.net.URLConnection)} 
+     * and static constants in the same class. */
     public static class TrustAllStrategy implements TrustStrategy {
         @Override
         public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {

--- a/core/src/test/java/brooklyn/BrooklynVersionTest.java
+++ b/core/src/test/java/brooklyn/BrooklynVersionTest.java
@@ -19,18 +19,63 @@
 package brooklyn;
 
 import static org.testng.Assert.assertEquals;
+
+import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import brooklyn.util.text.Strings;
 
 public class BrooklynVersionTest {
 
+  private static final Logger log = LoggerFactory.getLogger(BrooklynVersionTest.class);
+    
   @Test
   public void testGetVersion() {
-      assertEquals(BrooklynVersion.get(), BrooklynVersion.INSTANCE.getVersionFromStatic());
+      assertEquals(BrooklynVersion.get(), BrooklynVersion.INSTANCE.getVersion());
   }
     
   @Test
   public void testGetHardcodedClasspathVersion() {
-    assertEquals(BrooklynVersion.INSTANCE.getVersionFromClasspath(), "0.0.0-SNAPSHOT");
+      @SuppressWarnings("deprecation")
+      String v = BrooklynVersion.INSTANCE.getVersionFromClasspath();
+      Assert.assertTrue(BrooklynVersion.get().equals(v) || "0.0.0-SNAPSHOT".equals(v), v);
+  }
+  
+  @Test
+  public void testGetFromMaven() {
+      String v = BrooklynVersion.INSTANCE.getVersionFromMavenProperties();
+      Assert.assertTrue(v==null || BrooklynVersion.get().equals(v), v);
+  }
+  
+  @Test
+  public void testGetFromOsgi() {
+      String v = BrooklynVersion.INSTANCE.getVersionFromOsgiManifest();
+      Assert.assertTrue(v==null || BrooklynVersion.get().equals(v), v);
+  }
+  
+  @Test
+  public void testGetOsgiSha1() {
+      String sha1 = BrooklynVersion.INSTANCE.getSha1FromOsgiManifest();
+      log.info("sha1: "+sha1);
+      if (Strings.isNonBlank(sha1) || BrooklynVersion.isDevelopmentEnvironment())
+          return;
+      // we might not have a SHA1 if it's a standalone source build; just log warn in that case
+      log.warn("This build does not have git SHA1 information.");
+      // (can't assert anything, except that sha1 lookup doesn't NPE)
+  }
+  
+  @Test
+  public void testDevEnv() {
+      URL sp = getClass().getClassLoader().getResource("brooklyn/config/sample.properties");
+      if (sp==null) Assert.fail("Can't find test resources");
+      
+      log.info("Test for dev env: "+"Dev env? "+BrooklynVersion.isDevelopmentEnvironment()+"; path "+sp);
+      Assert.assertEquals(sp.getPath().endsWith("classes/brooklyn/config/sample.properties"), BrooklynVersion.isDevelopmentEnvironment(),
+          "Dev env? "+BrooklynVersion.isDevelopmentEnvironment()+"; path "+sp);
   }
   
 }

--- a/usage/cli/src/main/java/brooklyn/cli/AbstractMain.java
+++ b/usage/cli/src/main/java/brooklyn/cli/AbstractMain.java
@@ -165,10 +165,13 @@ public abstract class AbstractMain {
 
             System.out.println(BANNER);
             System.out.println("Version:  " + BrooklynVersion.get());
+            if (BrooklynVersion.INSTANCE.isSnapshot()) {
+                System.out.println("Git SHA1: " + BrooklynVersion.INSTANCE.getSha1FromOsgiManifest());
+            }
             System.out.println("Website:  http://brooklyn.incubator.apache.org");
             System.out.println("Source:   https://github.com/apache/incubator-brooklyn");
             System.out.println();
-            System.out.println("Copyright 2011-2014 The Apache Software Foundation.");
+            System.out.println("Copyright 2011-2015 The Apache Software Foundation.");
             System.out.println("Licensed under the Apache 2.0 License");
             System.out.println();
 
@@ -176,6 +179,15 @@ public abstract class AbstractMain {
         }
     }
 
+    public static class DefaultInfoCommand extends InfoCommand {
+        @Override
+        public Void call() throws Exception {
+            super.call();
+            System.out.println("ERROR: No command specified.");
+            System.out.println();
+            throw new ParseException("No command specified.");
+        }
+    }
 
     /** method intended for overriding when the script filename is different 
      * @return the name of the script the user has invoked */

--- a/usage/cli/src/test/java/brooklyn/cli/CliTest.java
+++ b/usage/cli/src/test/java/brooklyn/cli/CliTest.java
@@ -267,7 +267,7 @@ public class CliTest {
         assertTrue(details.contains("app=null"), details);   
         assertTrue(details.contains("script=null"), details);
         assertTrue(details.contains("location=null"), details);
-        assertTrue(details.contains("port=8081"), details);
+        assertTrue(details.contains("port=null"), details);
         assertTrue(details.contains("noConsole=false"), details);
         assertTrue(details.contains("noConsoleSecurity=false"), details);
         assertTrue(details.contains("noShutdownOnExit=false"), details);

--- a/usage/cli/src/test/java/brooklyn/cli/CloudExplorerLiveTest.java
+++ b/usage/cli/src/test/java/brooklyn/cli/CloudExplorerLiveTest.java
@@ -21,6 +21,7 @@ package brooklyn.cli;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import io.airlift.command.Cli;
+import io.airlift.command.ParseException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -28,6 +29,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.List;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
@@ -49,8 +51,13 @@ public class CloudExplorerLiveTest {
     }
 
     @Test
-    public void testNoArgsReturnsInfo() throws Exception {
-        call(new String[0]);
+    public void testNoArgsThrows() throws Exception {
+        try {
+            call(new String[0]);
+            Assert.fail("No args should fail");
+        } catch (ParseException e) {
+            Assert.assertTrue(e.toString().contains("No command specified"), ""+e);
+        }
     }
 
     // A user running these tests might not have any instances; so don't assert that there will be one

--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynLauncher.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynLauncher.java
@@ -144,6 +144,7 @@ public class BrooklynLauncher {
     private boolean startWebApps = true;
     private boolean startBrooklynNode = false;
     private PortRange port = null;
+    private Boolean useHttps = null;
     private InetAddress bindAddress = null;
     private InetAddress publicAddress = null;
     private Map<String,String> webApps = new LinkedHashMap<String,String>();
@@ -335,15 +336,24 @@ public class BrooklynLauncher {
      * As {@link #webconsolePort(PortRange)} taking a string range
      */
     public BrooklynLauncher webconsolePort(String port) {
+        if (port==null) return webconsolePort((PortRange)null);
         return webconsolePort(PortRanges.fromString(port));
     }
 
     /**
      * Specifies the port where the web console (and any additional webapps specified) will listen;
-     * default "8081+" (or "8443+" for https) being the first available >= 8081.
+     * default (null) means "8081+" being the first available >= 8081 (or "8443+" for https).
      */ 
     public BrooklynLauncher webconsolePort(PortRange port) {
         this.port = port;
+        return this;
+    }
+
+    /**
+     * Specifies whether the webconsole should use https.
+     */ 
+    public BrooklynLauncher webconsoleHttps(Boolean useHttps) {
+        this.useHttps = useHttps;
         return this;
     }
 
@@ -721,7 +731,8 @@ public class BrooklynLauncher {
             webServer = new BrooklynWebServer(webconsoleFlags, managementContext);
             webServer.setBindAddress(bindAddress);
             webServer.setPublicAddress(publicAddress);
-            webServer.setPort(port);
+            if (port!=null) webServer.setPort(port);
+            if (useHttps!=null) webServer.setHttpsEnabled(useHttps);
             webServer.putAttributes(brooklynProperties);
             if (skipSecurityFilter != Boolean.TRUE) {
                 webServer.setSecurityFilter(BrooklynPropertiesSecurityFilter.class);

--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
@@ -212,6 +212,9 @@ public class BrooklynWebServer {
     }
 
     public BrooklynWebServer setPort(Object port) {
+        if (port==null) {
+            this.requestedPort = null;
+        }
         if (getActualPort()>0)
             throw new IllegalStateException("Can't set port after port has been assigned to server (using "+getActualPort()+")");
         this.requestedPort = TypeCoercions.coerce(port, PortRange.class);
@@ -221,6 +224,11 @@ public class BrooklynWebServer {
     @VisibleForTesting
     File getWebappTempDir() {
         return webappTempDir;
+    }
+    
+    public BrooklynWebServer setHttpsEnabled(Boolean httpsEnabled) {
+        this.httpsEnabled = httpsEnabled;
+        return this;
     }
     
     public boolean getHttpsEnabled() {
@@ -338,7 +346,10 @@ public class BrooklynWebServer {
         if (actualPort == -1){
             PortRange portRange = requestedPort;
             if (portRange==null) {
-                portRange = getHttpsEnabled()? httpsPort : httpPort;
+                portRange = managementContext.getConfig().getConfig(BrooklynWebConfig.WEB_CONSOLE_PORT);
+            }
+            if (portRange==null) {
+                portRange = getHttpsEnabled() ? httpsPort : httpPort;
             }
             actualPort = LocalhostMachineProvisioningLocation.obtainPort(getAddress(), portRange);
             if (actualPort == -1) 

--- a/usage/launcher/src/test/java/brooklyn/launcher/WebAppRunnerTest.java
+++ b/usage/launcher/src/test/java/brooklyn/launcher/WebAppRunnerTest.java
@@ -70,7 +70,7 @@ public class WebAppRunnerTest {
         Map attributes = MutableMap.copyOf( (Map) bigProps.get("attributes") );
         bigProps.put("attributes", attributes);
 
-        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newDefault();
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
         brooklynProperties.putAll(bigProps);
         brooklynProperties.put("brooklyn.webconsole.security.provider","brooklyn.rest.security.provider.AnyoneSecurityProvider");
         brooklynProperties.put("brooklyn.webconsole.security.https.required","false");
@@ -145,7 +145,7 @@ public class WebAppRunnerTest {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/hello-world.war");
 
         BrooklynLauncher launcher = BrooklynLauncher.newInstance()
-                .globalBrooklynPropertiesFile(null)
+                .brooklynProperties(BrooklynProperties.Factory.newEmpty())
                 .brooklynProperties("brooklyn.webconsole.security.provider","brooklyn.rest.security.provider.AnyoneSecurityProvider")
                 .webapp("/hello", "hello-world.war")
                 .start();

--- a/usage/rest-server/src/main/java/brooklyn/rest/BrooklynWebConfig.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/BrooklynWebConfig.java
@@ -22,6 +22,7 @@ import brooklyn.config.ConfigKey;
 import brooklyn.config.ConfigMap;
 import brooklyn.config.ConfigPredicates;
 import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.location.PortRange;
 import brooklyn.rest.security.provider.DelegatingSecurityProvider;
 import brooklyn.rest.security.provider.ExplicitUsersSecurityProvider;
 
@@ -67,7 +68,11 @@ public class BrooklynWebConfig {
 
     public final static ConfigKey<Boolean> HTTPS_REQUIRED = ConfigKeys.newBooleanConfigKey(
             BASE_NAME+".security.https.required",
-            "Whether HTTPS is required", false); 
+            "Whether HTTPS is required; false here can be overridden by CLI option", false); 
+
+    public final static ConfigKey<PortRange> WEB_CONSOLE_PORT = ConfigKeys.newConfigKey(PortRange.class,
+        BASE_NAME+".port",
+        "Port/range for the web console to listen on; can be overridden by CLI option");
 
     public final static ConfigKey<String> KEYSTORE_URL = ConfigKeys.newStringConfigKey(
             BASE_NAME+".security.keystore.url",

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/ServerResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/ServerResource.java
@@ -219,6 +219,21 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
 
     @Override
     public VersionSummary getVersion() {
+        // TODO reconcile this with BrooklynVersion reading from the OSGi manifest
+        // @ahgittin / @sjcorbett to decide, is there need for this in addition to the OSGi manifest?
+        // TODO as part of this call should we have a strategy for reporting downstream builds in this call?
+        // for instance, we could look for
+        // * ALL "brooklyn-build-metadata.properties" files on the classpath
+        // * and/or ALL items on classpath with a custom header (eg "Brooklyn-OSGi-Feature-Name: My Project") in MANIFEST.MF
+        // i tend to favour the latter as MANIFEST.MF is already recognised; is there a reason to introduce a new file?
+        // whichever we do, i think:
+        // * "build-metadata.properties" is probably the wrong name
+        // * we should include brooklyn.version and a build timestamp in this file
+        // * the authority for brooklyn should probably be core rather than brooklyn-rest-server
+        
+        // TODO in version summary, maybe also have:
+        // features: [ { name: my-project, version: 0.1.0-SNAPSHOT, git-sha1: xxx }, ... ]
+        // osgi: [ /* similar metadata extracted from all active osgi bundles */ ]
         InputStream input = ResourceUtils.create().getResourceFromUrl("classpath://build-metadata.properties");
         Properties properties = new Properties();
         String gitSha1 = null, gitBranch = null;

--- a/usage/rest-server/src/main/java/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
@@ -57,6 +57,8 @@ public class ExplicitUsersSecurityProvider extends AbstractSecurityProvider impl
         allowedUsers = new LinkedHashSet<String>();
         String users = properties.getConfig(BrooklynWebConfig.USERS);
         if (users == null) {
+            // TODO unfortunately this is only activated *when* someone tries to log in
+            // (NB it seems like this class is not even instantiated until first log in)
             LOG.warn("REST has no users configured; no one will be able to log in!");
         } else if ("*".equals(users)) {
             LOG.info("REST allowing any user (so long as valid password is set)");

--- a/usage/test-support/src/main/java/brooklyn/test/HttpTestUtils.java
+++ b/usage/test-support/src/main/java/brooklyn/test/HttpTestUtils.java
@@ -39,12 +39,12 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
 
-import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 
 import brooklyn.util.collections.MutableMap;
+import brooklyn.util.crypto.SslTrustUtils;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.stream.Streams;
 import brooklyn.util.time.Time;
@@ -326,7 +326,7 @@ public class HttpTestUtils {
     
     public static String getContent(String url) {
         try {
-            return DefaultGroovyMethods.getText(new URL(url).openStream());
+            return Streams.readFullyString(SslTrustUtils.trustAll(new URL(url).openConnection()).getInputStream());
         } catch (Exception e) {
             throw Throwables.propagate(e);
         }


### PR DESCRIPTION
* adds config key for web-console port
* adds CLI for https
* port defaults to 8443+ if no port specified and using https
* default if no CLI options is to show help and an error
* some https test fixes
* discovers and reports Brooklyn OSGi metadata in log, including git SHA1 (and `brooklyn info`)