### PR TITLE
fix bug where missing script dir causes null script dir explicitly set in ssh tool

### DIFF
--- a/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
@@ -647,7 +647,7 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
     private Map<String, Object> augmentPropertiesWithSshConfigGivenToProps(Map<String, ?> props) {
         Map<String,Object> augmentedProps = Maps.newHashMap(props);
         for (ConfigKey<?> config : SSH_CONFIG_GIVEN_TO_PROPS) {
-            if (!props.containsKey(config.getName()))
+            if (!augmentedProps.containsKey(config.getName()) && hasConfig(config, true))
                 augmentedProps.put(config.getName(), getConfig(config));
         }
         return augmentedProps;

--- a/core/src/test/java/brooklyn/location/basic/SshMachineLocationIntegrationTest.java
+++ b/core/src/test/java/brooklyn/location/basic/SshMachineLocationIntegrationTest.java
@@ -114,4 +114,19 @@ public class SshMachineLocationIntegrationTest {
         int rc = sm.execScript("Test script directory execution", ImmutableList.of(command));
         assertEquals(rc, 0);
     }
+    
+    @Test(groups = "Integration")
+    public void testMissingLocationScriptDirIsAlsoOkay() throws Exception {
+        final String command = "echo hello";
+
+        Map<String, Object> locationConfig = ImmutableMap.<String, Object>builder()
+//                .put(SshMachineLocation.SCRIPT_DIR.getName(), "/var/tmp")
+                .build();
+
+        LocalhostMachineProvisioningLocation lhp = (LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().resolve("localhost", locationConfig);
+        SshMachineLocation sm = lhp.obtain();
+
+        int rc = sm.execScript("Test script directory execution", ImmutableList.of(command));
+        assertEquals(rc, 0);
+    }
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1694,7 +1694,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     .configureIfNotNull(CLOUD_REGION_ID, nodeRegion)
                     .configure(CALLER_CONTEXT, setup.get(CALLER_CONTEXT))
                     .configure(SshMachineLocation.DETECT_MACHINE_DETAILS, setup.get(SshMachineLocation.DETECT_MACHINE_DETAILS))
-                    .configure(SshMachineLocation.SCRIPT_DIR, setup.get(SshMachineLocation.SCRIPT_DIR))
+                    .configureIfNotNull(SshMachineLocation.SCRIPT_DIR, setup.get(SshMachineLocation.SCRIPT_DIR))
                     .configureIfNotNull(USE_PORT_FORWARDING, setup.get(USE_PORT_FORWARDING))
                     .configureIfNotNull(PORT_FORWARDER, setup.get(PORT_FORWARDER))
                     .configureIfNotNull(PORT_FORWARDING_MANAGER, setup.get(PORT_FORWARDING_MANAGER)));


### PR DESCRIPTION
bug introduced in #476

affects all deployments to ssh machines where script dir is not expliclty set, causing NPE