### PR TITLE
Forbid imports from com.google.api.client.repackaged

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1059,6 +1059,11 @@
                             <module name="FileTabCharacter">
                                 <property name="eachLine" value="true" />
                             </module>
+                            <module name="TreeWalker">
+                                <module name="IllegalImport">
+                                    <property name="illegalPkgs" value="com.google.api.client.repackaged"/>
+                                </module>
+                            </module>
                         </module>
                     </checkstyleRules>
                 </configuration>

--- a/software/network/src/test/java/brooklyn/entity/network/bind/BindDnsServerByonLiveTest.java
+++ b/software/network/src/test/java/brooklyn/entity/network/bind/BindDnsServerByonLiveTest.java
@@ -20,6 +20,7 @@ package brooklyn.entity.network.bind;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -33,7 +34,7 @@ public class BindDnsServerByonLiveTest extends BrooklynAppLiveTestSupport {
 
     @Test(groups = "Live")
     @Parameters({"locationSpec"})
-    public void testDns(String locationSpec) throws Exception {
+    public void testDns(@Optional String locationSpec) throws Exception {
         if (Strings.isBlank(locationSpec)) {
             LOG.info("{} got no spec, skipping test", this);
         } else {


### PR DESCRIPTION
Prompted by #503 and bf38d7f7c27e51938e59d8e6ebc75fa7df889f37. We could also prohibit `com.google.api.client` entirely or `..client.util` additionally.