### PR TITLE
fix time-sensitive sensor derivation when rebinding to old sensors

### DIFF
--- a/core/src/main/java/brooklyn/enricher/basic/AbstractTypeTransformingEnricher.java
+++ b/core/src/main/java/brooklyn/enricher/basic/AbstractTypeTransformingEnricher.java
@@ -61,7 +61,7 @@ public abstract class AbstractTypeTransformingEnricher<T,U> extends AbstractEnri
             Object value = producer.getAttribute((AttributeSensor)source);
             // TODO Aled didn't you write a convenience to "subscribeAndRunIfSet" ? (-Alex)
             if (value!=null)
-                onEvent(new BasicSensorEvent(source, producer, value));
+                onEvent(new BasicSensorEvent(source, producer, value, -1));
         }
     }
 }

--- a/core/src/main/java/brooklyn/enricher/basic/AddingEnricher.java
+++ b/core/src/main/java/brooklyn/enricher/basic/AddingEnricher.java
@@ -61,7 +61,7 @@ public class AddingEnricher extends AbstractEnricher implements SensorEventListe
             if (source instanceof AttributeSensor) {
                 Object value = entity.getAttribute((AttributeSensor)source);
                 if (value!=null)
-                    onEvent(new BasicSensorEvent(source, entity, value));
+                    onEvent(new BasicSensorEvent(source, entity, value, -1));
             }
         }
     }

--- a/core/src/main/java/brooklyn/enricher/basic/Combiner.java
+++ b/core/src/main/java/brooklyn/enricher/basic/Combiner.java
@@ -103,7 +103,7 @@ public class Combiner<T,U> extends AbstractEnricher implements SensorEventListen
                 // TODO Aled didn't you write a convenience to "subscribeAndRunIfSet" ? (-Alex)
                 //      Unfortunately not yet!
                 if (value != null) {
-                    onEvent(new BasicSensorEvent(sourceSensor, producer, value));
+                    onEvent(new BasicSensorEvent(sourceSensor, producer, value, -1));
                 }
             }
         }

--- a/core/src/main/java/brooklyn/enricher/basic/Propagator.java
+++ b/core/src/main/java/brooklyn/enricher/basic/Propagator.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import brooklyn.catalog.Catalog;
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.Attributes;
@@ -151,7 +150,7 @@ public class Propagator extends AbstractEnricher implements SensorEventListener<
         emit((Sensor)destinationSensor, event.getValue());
     }
 
-    /** useful post-addition to emit current values */
+    /** useful once sensors are added to emit all values */
     public void emitAllAttributes() {
         emitAllAttributes(false);
     }
@@ -166,6 +165,8 @@ public class Propagator extends AbstractEnricher implements SensorEventListener<
             if (s instanceof AttributeSensor) {
                 AttributeSensor destinationSensor = (AttributeSensor<?>) getDestinationSensor(s);
                 Object v = producer.getAttribute((AttributeSensor<?>)s);
+                // TODO we should keep a timestamp for the source sensor and echo it 
+                // (this pretends timestamps are current, which probably isn't the case when we are propagating)
                 if (v != null || includeNullValues) entity.setAttribute(destinationSensor, v);
             }
         }

--- a/core/src/main/java/brooklyn/enricher/basic/Transformer.java
+++ b/core/src/main/java/brooklyn/enricher/basic/Transformer.java
@@ -98,7 +98,7 @@ public class Transformer<T,U> extends AbstractEnricher implements SensorEventLis
             Object value = producer.getAttribute((AttributeSensor<?>)sourceSensor);
             // TODO would be useful to have a convenience to "subscribeAndThenIfItIsAlreadySetRunItOnce"
             if (value!=null) {
-                onEvent(new BasicSensorEvent(sourceSensor, producer, value));
+                onEvent(new BasicSensorEvent(sourceSensor, producer, value, -1));
             }
         }
     }

--- a/core/src/main/java/brooklyn/enricher/basic/Transformer.java
+++ b/core/src/main/java/brooklyn/enricher/basic/Transformer.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import brooklyn.catalog.Catalog;
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.ConfigKeys;

