### PR TITLE
Remove non-Apache repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
       brooklyn.explicitModules :: only builds explicit modules (instead of default modules)
 
-      brooklyn.deployTo={cloudsoftFilesystem,cloudsoftArtifactory,sonatype,apache} ::
+      brooklyn.deployTo={apache} ::
             :: required when deploying; specify the deployment target
 
       javadoc :: build javadoc (adds a minute or two; enabled automatically for target deploy)
@@ -747,7 +747,7 @@
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
-                        <arguments>-Dbrooklyn.deployTo=sonatype</arguments>
+                        <arguments>-Dbrooklyn.deployTo=apache</arguments>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>
@@ -1881,58 +1881,6 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                 </plugin>
             </plugins></build>
-        </profile>
-
-        <!-- different properties used to deploy to different locations depending on profiles;
-             default is cloudsoft filesystem repo, but some sources still use cloudsoft artifactory as source
-             (and soon we will support artifactory) -->
-        <profile>
-            <id>cloudsoft-filesystem-repo</id>
-            <activation> <property><name>brooklyn.deployTo</name><value>cloudsoftFilesystem</value></property> </activation>
-            <distributionManagement>
-                <repository>
-                    <id>cloudsoft-deploy-cloudfront-origin-releases</id>
-                    <name>Cloudsoft Release Filesystem repo (used as origin for cloudfront)</name>
-                    <url>scpexe://root@developers-origin.cloudsoftcorp.com/var/www/developers/maven/releases/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>cloudsoft-deploy-cloudfront-origin-snapshots</id>
-                    <name>Cloudsoft Snapshot Filesystem repo (used as origin for cloudfront)</name>
-                    <url>scpexe://root@developers-origin.cloudsoftcorp.com/var/www/developers/maven/snapshots/</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-        <profile>
-            <id>cloudsoft-artifactory-repo</id>
-            <activation> <property><name>brooklyn.deployTo</name><value>cloudsoftArtifactory</value></property> </activation>
-            <distributionManagement>
-                <repository>
-                    <id>cloudsoft-deploy-artifactory-release</id>
-                    <name>Cloudsoft Artifactory libs-release-local repo</name>
-                    <url>http://ccweb.cloudsoftcorp.com/maven/libs-release-local/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>cloudsoft-deploy-artifactory-snapshot</id>
-                    <name>Cloudsoft Artifactory libs-snapshot-local repo</name>
-                    <url>http://ccweb.cloudsoftcorp.com/maven/libs-snapshot-local/</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-        <profile>
-            <id>sonatype-nexus-repo</id>
-            <activation> <property><name>brooklyn.deployTo</name><value>sonatype</value></property> </activation>
-            <distributionManagement>
-                <repository>
-                    <id>sonatype-nexus-staging</id>
-                    <name>Nexus Release Repository</name>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-                <snapshotRepository>
-                    <id>sonatype-nexus-snapshots</id>
-                    <name>Sonatype Nexus Snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                </snapshotRepository>
-            </distributionManagement>
         </profile>
         <profile>
             <id>apache-repo</id>


### PR DESCRIPTION
Use `altDeploymentRepository` if alternative repos needed. `brooklyn.deployTo` remains only as a marker to activate source and gpg plugins during build.