### PR TITLE
Java 8 compile fixes

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/ExplicitEffector.java
+++ b/core/src/main/java/brooklyn/entity/basic/ExplicitEffector.java
@@ -38,7 +38,7 @@ public abstract class ExplicitEffector<I,T> extends AbstractEffector<T> {
     }
 
     public T call(Entity entity, Map parameters) {
-        return invokeEffector((I) entity, parameters );
+        return invokeEffector((I) entity, (Map<String,?>)parameters );
     }
 
     public abstract T invokeEffector(I trait, Map<String,?> parameters);

--- a/core/src/main/java/brooklyn/entity/basic/ServiceStateLogic.java
+++ b/core/src/main/java/brooklyn/entity/basic/ServiceStateLogic.java
@@ -183,9 +183,9 @@ public class ServiceStateLogic {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public static final EnricherSpec<?> newEnricherForServiceUpIfNotUpIndicatorsEmpty() {
             return Enrichers.builder()
-                .transforming(SERVICE_NOT_UP_INDICATORS).publishing(Attributes.SERVICE_UP)
+                .transforming(SERVICE_NOT_UP_INDICATORS).<Object>publishing(Attributes.SERVICE_UP)
                 .suppressDuplicates(true)
-                .computing( /* cast hacks to support removing */ (Function)
+                .computing(
                     Functionals.<Map<String,?>>
                         ifNotEquals(null).<Object>apply(Functions.forPredicate(CollectionFunctionals.<String>mapSizeEquals(0)))
                         .defaultValue(Entities.REMOVE) )

--- a/core/src/main/java/brooklyn/event/basic/DependentConfiguration.java
+++ b/core/src/main/java/brooklyn/event/basic/DependentConfiguration.java
@@ -707,7 +707,7 @@ public class DependentConfiguration {
         // if desired, the use of this multiSource could allow different conditions; 
         // but probably an easier API just for the caller to build the parallel task  
         protected final List<AttributeAndSensorCondition<?>> multiSource = Lists.newArrayList();
-        protected Function<? super List<V>, ? extends V2> postProcessFromMultiple;
+        protected Function<? super List<V>, V2> postProcessFromMultiple;
         
         /** returns a task for parallel execution returning a list of values of the given sensor list on the given entity, 
          * optionally when the values satisfy a given readiness predicate (defaulting to groovy truth if not supplied) */ 
@@ -810,7 +810,7 @@ public class DependentConfiguration {
                             List<V> prePostProgress = DynamicTasks.queue(parallelTask).get();
                             return DynamicTasks.queue(
                                 Tasks.<V2>builder().name("post-processing").description("Applying "+postProcessFromMultiple)
-                                    .body(Functionals.<List<V>,V2>callable((Function)postProcessFromMultiple, prePostProgress))
+                                    .body(Functionals.callable(postProcessFromMultiple, prePostProgress))
                                     .build()).get();
                         }
                     })

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/cassandra/CassandraNodeImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/cassandra/CassandraNodeImpl.java
@@ -418,9 +418,10 @@ public class CassandraNodeImpl extends SoftwareProcessImpl implements CassandraN
                 .pollAttribute(new JmxAttributePollConfig<Set<BigInteger>>(TOKENS)
                         .objectName(storageServiceMBean)
                         .attributeName("TokenToEndpointMap")
-                        .onSuccess((Function) new Function<Map, Set<BigInteger>>() {
+                        .onSuccess(new Function<Object, Set<BigInteger>>() {
                             @Override
-                            public Set<BigInteger> apply(@Nullable Map input) {
+                            public Set<BigInteger> apply(@Nullable Object arg) {
+                                Map input = (Map)arg;
                                 if (input == null || input.isEmpty()) return null;
                                 // FIXME does not work on aws-ec2, uses RFC1918 address
                                 Predicate<String> self = Predicates.in(ImmutableList.of(getAttribute(HOSTNAME), getAttribute(ADDRESS), getAttribute(SUBNET_ADDRESS), getAttribute(SUBNET_HOSTNAME)));
@@ -435,9 +436,10 @@ public class CassandraNodeImpl extends SoftwareProcessImpl implements CassandraN
                 .pollAttribute(new JmxAttributePollConfig<BigInteger>(TOKEN)
                         .objectName(storageServiceMBean)
                         .attributeName("TokenToEndpointMap")
-                        .onSuccess((Function) new Function<Map, BigInteger>() {
+                        .onSuccess(new Function<Object, BigInteger>() {
                             @Override
-                            public BigInteger apply(@Nullable Map input) {
+                            public BigInteger apply(@Nullable Object arg) {
+                                Map input = (Map)arg;
                                 // TODO remove duplication from setting TOKENS
                                 if (input == null || input.isEmpty()) return null;
                                 // FIXME does not work on aws-ec2, uses RFC1918 address
@@ -462,9 +464,10 @@ public class CassandraNodeImpl extends SoftwareProcessImpl implements CassandraN
                 .pollAttribute(new JmxAttributePollConfig<Integer>(PEERS)
                         .objectName(storageServiceMBean)
                         .attributeName("TokenToEndpointMap")
-                        .onSuccess((Function) new Function<Map, Integer>() {
+                        .onSuccess(new Function<Object, Integer>() {
                             @Override
-                            public Integer apply(@Nullable Map input) {
+                            public Integer apply(@Nullable Object arg) {
+                                Map input = (Map)arg;
                                 if (input == null || input.isEmpty()) return 0;
                                 return input.size();
                             }
@@ -473,9 +476,10 @@ public class CassandraNodeImpl extends SoftwareProcessImpl implements CassandraN
                 .pollAttribute(new JmxAttributePollConfig<Integer>(LIVE_NODE_COUNT)
                         .objectName(storageServiceMBean)
                         .attributeName("LiveNodes")
-                        .onSuccess((Function) new Function<List, Integer>() {
+                        .onSuccess(new Function<Object, Integer>() {
                             @Override
-                            public Integer apply(@Nullable List input) {
+                            public Integer apply(@Nullable Object arg) {
+                                List input = (List)arg;
                                 if (input == null || input.isEmpty()) return 0;
                                 return input.size();
                             }

--- a/software/osgi/src/main/java/brooklyn/entity/osgi/karaf/KarafContainerImpl.java
+++ b/software/osgi/src/main/java/brooklyn/entity/osgi/karaf/KarafContainerImpl.java
@@ -125,7 +125,12 @@ public class KarafContainerImpl extends SoftwareProcessImpl implements KarafCont
                 .pollAttribute(new JmxAttributePollConfig<Map>(KARAF_INSTANCES)
                         .objectName(karafAdminObjectName)
                         .attributeName("Instances")
-                        .onSuccess((Function)JmxValueFunctions.tabularDataToMap())
+                        .onSuccess(new Function<Object, Map>() {
+                            @Override
+                            public Map apply(Object input) {
+                                return JmxValueFunctions.tabularDataToMap((TabularData)input);
+                            }
+                        })
                         .onException(new Function<Exception,Map>() {
                                 @Override public Map apply(Exception input) {
                                     // If MBean is unreachable, then mark as service-down


### PR DESCRIPTION
Problems are at places where generics are misused. Usually preceded by compiler warnings.