### PR TITLE
Softlayer safe name length

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsMachineNamer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsMachineNamer.java
@@ -26,20 +26,22 @@ public class JcloudsMachineNamer extends CloudMachineNamer {
     public JcloudsMachineNamer(ConfigBag setup) {
         super(setup);
     }
-    
+
     /** returns the max length of a VM name for the cloud specified in setup;
      * this value is typically decremented by 9 to make room for jclouds labels */
     public Integer getCustomMaxNameLength() {
         // otherwise, for some known clouds which only allow a short name, use that length
-        if ("vcloud".equals( setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER) )) 
+        if ("vcloud".equals( setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER) ))
             return 24;
-        if ("abiquo".equals( setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER) )) 
+        if ("abiquo".equals( setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER) ))
             return 39;
         if ("google-compute-engine".equals( setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER) ))
             return 39;
+        if ("softlayer".equals( setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER) ))
+            return 55;
         // TODO other cloud max length rules
-        
-        return null;  
+
+        return null;
     }
-    
+
 }


### PR DESCRIPTION
After extensive testing it would appear that:
- anything up to 55 chars seems to be fine.  
- 56-58 characters you could jclouds exceptions while provisioning.  
- 59 chars up to around 80 ish you get a provisioned machine with no hostname 
- if you set the chars at higher than 100(ish) you get an error saying that the maximum length had been exceeded.

Someone else please test before merging.
