### PR TITLE
Fix projects build order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1296,8 +1296,8 @@
                 <module>usage/cli</module>
                 <module>usage/all</module>
                 <module>usage/dist</module>
-                <module>usage/archetypes/quickstart</module>
                 <module>usage/downstream-parent</module>
+                <module>usage/archetypes/quickstart</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
The quickstart generated project depends on downstream-parent, but it is not yet built. Change modules build order.