--- a/core/src/main/java/brooklyn/event/basic/BasicSensorEvent.java
+++ b/core/src/main/java/brooklyn/event/basic/BasicSensorEvent.java
@@ -51,19 +51,14 @@ public class BasicSensorEvent<T> implements SensorEvent<T> {
 
     /** arguments should not be null (except in certain limited testing situations) */
     public BasicSensorEvent(Sensor<T> sensor, Entity source, T value) {
-        this(sensor, source, value, 0);
+        this(sensor, source, value, System.currentTimeMillis());
     }
     
     public BasicSensorEvent(Sensor<T> sensor, Entity source, T value, long timestamp) {
         this.sensor = sensor;
         this.source = source;
         this.value = value;
-
-        if (timestamp > 0) {
-            this.timestamp = timestamp;
-        } else {
-            this.timestamp = System.currentTimeMillis();
-        }
+        this.timestamp = timestamp;
     }
     
     public static <T> SensorEvent<T> of(Sensor<T> sensor, Entity source, T value, long timestamp) {

--- a/policy/src/main/java/brooklyn/enricher/RollingTimeWindowMeanEnricher.java
+++ b/policy/src/main/java/brooklyn/enricher/RollingTimeWindowMeanEnricher.java
@@ -64,11 +64,6 @@ public class RollingTimeWindowMeanEnricher<T extends Number> extends AbstractTyp
     public static ConfigKey<Double> CONFIDENCE_REQUIRED_TO_PUBLISH = ConfigKeys.newDoubleConfigKey("confidenceRequired",
         "Minimum confidence level (ie period covered) required to publish a rolling average", 0.8d);
 
-    // without this, we will refuse to publish if the server time differs from the publisher time (in a distributed setup);
-    // also we won't publish if a lot of time is spent actually doing the computation
-    public static ConfigKey<Duration> TIMESTAMP_GRACE_TIME = ConfigKeys.newConfigKey(Duration.class, "timestampGraceTime",
-        "When computing windowed average, allow this much slippage time between published metrics and local clock", Duration.millis(500));
-
     public static class ConfidenceQualifiedNumber {
         final Double value;
         final double confidence;
@@ -133,10 +128,12 @@ public class RollingTimeWindowMeanEnricher<T extends Number> extends AbstractTyp
         }
     }
     
+    @Deprecated /** @deprecatedsince 0.7.0; not used; use the 2-arg method */
     public ConfidenceQualifiedNumber getAverage() {
-        return getAverage(System.currentTimeMillis(), getConfig(TIMESTAMP_GRACE_TIME).toMilliseconds());
+        return getAverage(System.currentTimeMillis(), 0);
     }
     
+    @Deprecated /** @deprecated since 0.7.0; not used; use the 2-arg method */
     public ConfidenceQualifiedNumber getAverage(long fromTimeExact) {
         return getAverage(fromTimeExact, 0);
     }
@@ -145,11 +142,6 @@ public class RollingTimeWindowMeanEnricher<T extends Number> extends AbstractTyp
         if (timestamps.isEmpty()) {
             return lastAverage = new ConfidenceQualifiedNumber(lastAverage.value, 0.0d);
         }
-        
-        // (previously there was an old comment here, pre-Jul-2014,  
-        // saying "grkvlt - see email to development list";
-        // but i can't find that email)
-        // some of the more recent confidence and bogus-timestamp + exclusion logic might fix this though
         
         long firstTimestamp = -1;
         Iterator<Long> ti = timestamps.iterator();

--- a/policy/src/main/java/brooklyn/enricher/TimeWeightedDeltaEnricher.java
+++ b/policy/src/main/java/brooklyn/enricher/TimeWeightedDeltaEnricher.java
@@ -23,7 +23,6 @@ import groovy.lang.Closure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import brooklyn.catalog.Catalog;
 import brooklyn.enricher.basic.AbstractTypeTransformingEnricher;
 import brooklyn.entity.Entity;
 import brooklyn.event.AttributeSensor;
@@ -102,8 +101,8 @@ public class TimeWeightedDeltaEnricher<T extends Number> extends AbstractTypeTra
             return;
         }
         
-        if (eventTime > lastTime) {
-            if (lastValue == null) {
+        if (eventTime > 0 && eventTime > lastTime) {
+            if (lastValue == null || lastTime <= 0) {
                 // cannot calculate time-based delta with a single value
                 if (LOG.isTraceEnabled()) LOG.trace("{} received event but no last value so will not emit, null -> {} at {}", new Object[] {this, current, eventTime}); 
             } else {
@@ -116,6 +115,9 @@ public class TimeWeightedDeltaEnricher<T extends Number> extends AbstractTypeTra
             }
             lastValue = current;
             lastTime = eventTime;
+        } else if (lastTime<0) {
+            lastValue = current;
+            lastTime = -1;
         }
     }
 }

