### PR TITLE
Improve CLI customisability for downstream projects

### DIFF
--- a/usage/cli/src/main/java/brooklyn/cli/AbstractMain.java
+++ b/usage/cli/src/main/java/brooklyn/cli/AbstractMain.java
@@ -70,7 +70,7 @@ public abstract class AbstractMain {
     private static final Logger log = LoggerFactory.getLogger(AbstractMain.class);
 
     // Launch banner
-    public static final String BANNER =
+    public static final String DEFAULT_BANNER =
         " _                     _    _             \n" +
         "| |__  _ __ ___   ___ | | _| |_   _ _ __ (R)\n" +
         "| '_ \\| '__/ _ \\ / _ \\| |/ / | | | | '_ \\ \n" +
@@ -84,6 +84,16 @@ public abstract class AbstractMain {
     public static final int EXECUTION_ERROR = 2;
     public static final int CONFIGURATION_ERROR = 3;
 
+    /**
+     * Field intended for sub-classes (with their own {@code main()}) to customize the banner.
+     * All accesses to the banner are done through this field, to ensure consistent customization.
+     * 
+     * Note that a {@code getBanner()} method is not an option for supporting this, because
+     * it is accessed from static inner-classes (such as {@link InfoCommand}, so non-static
+     * methods are not an option (and one can't override static methods).
+     */
+    protected static volatile String banner = DEFAULT_BANNER;
+    
     /** abstract superclass for commands defining global options, but not arguments,
      * as that prevents Help from being injectable in the {@link HelpCommand} subclass */
     public static abstract class BrooklynCommand implements Callable<Void> {
@@ -163,7 +173,7 @@ public abstract class AbstractMain {
             if (log.isDebugEnabled()) log.debug("Invoked info command: {}", this);
             warnIfArguments();
 
-            System.out.println(BANNER);
+            System.out.println(banner);
             System.out.println("Version:  " + BrooklynVersion.get());
             if (BrooklynVersion.INSTANCE.isSnapshot()) {
                 System.out.println("Git SHA1: " + BrooklynVersion.INSTANCE.getSha1FromOsgiManifest());

--- a/usage/cli/src/main/java/brooklyn/cli/Main.java
+++ b/usage/cli/src/main/java/brooklyn/cli/Main.java
@@ -351,7 +351,7 @@ public class Main extends AbstractMain {
             try {
                 if (log.isDebugEnabled()) log.debug("Invoked launch command {}", this);
                 
-                if (!quiet) stdout.println(BANNER);
+                if (!quiet) stdout.println(banner);
     
                 if (verbose) {
                     if (app != null) {
@@ -773,7 +773,7 @@ public class Main extends AbstractMain {
             try {
                 log.info("Retrieving and copying persisted state to "+destinationDir+(Strings.isBlank(destinationLocation) ? "" : " @ "+destinationLocation));
                 
-                if (!quiet) stdout.println(BANNER);
+                if (!quiet) stdout.println(banner);
     
                 PersistMode persistMode = PersistMode.AUTO;
                 HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.DISABLED;
@@ -828,12 +828,6 @@ public class Main extends AbstractMain {
         }
     }
 
-    /** method intended for overriding when the script filename is different 
-     * @return the name of the script the user has invoked */
-    protected String cliScriptName() {
-        return "brooklyn";
-    }
-
     /** method intended for overriding when a different {@link Cli} is desired,
      * or when the subclass wishes to change any of the arguments */
     @SuppressWarnings("unchecked")
@@ -841,10 +835,10 @@ public class Main extends AbstractMain {
     protected CliBuilder<BrooklynCommand> cliBuilder() {
         CliBuilder<BrooklynCommand> builder = Cli.<BrooklynCommand>builder(cliScriptName())
                 .withDescription("Brooklyn Management Service")
-                .withDefaultCommand(DefaultInfoCommand.class)
+                .withDefaultCommand(cliDefaultInfoCommand())
                 .withCommands(
                         HelpCommand.class,
-                        InfoCommand.class,
+                        cliInfoCommand(),
                         GeneratePasswordCommand.class,
                         CopyStateCommand.class,
                         ListAllCommand.class,
@@ -876,5 +870,15 @@ public class Main extends AbstractMain {
     /** method intended for overriding when a custom {@link LaunchCommand} is being specified  */
     protected Class<? extends BrooklynCommand> cliLaunchCommand() {
         return LaunchCommand.class;
+    }
+    
+    /** method intended for overriding when a custom {@link InfoCommand} is being specified  */
+    protected Class<? extends BrooklynCommand> cliInfoCommand() {
+        return InfoCommand.class;
+    }
+    
+    /** method intended for overriding when a custom {@link InfoCommand} is being specified  */
+    protected Class<? extends BrooklynCommand> cliDefaultInfoCommand() {
+        return DefaultInfoCommand.class;
     }
 }


### PR DESCRIPTION
- Make ASCII art banner customisable
- Make info command customisable
- Make default-info command customisable (i.e. that displayed when no args supplied)
- Remove redundant duplicate Main.cliScriptName, as already declared in AbstractMain
- Adds tests