### PR TITLE
obfuscate passwords and credentials in the gui (literal "shadow passwords")

### DIFF
--- a/docs/_extra/deploying-yaml.md
+++ b/docs/_extra/deploying-yaml.md
@@ -27,6 +27,8 @@ you can:
 $ curl -T ./blueprint.yaml -X POST http://localhost:8081/v1/applications
 {% endhighlight %}
 
+You may also need a `-H "Content-Type: application/yaml"` depending on type configuration.
+(Not usually for this, but often for other calls.)
 
 - In the web-console, select the "YAML" tab in the "Add Application" wizard:
 

--- a/usage/jsgui/src/main/webapp/assets/css/base.css
+++ b/usage/jsgui/src/main/webapp/assets/css/base.css
@@ -1455,13 +1455,13 @@ textarea.param-value {
 }
 
 /* For secret things */
-tr.secret-info span.value {
+.secret-info span.value {
     display: none;
 }
-tr.secret-info.secret-revealed span.value {
+.secret-info.secret-revealed span.value {
     display: inherit;
 }
-tr.secret-info.secret-revealed span.secret-indicator {
+.secret-info.secret-revealed span.secret-indicator {
     display: none;
 }
 

--- a/usage/jsgui/src/main/webapp/assets/css/base.css
+++ b/usage/jsgui/src/main/webapp/assets/css/base.css
@@ -1453,3 +1453,20 @@ textarea.param-value {
 #catalog-details-accordion {
     margin-top: 12px;
 }
+
+/* For secret things */
+tr.secret-info span.value {
+    display: none;
+}
+tr.secret-info.secret-revealed span.value {
+    display: inherit;
+}
+tr.secret-info.secret-revealed span.secret-indicator {
+    display: none;
+}
+
+.secret-indicator {
+    /* blur */
+    color: transparent;
+    text-shadow: 0 0 5px rgba(0,0,0,0.5);
+}

--- a/usage/jsgui/src/main/webapp/assets/js/util/brooklyn-utils.js
+++ b/usage/jsgui/src/main/webapp/assets/js/util/brooklyn-utils.js
@@ -162,6 +162,17 @@ define([
             return alternateMessage;
         }
     };
+    
+    secretWords = [ "password", "passwd", "credential", "secret", "private", "access.cert", "access.key" ];
+    
+    Util.isSecret = function (key) {
+        if (!key) return false;
+        key = key.toString().toLowerCase();
+        for (secretWord in secretWords)
+            if (key.indexOf(secretWords[secretWord]) >= 0)
+                return true;
+        return false; 
+    };
 
     return Util;
 

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-config.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-config.js
@@ -45,7 +45,7 @@ define([
             'click .refresh':'updateConfigNow',
             'click .filterEmpty':'toggleFilterEmpty',
             'click .toggleAutoRefresh':'toggleAutoRefresh',
-            'click #config-table tr.secret-info td.config-value':'toggleSecrecyVisibility',
+            'click #config-table div.secret-info':'toggleSecrecyVisibility',
 
             'mouseup .valueOpen':'valueOpen',
             'mouseover #config-table tbody tr':'noteFloatMenuActive',
@@ -97,6 +97,7 @@ define([
                                              configName = row[0],
                                              actions = that.getConfigActions(configName);
                                          
+                                         // NB: the row might not yet exist
                                          var $row = $('tr[id="'+configName+'"]');
                                          
                                          // datatables doesn't seem to expose any way to modify the html in place for a cell,
@@ -104,8 +105,8 @@ define([
                                          
                                          var result = "<span class='value'>"+(hasEscapedValue ? escapedValue : '')+"</span>";
                                          
-                                         if (Util.isSecret(configName)) {
-                                            $row.addClass("secret-info");
+                                         var isSecret = Util.isSecret(configName);
+                                         if (isSecret) {
                                             result += "<span class='secret-indicator'>(hidden)</span>";
                                          }
                                          
@@ -159,7 +160,9 @@ define([
                                                 "<div class='floatLeft'><span class='icon-chevron-down hasFloatDown'></span>" +
                                                 downMenu +
                                                 "</div>";
-                                         result = "<div class='floatGroup'>" + result + "</div>";
+                                         result = "<div class='floatGroup"+
+                                            (isSecret ? " secret-info" : "")+
+                                            "'>" + result + "</div>";
                                          // also see updateFloatMenus which wires up the JS for these classes
                                          
                                          return result;
@@ -437,7 +440,7 @@ define([
         },
         
         toggleSecrecyVisibility: function(event) {
-            $(event.target).closest('tr.secret-info').toggleClass('secret-revealed');
+            $(event.target).closest('.secret-info').toggleClass('secret-revealed');
         },
         
         /**

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
@@ -48,7 +48,7 @@ define([
             'click .refresh': 'updateSensorsNow',
             'click .filterEmpty':'toggleFilterEmpty',
             'click .toggleAutoRefresh':'toggleAutoRefresh',
-            'click #sensors-table tr.secret-info td.sensor-value':'toggleSecrecyVisibility',
+            'click #sensors-table div.secret-info':'toggleSecrecyVisibility',
             
             'mouseup .valueOpen':'valueOpen',
             'mouseover #sensors-table tbody tr':'noteFloatMenuActive',
@@ -105,6 +105,7 @@ define([
                                              sensorName = row[0],
                                              actions = that.getSensorActions(sensorName);
                                          
+                                         // NB: the row might not yet exist
                                          var $row = $('tr[id="'+sensorName+'"]');
                                          
                                          // datatables doesn't seem to expose any way to modify the html in place for a cell,
@@ -112,8 +113,8 @@ define([
                                          
                                          var result = "<span class='value'>"+(hasEscapedValue ? escapedValue : '')+"</span>";
 
-                                         if (Util.isSecret(sensorName)) {
-                                            $row.addClass("secret-info");
+                                         var isSecret = Util.isSecret(sensorName);
+                                         if (isSecret) {
                                             result += "<span class='secret-indicator'>(hidden)</span>";
                                          }
                                          
@@ -167,7 +168,9 @@ define([
                                          		"<div class='floatLeft'><span class='icon-chevron-down hasFloatDown'></span>" +
                                          		downMenu +
                                          		"</div>";
-                                         result = "<div class='floatGroup'>" + result + "</div>";
+                                         result = "<div class='floatGroup"+
+                                            (isSecret ? " secret-info" : "")+
+                                            "'>" + result + "</div>";
                                          // also see updateFloatMenus which wires up the JS for these classes
                                          
                                          return result;
@@ -456,7 +459,7 @@ define([
         },
         
         toggleSecrecyVisibility: function(event) {
-            $(event.target).closest('tr.secret-info').toggleClass('secret-revealed');
+            $(event.target).closest('.secret-info').toggleClass('secret-revealed');
         },
         
         /**

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
@@ -48,6 +48,7 @@ define([
             'click .refresh': 'updateSensorsNow',
             'click .filterEmpty':'toggleFilterEmpty',
             'click .toggleAutoRefresh':'toggleAutoRefresh',
+            'click #sensors-table tr.secret-info td.sensor-value':'toggleSecrecyVisibility',
             
             'mouseup .valueOpen':'valueOpen',
             'mouseover #sensors-table tbody tr':'noteFloatMenuActive',
@@ -104,17 +105,24 @@ define([
                                              sensorName = row[0],
                                              actions = that.getSensorActions(sensorName);
                                          
+                                         var $row = $('tr[id="'+sensorName+'"]');
+                                         
                                          // datatables doesn't seem to expose any way to modify the html in place for a cell,
                                          // so we rebuild
                                          
                                          var result = "<span class='value'>"+(hasEscapedValue ? escapedValue : '')+"</span>";
+
+                                         if (Util.isSecret(sensorName)) {
+                                            $row.addClass("secret-info");
+                                            result += "<span class='secret-indicator'>(hidden)</span>";
+                                         }
+                                         
                                          if (actions.open)
                                              result = "<a href='"+actions.open+"'>" + result + "</a>";
                                          if (escapedValue==null || escapedValue.length < 3)
                                              // include whitespace so we can click on it, if it's really small
                                              result += "&nbsp;&nbsp;&nbsp;&nbsp;";
 
-                                         var $row = $('tr[id="'+sensorName+'"]');
                                          var existing = $row.find('.dynamic-contents');
                                          // for the json url, use the full url (relative to window.location.href)
                                          var jsonUrl = actions.json ? new URI(actions.json).resolve(new URI(window.location.href)).toString() : null;
@@ -445,6 +453,10 @@ define([
         enableAutoRefresh: function(isEnabled) {
             this.refreshActive = isEnabled;
             return this;
+        },
+        
+        toggleSecrecyVisibility: function(event) {
+            $(event.target).closest('tr.secret-info').toggleClass('secret-revealed');
         },
         
         /**


### PR DESCRIPTION
applies text shadowing to blur keys that say obvious things like "password" and "credential",
to config table and sensors table. clears up when you click it.
this prevents people looking over your shoulder from seeing things they shouldn't,
but it doesn't block REST access, and if you click on it you can still see it.
(this is a common trick done at AWS & SL, btw.)

a separate feature is to enforce visibility of sensors; this can be done with entitlements on a per-sensor basis
but it might be nice to have an easy entitlements mode where "sensitive" info is not available,
and options on config keys (similar to how i just did it with ConfigInheritance,
in https://github.com/apache/incubator-brooklyn/pull/483) to allow ConfigSensitivity.

an easy way to test is:

    curl -v -X POST -H "Content-Type: application/json" --data \"foo\" http://127.0.0.1:8082/v1/applications/YKH2Dp3E/entities/NN0BJzNA/sensors/my_secret

here's what it looks like:

![screen shot 2015-01-28 at 16 05 23](https://cloud.githubusercontent.com/assets/496540/5941241/89d8c3fe-a707-11e4-8b4d-7e0ef1c2b28f.png)