--- a/policy/src/main/java/brooklyn/policy/autoscaling/AutoScalerPolicy.java
+++ b/policy/src/main/java/brooklyn/policy/autoscaling/AutoScalerPolicy.java
@@ -690,7 +690,7 @@ public class AutoScalerPolicy extends AbstractPolicy {
             unboundedSize = (int)Math.ceil(currentTotalActivity/metricUpperBoundD);
             desiredSize = toBoundedDesiredPoolSize(unboundedSize);
             if (desiredSize > currentSize) {
-                if (LOG.isTraceEnabled()) LOG.trace("{} resizing out pool {} from {} to {} ({} > {})", new Object[] {this, poolEntity, currentSize, desiredSize, currentMetricD, metricUpperBoundD});
+                if (LOG.isDebugEnabled()) LOG.debug("{} provisionally resizing out pool {} from {} to {} ({} > {})", new Object[] {this, poolEntity, currentSize, desiredSize, currentMetricD, metricUpperBoundD});
                 scheduleResize(desiredSize);
             } else {
                 if (LOG.isTraceEnabled()) LOG.trace("{} not resizing pool {} from {} ({} > {} > {}, but scale-out blocked eg by bounds/check)", new Object[] {this, poolEntity, currentSize, currentMetricD, metricUpperBoundD, metricLowerBoundD});
@@ -708,7 +708,7 @@ public class AutoScalerPolicy extends AbstractPolicy {
                 desiredSize = toBoundedDesiredPoolSize(desiredSize);
             }
             if (desiredSize < currentSize) {
-                if (LOG.isTraceEnabled()) LOG.trace("{} resizing back pool {} from {} to {} ({} < {})", new Object[] {this, poolEntity, currentSize, desiredSize, currentMetricD, metricLowerBoundD});
+                if (LOG.isDebugEnabled()) LOG.debug("{} provisionally resizing back pool {} from {} to {} ({} < {})", new Object[] {this, poolEntity, currentSize, desiredSize, currentMetricD, metricLowerBoundD});
                 scheduleResize(desiredSize);
             } else {
                 if (LOG.isTraceEnabled()) LOG.trace("{} not resizing pool {} from {} ({} < {} < {}, but scale-back blocked eg by bounds/check)", new Object[] {this, poolEntity, currentSize, currentMetricD, metricLowerBoundD, metricUpperBoundD});

--- a/policy/src/test/java/brooklyn/enricher/RebindEnricherTest.java
+++ b/policy/src/test/java/brooklyn/enricher/RebindEnricherTest.java
@@ -35,6 +35,7 @@ import brooklyn.test.EntityTestUtils;
 import brooklyn.test.entity.TestApplication;
 import brooklyn.util.http.BetterMockWebServer;
 import brooklyn.util.time.Duration;
+import brooklyn.util.time.Time;
 
 import com.google.mockwebserver.MockResponse;
 
@@ -107,6 +108,8 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         
         TestApplication newApp = rebind();
 
+        newApp.setAttribute(INT_METRIC, 10);
+        Time.sleep(Duration.millis(10));
         newApp.setAttribute(INT_METRIC, 10);
         EntityTestUtils.assertAttributeEqualsEventually(newApp, DOUBLE_METRIC, 10d);
     }

--- a/policy/src/test/java/brooklyn/enricher/RollingTimeWindowMeanEnricherTest.groovy
+++ b/policy/src/test/java/brooklyn/enricher/RollingTimeWindowMeanEnricherTest.groovy
@@ -93,9 +93,17 @@ class RollingTimeWindowMeanEnricherTest {
     }
     
     @Test
-    public void testSingleValueAverage() {
+    public void testSingleValueTimeAverage() {
         averager.onEvent(intSensor.newEvent(producer, 10), 1000)
         average = averager.getAverage(1000)
+        assertEquals(average.confidence, 0d)
+    }
+    
+    @Test
+    public void testTwoValueAverageForPeriod() {
+        averager.onEvent(intSensor.newEvent(producer, 10), 1000)
+        averager.onEvent(intSensor.newEvent(producer, 10), 2000)
+        average = averager.getAverage(2000)
         assertEquals(average.value, 10 /1d)
         assertEquals(average.confidence, 1d)
     }


### PR DESCRIPTION
before this, autoscaler might scale out on rebind, because the
last total reqs might be 100, if data is v old, current value might be 10000;
a recent timestamp is attached to initial value, meaning it computes 9900 new reqs in a 1s window.

this forces an invalid timestamp for enrichers

better fix would be to store timestamp on sensors themselves