### PR TITLE
Mirroring entities should wait for a proper restart of remote

### DIFF
--- a/api/src/main/java/brooklyn/management/ha/HighAvailabilityManager.java
+++ b/api/src/main/java/brooklyn/management/ha/HighAvailabilityManager.java
@@ -44,7 +44,7 @@ public interface HighAvailabilityManager {
 
     ManagementNodeState getNodeState();
     
-    /** The time in milliseconds when the state was last changed */
+    /** The time in milliseconds when the state was last changed. -1 if no state transition has occurred yet.*/
     long getLastStateChange();
     
     /**

--- a/api/src/main/java/brooklyn/management/ha/HighAvailabilityManager.java
+++ b/api/src/main/java/brooklyn/management/ha/HighAvailabilityManager.java
@@ -44,6 +44,9 @@ public interface HighAvailabilityManager {
 
     ManagementNodeState getNodeState();
     
+    /** The time in milliseconds when the state was last changed */
+    long getLastStateChange();
+    
     /**
      * @param persister
      * @return self
@@ -128,5 +131,5 @@ public interface HighAvailabilityManager {
 
     /** Returns a collection of metrics */
     Map<String,Object> getMetrics();
-    
+
 }

--- a/core/src/main/java/brooklyn/management/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/brooklyn/management/ha/HighAvailabilityManagerImpl.java
@@ -1077,4 +1077,13 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         return result;
     }
     
+    @Override
+    public long getLastStateChange() {
+        if (nodeStateHistory.size() > 0) {
+            return (Long)nodeStateHistory.get(0).get("timestamp");
+        } else {
+            return 0;
+        }
+    }
+    
 }

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentManagementContext.java
@@ -603,5 +603,9 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
         public void publishClearNonMaster() {
             throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
         }
+        @Override
+        public long getLastStateChange() {
+            throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
+        }
     }
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -260,7 +260,10 @@ public interface SoftwareProcess extends Entity, Startable {
 
     @Beta
     public static class StopSoftwareParameters {
-        @Beta /** @since 0.7.0 semantics of parameters to restart being explored */
+        /** @since 0.7.0 semantics of parameters to restart being explored
+         *  @deprecated since 0.7.0 use  {@link #STOP_MACHINE_MODE} instead */
+        @Beta
+        @Deprecated
         public static final ConfigKey<Boolean> STOP_MACHINE = ConfigKeys.newBooleanConfigKey("stopMachine",
                 "Whether to stop the machine provisioned for this entity:  'true', or 'false' are supported, "
                         + "with the default being 'true'", true);

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -260,27 +260,33 @@ public interface SoftwareProcess extends Entity, Startable {
 
     @Beta
     public static class StopSoftwareParameters {
-        /** @since 0.7.0 semantics of parameters to restart being explored
-         *  @deprecated since 0.7.0 use  {@link #STOP_MACHINE_MODE} instead */
-        @Beta
-        @Deprecated
-        public static final ConfigKey<Boolean> STOP_MACHINE = ConfigKeys.newBooleanConfigKey("stopMachine",
-                "Whether to stop the machine provisioned for this entity:  'true', or 'false' are supported, "
-                        + "with the default being 'true'", true);
-
         //IF_NOT_STOPPED includes STARTING, STOPPING, RUNNING
         public enum StopMode { ALWAYS, IF_NOT_STOPPED, NEVER };
 
         @Beta /** @since 0.7.0 semantics of parameters to restart being explored */
         public static final ConfigKey<StopMode> STOP_PROCESS_MODE = ConfigKeys.newConfigKey(StopMode.class, "stopProcessMode",
-                "When to stop the process with regard to the entity state", StopMode.IF_NOT_STOPPED);
+                "When to stop the process with regard to the entity state" +
+                "ALWAYS will try to stop the process even if the entity is marked as stopped, " +
+                "IF_NOT_STOPPED stops the process only if the entity is not marked as stopped, " +
+                "NEVER doesn't stop the process.", StopMode.IF_NOT_STOPPED);
 
         @Beta /** @since 0.7.0 semantics of parameters to restart being explored */
         public static final ConfigKey<StopMode> STOP_MACHINE_MODE = ConfigKeys.newConfigKey(StopMode.class, "stopMachineMode",
                 "When to stop the machine with regard to the entity state. " +
-                "ALWAYS will try to stop the machine even if the entity is already stopped, " +
-                "IF_NOT_STOPPED stops the machine only if the entity is not already stopped, " +
+                "ALWAYS will try to stop the machine even if the entity is marked as stopped, " +
+                "IF_NOT_STOPPED stops the machine only if the entity is not marked as stopped, " +
                 "NEVER doesn't stop the machine.", StopMode.IF_NOT_STOPPED);
+
+        /** @since 0.7.0 semantics of parameters to restart being explored
+         *  @deprecated since 0.7.0 use  {@link #STOP_MACHINE_MODE} instead */
+        @Beta
+        @Deprecated
+        public static final ConfigKey<Boolean> STOP_MACHINE = ConfigKeys.newBooleanConfigKey("stopMachine",
+                "Whether to stop the machine provisioned for this entity:  'true', or 'false' are supported, " +
+                "with the default being 'true'." +
+                " 'true' is equivalent to " + STOP_MACHINE_MODE.getName() + " = " + StopMode.IF_NOT_STOPPED.name() + "." +
+                " 'false' is equivalent to " + STOP_MACHINE_MODE.getName() + " = " + StopMode.NEVER.name() + ".", true);
+
     }
     
     // NB: the START, STOP, and RESTART effectors themselves are (re)defined by MachineLifecycleEffectorTasks

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -60,6 +60,10 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
             return;
         }
         
+        DynamicTasks.queue("pre-restart", new Runnable() { public void run() {
+            preRestartCustom();
+        }});
+
         log.debug("restart of "+entity()+" appears to have driver and hostname - doing driver-level restart");
         entity().getDriver().restart();
         
@@ -67,6 +71,7 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
         
         DynamicTasks.queue("post-restart", new Runnable() { public void run() {
             postStartCustom();
+            postRestartCustom();
             ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
         }});
     }
@@ -173,6 +178,20 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
         super.preStopCustom();
         
         entity().preStop();
+    }
+
+    @Override
+    protected void preRestartCustom() {
+        super.preRestartCustom();
+        
+        entity().preRestart();
+    }
+
+    @Override
+    protected void postRestartCustom() {
+        super.postRestartCustom();
+        
+        entity().postRestart();
     }
 
     @Override

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -271,6 +271,12 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     protected void postStop() {
     }
 
+    protected void preRestart() {
+    }
+
+    protected void postRestart() {
+    }
+
     /**
      * For disconnecting from the running app. Will be called on stop.
      */

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -47,6 +47,7 @@ import brooklyn.entity.brooklynnode.effector.SetHighAvailabilityModeEffectorBody
 import brooklyn.entity.brooklynnode.effector.SetHighAvailabilityPriorityEffectorBody;
 import brooklyn.entity.effector.EffectorBody;
 import brooklyn.entity.effector.Effectors;
+import brooklyn.entity.software.MachineLifecycleEffectorTasks;
 import brooklyn.entity.trait.Startable;
 import brooklyn.event.feed.ConfigToAttributes;
 import brooklyn.event.feed.http.HttpFeed;
@@ -155,7 +156,18 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
     @Override
     protected void preStop() {
         super.preStop();
-        shutdownGracefully();
+        if (MachineLifecycleEffectorTasks.canStop(getStopProcessModeParam(), this)) {
+            shutdownGracefully();
+        }
+    }
+
+    private StopMode getStopProcessModeParam() {
+        ConfigBag parameters = BrooklynTaskTags.getCurrentEffectorParameters();
+        if (parameters != null) {
+            return parameters.get(StopSoftwareParameters.STOP_PROCESS_MODE);
+        } else {
+            return StopSoftwareParameters.STOP_PROCESS_MODE.getDefaultValue();
+        }
     }
 
     @Override

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -192,8 +192,7 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
     protected void postStop() {
         super.postStop();
         ConfigBag stopParameters = BrooklynTaskTags.getCurrentEffectorParameters();
-        //unmanage only if stopping the machine
-        if (stopParameters == null || stopParameters.get(StopSoftwareParameters.STOP_MACHINE)) {
+        if (isStopMachine(stopParameters)) {
             // Don't unmanage in entity's task context as it will self-cancel the task. Wait for the stop effector to complete.
             // If this is not enough (still getting Caused by: java.util.concurrent.CancellationException: null) then
             // we could search for the top most task with entity context == this and wait on it. Even stronger would be
@@ -201,6 +200,11 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
             Task<?> stopEffectorTask = BrooklynTaskTags.getClosestEffectorTask(Tasks.current(), Startable.STOP);
             getManagementContext().getExecutionManager().submit(new UnmanageTask(stopEffectorTask, this));
         }
+    }
+
+    private boolean isStopMachine(ConfigBag stopParameters) {
+        return stopParameters == null ||
+                stopParameters.get(StopSoftwareParameters.STOP_MACHINE_MODE) != StopMode.NEVER;
     }
 
     private void queueShutdownTask() {

--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/effector/BrooklynNodeUpgradeEffectorBody.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/effector/BrooklynNodeUpgradeEffectorBody.java
@@ -32,6 +32,7 @@ import brooklyn.entity.basic.EntityInternal;
 import brooklyn.entity.basic.EntityTasks;
 import brooklyn.entity.basic.SoftwareProcess;
 import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters;
+import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters.StopMode;
 import brooklyn.entity.brooklynnode.BrooklynCluster;
 import brooklyn.entity.brooklynnode.BrooklynNode;
 import brooklyn.entity.brooklynnode.BrooklynNodeDriver;
@@ -118,7 +119,7 @@ public class BrooklynNodeUpgradeEffectorBody extends EffectorBody<Void> {
         
         // Stop running instance
         DynamicTasks.queue(Tasks.builder().name("shutdown node")
-                .add(Effectors.invocation(entity(), BrooklynNode.STOP_NODE_BUT_LEAVE_APPS, ImmutableMap.of(StopSoftwareParameters.STOP_MACHINE, Boolean.FALSE)))
+                .add(Effectors.invocation(entity(), BrooklynNode.STOP_NODE_BUT_LEAVE_APPS, ImmutableMap.of(StopSoftwareParameters.STOP_MACHINE_MODE, StopMode.NEVER)))
                 .build());
 
         // backup old files
@@ -192,7 +193,7 @@ public class BrooklynNodeUpgradeEffectorBody extends EffectorBody<Void> {
 
         // 3 stop new version
         DynamicTasks.queue(Tasks.builder().name("shutdown transient node")
-            .add(Effectors.invocation(dryRunChild, BrooklynNode.STOP_NODE_BUT_LEAVE_APPS, ImmutableMap.of(StopSoftwareParameters.STOP_MACHINE, Boolean.FALSE)))
+            .add(Effectors.invocation(dryRunChild, BrooklynNode.STOP_NODE_BUT_LEAVE_APPS, ImmutableMap.of(StopSoftwareParameters.STOP_MACHINE_MODE, StopMode.NEVER)))
             .build());
 
         DynamicTasks.queue(Tasks.<Void>builder().name("remove transient node").body(

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -487,10 +487,10 @@ public abstract class MachineLifecycleEffectorTasks {
         } else {
             DynamicTasks.queue("stopping (machine)", new Callable<String>() { public String call() {
                 DynamicTasks.markInessential();
-                stop(ConfigBag.newInstance().configure(StopSoftwareParameters.STOP_MACHINE, true));
+                stop(ConfigBag.newInstance().configure(StopSoftwareParameters.STOP_MACHINE_MODE, StopMode.IF_NOT_STOPPED));
                 DynamicTasks.waitForLast();
                 return "Stop of machine completed with no errors.";
-            }});            
+            }});
         }
 
         DynamicTasks.queue("starting", new Runnable() { public void run() {
@@ -541,7 +541,9 @@ public abstract class MachineLifecycleEffectorTasks {
 
         log.info("Stopping {} in {}", entity(), entity().getLocations());
 
+        @SuppressWarnings("deprecation")
         final boolean hasStopMachine = parameters.containsKey(StopSoftwareParameters.STOP_MACHINE);
+        @SuppressWarnings("deprecation")
         final Boolean isStopMachine = parameters.get(StopSoftwareParameters.STOP_MACHINE);
 
         final StopMode stopProcessMode = parameters.get(StopSoftwareParameters.STOP_PROCESS_MODE);

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -477,6 +477,13 @@ public abstract class MachineLifecycleEffectorTasks {
         if (isRestartMachine==RestartMachineMode.AUTO) 
             isRestartMachine = getDefaultRestartStopsMachine() ? RestartMachineMode.TRUE : RestartMachineMode.FALSE; 
 
+        DynamicTasks.queue("pre-restart", new Runnable() { public void run() {
+            //Calling preStopCustom without a corresponding postStopCustom invocation
+            //doesn't look right so use a separate callback pair; Also depending on the arguments
+            //stop() could be called which will call the {pre,post}StopCustom on its own.
+            preRestartCustom();
+        }});
+
         if (isRestartMachine==RestartMachineMode.FALSE) {
             DynamicTasks.queue("stopping (process)", new Callable<String>() { public String call() {
                 DynamicTasks.markInessential();
@@ -501,6 +508,10 @@ public abstract class MachineLifecycleEffectorTasks {
         }});
         
         restartChildren(parameters);
+
+        DynamicTasks.queue("post-restart", new Runnable() { public void run() {
+            postRestartCustom();
+        }});
 
         DynamicTasks.waitForLast();
         ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
@@ -670,6 +681,14 @@ public abstract class MachineLifecycleEffectorTasks {
     }
 
     protected void postStopCustom() {
+        // nothing needed here
+    }
+
+    protected void preRestartCustom() {
+        // nothing needed here
+    }
+
+    protected void postRestartCustom() {
         // nothing needed here
     }
 

--- a/software/base/src/test/java/brooklyn/entity/brooklynnode/MockBrooklynNode.java
+++ b/software/base/src/test/java/brooklyn/entity/brooklynnode/MockBrooklynNode.java
@@ -23,8 +23,6 @@ import java.util.Collection;
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.basic.AbstractEntity;
 import brooklyn.entity.basic.ConfigKeys;
-import brooklyn.entity.brooklynnode.BrooklynNode;
-import brooklyn.entity.brooklynnode.EntityHttpClient;
 import brooklyn.entity.brooklynnode.CallbackEntityHttpClient.Request;
 import brooklyn.entity.brooklynnode.effector.SetHighAvailabilityModeEffectorBody;
 import brooklyn.entity.brooklynnode.effector.SetHighAvailabilityPriorityEffectorBody;

--- a/software/base/src/test/java/brooklyn/entity/software/MachineLifecycleEffectorTasksTest.java
+++ b/software/base/src/test/java/brooklyn/entity/software/MachineLifecycleEffectorTasksTest.java
@@ -23,11 +23,17 @@ import static org.testng.Assert.assertEquals;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import brooklyn.entity.basic.BasicEntityImpl;
+import brooklyn.entity.basic.Lifecycle;
+import brooklyn.entity.basic.SoftwareProcess;
 import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters.StopMode;
 
 public class MachineLifecycleEffectorTasksTest {
     public static boolean canStop(StopMode stopMode, boolean isEntityStopped) {
-        return MachineLifecycleEffectorTasks.canStop(stopMode, isEntityStopped);
+        BasicEntityImpl entity = new BasicEntityImpl();
+        Lifecycle state = isEntityStopped ? Lifecycle.STOPPED : Lifecycle.RUNNING;
+        entity.setAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL, state);
+        return MachineLifecycleEffectorTasks.canStop(stopMode, entity);
     }
     
     @DataProvider(name = "canStopStates")

--- a/usage/jsgui/src/main/webapp/assets/js/router.js
+++ b/usage/jsgui/src/main/webapp/assets/js/router.js
@@ -89,7 +89,7 @@ define([
         homePage:function (trail) {
             var that = this;
             // render the page after we fetch the collection -- no rendering on error
-            this.applications.fetch({success:function () {
+            function render() {
                 var homeView = new HomeView({
                     collection:that.applications,
                     locations:that.locations,
@@ -97,6 +97,9 @@ define([
                 });
                 var veryFirstViewLoad = !that.currentView;
                 that.showView("#application-content", homeView);
+            }
+            this.applications.fetch({success:function () {
+                render();
                 // show add application wizard if none already exist and this is the first page load
                 if ((veryFirstViewLoad && trail=='auto' && that.applications.isEmpty()) ||
                      (trail=='add_application') ) {
@@ -106,7 +109,7 @@ define([
                         }
                     });
                 }
-            }})
+            }, error: render});
         },
         applicationsPage:function (app, trail, tab) {
             if (trail === undefined) trail = app

--- a/usage/jsgui/src/test/java/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncherTest.java
+++ b/usage/jsgui/src/test/java/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncherTest.java
@@ -64,12 +64,7 @@ public class BrooklynJavascriptGuiLauncherTest {
     protected void checkUrlContains(final String path, final String text) {
         //Server may return 403 until it loads completely, wait a bit
         //until it stabilizes.
-        Asserts.succeedsEventually(new Runnable() {
-            @Override
-            public void run() {
-                HttpTestUtils.assertContentContainsText(rootUrl()+path, text);
-            }
-        });
+        HttpTestUtils.assertContentEventuallyContainsText(rootUrl()+path, text);
     }
 
     protected void checkEventuallyHealthy() {

--- a/usage/jsgui/src/test/java/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncherTest.java
+++ b/usage/jsgui/src/test/java/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncherTest.java
@@ -27,6 +27,7 @@ import brooklyn.config.BrooklynServiceAttributes;
 import brooklyn.entity.basic.Entities;
 import brooklyn.management.ManagementContext;
 import brooklyn.rest.BrooklynRestApiLauncherTestFixture;
+import brooklyn.test.Asserts;
 import brooklyn.test.HttpTestUtils;
 
 /** Convenience and demo for launching programmatically. */
@@ -60,8 +61,15 @@ public class BrooklynJavascriptGuiLauncherTest {
         checkUrlContains("/v1/catalog/entities", "Tomcat");
     }
 
-    protected void checkUrlContains(String path, String text) {
-        HttpTestUtils.assertContentContainsText(rootUrl()+path, text);
+    protected void checkUrlContains(final String path, final String text) {
+        //Server may return 403 until it loads completely, wait a bit
+        //until it stabilizes.
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                HttpTestUtils.assertContentContainsText(rootUrl()+path, text);
+            }
+        });
     }
 
     protected void checkEventuallyHealthy() {

--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
@@ -321,6 +321,8 @@ public class BrooklynWebServer {
         // Accept gzipped requests and responses, disable caching for dynamic content
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_REQUEST_FILTERS, GZIPContentEncodingFilter.class.getName());
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS, ImmutableList.of(GZIPContentEncodingFilter.class, NoCacheFilter.class));
+        // Checks if appropriate request given HA status
+        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, brooklyn.rest.filter.HaStateCheckResourceFilter.class.getName());
         // configure to match empty path, or any thing which looks like a file path with /assets/ and extension html, css, js, or png
         // and treat that as static content
         config.getProperties().put(ServletContainer.PROPERTY_WEB_PAGE_CONTENT_REGEX, "(/?|[^?]*/assets/[^?]+\\.[A-Za-z0-9_]+)");

--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
@@ -60,9 +60,11 @@ import brooklyn.rest.BrooklynRestApi;
 import brooklyn.rest.BrooklynWebConfig;
 import brooklyn.rest.filter.BrooklynPropertiesSecurityFilter;
 import brooklyn.rest.filter.HaMasterCheckFilter;
+import brooklyn.rest.filter.HaStateCheckResourceFilter;
 import brooklyn.rest.filter.LoggingFilter;
 import brooklyn.rest.filter.NoCacheFilter;
 import brooklyn.rest.filter.RequestTaggingFilter;
+import brooklyn.rest.util.ManagementContextProvider;
 import brooklyn.util.BrooklynNetworkUtils;
 import brooklyn.util.ResourceUtils;
 import brooklyn.util.collections.MutableMap;
@@ -322,7 +324,7 @@ public class BrooklynWebServer {
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_REQUEST_FILTERS, GZIPContentEncodingFilter.class.getName());
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS, ImmutableList.of(GZIPContentEncodingFilter.class, NoCacheFilter.class));
         // Checks if appropriate request given HA status
-        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, brooklyn.rest.filter.HaStateCheckResourceFilter.class.getName());
+        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, HaStateCheckResourceFilter.class.getName());
         // configure to match empty path, or any thing which looks like a file path with /assets/ and extension html, css, js, or png
         // and treat that as static content
         config.getProperties().put(ServletContainer.PROPERTY_WEB_PAGE_CONTENT_REGEX, "(/?|[^?]*/assets/[^?]+\\.[A-Za-z0-9_]+)");
@@ -332,6 +334,9 @@ public class BrooklynWebServer {
         FilterHolder filterHolder = new FilterHolder(new ServletContainer(config));
 
         context.addFilter(filterHolder, "/*", EnumSet.allOf(DispatcherType.class));
+
+        ManagementContext mgmt = (ManagementContext) context.getAttribute(BrooklynServiceAttributes.BROOKLYN_MANAGEMENT_CONTEXT);
+        config.getSingletons().add(new ManagementContextProvider(mgmt));
     }
 
     ContextHandlerCollectionHotSwappable handlers = new ContextHandlerCollectionHotSwappable();

--- a/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
+++ b/usage/launcher/src/main/java/brooklyn/launcher/BrooklynWebServer.java
@@ -60,7 +60,7 @@ import brooklyn.rest.BrooklynRestApi;
 import brooklyn.rest.BrooklynWebConfig;
 import brooklyn.rest.filter.BrooklynPropertiesSecurityFilter;
 import brooklyn.rest.filter.HaMasterCheckFilter;
-import brooklyn.rest.filter.HaStateCheckResourceFilter;
+import brooklyn.rest.filter.HaHotCheckResourceFilter;
 import brooklyn.rest.filter.LoggingFilter;
 import brooklyn.rest.filter.NoCacheFilter;
 import brooklyn.rest.filter.RequestTaggingFilter;
@@ -324,7 +324,7 @@ public class BrooklynWebServer {
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_REQUEST_FILTERS, GZIPContentEncodingFilter.class.getName());
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS, ImmutableList.of(GZIPContentEncodingFilter.class, NoCacheFilter.class));
         // Checks if appropriate request given HA status
-        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, HaStateCheckResourceFilter.class.getName());
+        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, HaHotCheckResourceFilter.class.getName());
         // configure to match empty path, or any thing which looks like a file path with /assets/ and extension html, css, js, or png
         // and treat that as static content
         config.getProperties().put(ServletContainer.PROPERTY_WEB_PAGE_CONTENT_REGEX, "(/?|[^?]*/assets/[^?]+\\.[A-Za-z0-9_]+)");

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotCheckResourceFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotCheckResourceFilter.java
@@ -40,7 +40,7 @@ import com.sun.jersey.spi.container.ContainerResponseFilter;
 import com.sun.jersey.spi.container.ResourceFilter;
 import com.sun.jersey.spi.container.ResourceFilterFactory;
 
-public class HaStateCheckResourceFilter implements ResourceFilterFactory {
+public class HaHotCheckResourceFilter implements ResourceFilterFactory {
     private static final Set<ManagementNodeState> HOT_STATES = ImmutableSet.of(
             ManagementNodeState.MASTER, ManagementNodeState.HOT_STANDBY, ManagementNodeState.HOT_BACKUP);
     private static final long STATE_CHANGE_SETTLE_OFFSET = Duration.seconds(10).toMilliseconds();

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotCheckResourceFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotCheckResourceFilter.java
@@ -81,7 +81,7 @@ public class HaHotCheckResourceFilter implements ResourceFilterFactory {
         }
 
         private boolean isStateLoaded() {
-            return isHaHotStatus() && !RebindTracker.isRebinding() && !recentlySwitchedState();
+            return isHaHotStatusOrDisabled() && !RebindTracker.isRebinding() && !recentlySwitchedState();
         }
 
         // Ideally there will be a separate state to indicate that we switched state
@@ -99,7 +99,8 @@ public class HaHotCheckResourceFilter implements ResourceFilterFactory {
                     am.getResource().getAnnotation(HaHotStateRequired.class) != null);
         }
 
-        private boolean isHaHotStatus() {
+        private boolean isHaHotStatusOrDisabled() {
+            if (!mgmt.getHighAvailabilityManager().isRunning()) return true;
             ManagementNodeState state = mgmt.getHighAvailabilityManager().getNodeState();
             return HOT_STATES.contains(state);
         }

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotCheckResourceFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotCheckResourceFilter.java
@@ -89,6 +89,7 @@ public class HaHotCheckResourceFilter implements ResourceFilterFactory {
         // and starting rebind so add a time offset just to be sure.
         private boolean recentlySwitchedState() {
             long lastStateChange = mgmt.getHighAvailabilityManager().getLastStateChange();
+            if (lastStateChange == -1) return false;
             return System.currentTimeMillis() - lastStateChange < STATE_CHANGE_SETTLE_OFFSET;
         }
 

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotStateRequired.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotStateRequired.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface HaHotStateRequired {}

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotStateRequired.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaHotStateRequired.java
@@ -23,6 +23,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * When a REST method (or its containing class) is marked with this annotation
+ * requests to it will fail with a 403 response if the instance is not in MASTER
+ * mode (or has recently switched or is still rebinding). Guards the method so
+ * that when it returns the caller can be certain of the response. For example
+ * if the response is 404, then the resource doesn't exist as opposed to
+ * not being loaded from persistence store yet.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface HaHotStateRequired {}

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaMasterCheckFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaMasterCheckFilter.java
@@ -42,7 +42,7 @@ import brooklyn.management.ha.ManagementNodeState;
  */
 public class HaMasterCheckFilter implements Filter {
 
-    private static final String SKIP_CHECK_HEADER = "Brooklyn-Allow-Non-Master-Access";
+    protected static final String SKIP_CHECK_HEADER = "Brooklyn-Allow-Non-Master-Access";
     private static final Set<String> SAFE_STANDBY_METHODS = Sets.newHashSet("GET", "HEAD");
 
     protected ManagementContext mgmt;

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaMasterCheckFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaMasterCheckFilter.java
@@ -42,7 +42,7 @@ import brooklyn.management.ha.ManagementNodeState;
  */
 public class HaMasterCheckFilter implements Filter {
 
-    protected static final String SKIP_CHECK_HEADER = "Brooklyn-Allow-Non-Master-Access";
+    public static final String SKIP_CHECK_HEADER = "Brooklyn-Allow-Non-Master-Access";
     private static final Set<String> SAFE_STANDBY_METHODS = Sets.newHashSet("GET", "HEAD");
 
     protected ManagementContext mgmt;

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaStateCheckResourceFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaStateCheckResourceFilter.java
@@ -22,13 +22,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import javax.servlet.ServletContext;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import brooklyn.config.BrooklynServiceAttributes;
 import brooklyn.entity.rebind.RebindManagerImpl.RebindTracker;
 import brooklyn.management.ManagementContext;
 import brooklyn.management.ha.ManagementNodeState;
@@ -110,7 +108,6 @@ public class HaStateCheckResourceFilter implements ResourceFilterFactory {
 
     @Override
     public List<ResourceFilter> create(AbstractMethod am) {
-        ManagementContext mgmt = (ManagementContext)servletContext.getAttribute(BrooklynServiceAttributes.BROOKLYN_MANAGEMENT_CONTEXT);
         return Collections.<ResourceFilter>singletonList(new MethodFilter(am, mgmt));
     }
 

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/HaStateCheckResourceFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/HaStateCheckResourceFilter.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.filter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import brooklyn.config.BrooklynServiceAttributes;
+import brooklyn.management.ManagementContext;
+import brooklyn.management.ha.ManagementNodeState;
+
+import com.google.common.collect.ImmutableSet;
+import com.sun.jersey.api.model.AbstractMethod;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerRequestFilter;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+import com.sun.jersey.spi.container.ResourceFilter;
+import com.sun.jersey.spi.container.ResourceFilterFactory;
+
+public class HaStateCheckResourceFilter implements ResourceFilterFactory {
+    private static final Set<ManagementNodeState> HOT_STATES = ImmutableSet.of(
+            ManagementNodeState.MASTER, ManagementNodeState.HOT_STANDBY, ManagementNodeState.HOT_BACKUP);
+
+    @Context
+    private ServletContext servletContext;
+
+    private static class MethodFilter implements ResourceFilter, ContainerRequestFilter {
+        private AbstractMethod am;
+        private ManagementContext mgmt;
+
+        public MethodFilter(AbstractMethod am, ManagementContext mgmt) {
+            this.am = am;
+            this.mgmt = mgmt;
+        }
+
+        @Override
+        public ContainerRequestFilter getRequestFilter() {
+            return this;
+        }
+
+        @Override
+        public ContainerResponseFilter getResponseFilter() {
+            return null;
+        }
+
+        @Override
+        public ContainerRequest filter(ContainerRequest request) {
+            boolean isHot = isHaHotStatus();
+            boolean isOverriden = "true".equalsIgnoreCase(request.getHeaderValue(HaMasterCheckFilter.SKIP_CHECK_HEADER));
+            if (!isHot && !isOverriden &&
+                    (am.getAnnotation(HaHotStateRequired.class) != null ||
+                    am.getResource().getAnnotation(HaHotStateRequired.class) != null)) {
+                Response response = Response.status(Response.Status.FORBIDDEN)
+                        .type(MediaType.APPLICATION_JSON)
+                        .entity("{\"error\":403,\"message\":\"Requests should be made to the master Brooklyn server\"}")
+                        .build();
+                throw new WebApplicationException(response);
+            }
+            return request;
+        }
+
+        private boolean isHaHotStatus() {
+            ManagementNodeState state = mgmt.getHighAvailabilityManager().getNodeState();
+            return HOT_STATES.contains(state);
+        }
+
+    }
+
+    @Override
+    public List<ResourceFilter> create(AbstractMethod am) {
+        ManagementContext mgmt = (ManagementContext)servletContext.getAttribute(BrooklynServiceAttributes.BROOKLYN_MANAGEMENT_CONTEXT);
+        return Collections.<ResourceFilter>singletonList(new MethodFilter(am, mgmt));
+    }
+
+}

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/ApplicationResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/ApplicationResource.java
@@ -69,6 +69,7 @@ import brooklyn.rest.domain.ApplicationSummary;
 import brooklyn.rest.domain.EntitySpec;
 import brooklyn.rest.domain.EntitySummary;
 import brooklyn.rest.domain.TaskSummary;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.ApplicationTransformer;
 import brooklyn.rest.transform.EntityTransformer;
 import brooklyn.rest.transform.TaskTransformer;
@@ -82,6 +83,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 
+@HaHotStateRequired
 public class ApplicationResource extends AbstractBrooklynRestResource implements ApplicationApi {
 
     private static final Logger log = LoggerFactory.getLogger(ApplicationResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/CatalogResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/CatalogResource.java
@@ -51,6 +51,7 @@ import brooklyn.rest.api.CatalogApi;
 import brooklyn.rest.domain.ApiError;
 import brooklyn.rest.domain.CatalogEntitySummary;
 import brooklyn.rest.domain.CatalogItemSummary;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.CatalogTransformer;
 import brooklyn.rest.util.WebResourceUtils;
 import brooklyn.util.ResourceUtils;
@@ -70,6 +71,7 @@ import com.google.common.io.Files;
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.wordnik.swagger.core.ApiParam;
 
+@HaHotStateRequired
 public class CatalogResource extends AbstractBrooklynRestResource implements CatalogApi {
 
     private static final Logger log = LoggerFactory.getLogger(CatalogResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/EffectorResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/EffectorResource.java
@@ -42,6 +42,7 @@ import brooklyn.management.internal.EffectorUtils;
 import brooklyn.rest.api.EffectorApi;
 import brooklyn.rest.domain.EffectorSummary;
 import brooklyn.rest.domain.SummaryComparators;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.EffectorTransformer;
 import brooklyn.rest.transform.TaskTransformer;
 import brooklyn.rest.util.WebResourceUtils;
@@ -49,6 +50,7 @@ import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.guava.Maybe;
 import brooklyn.util.time.Time;
 
+@HaHotStateRequired
 public class EffectorResource extends AbstractBrooklynRestResource implements EffectorApi {
 
     private static final Logger log = LoggerFactory.getLogger(EffectorResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/EntityConfigResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/EntityConfigResource.java
@@ -36,6 +36,7 @@ import brooklyn.event.basic.BasicConfigKey;
 import brooklyn.management.entitlement.Entitlements;
 import brooklyn.rest.api.EntityConfigApi;
 import brooklyn.rest.domain.EntityConfigSummary;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.EntityTransformer;
 import brooklyn.rest.util.WebResourceUtils;
 import brooklyn.util.flags.TypeCoercions;
@@ -46,6 +47,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+@HaHotStateRequired
 public class EntityConfigResource extends AbstractBrooklynRestResource implements EntityConfigApi {
 
     private static final Logger LOG = LoggerFactory.getLogger(EntityConfigResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/EntityResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/EntityResource.java
@@ -53,6 +53,7 @@ import brooklyn.rest.api.EntityApi;
 import brooklyn.rest.domain.EntitySummary;
 import brooklyn.rest.domain.LocationSummary;
 import brooklyn.rest.domain.TaskSummary;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.EntityTransformer;
 import brooklyn.rest.transform.LocationTransformer;
 import brooklyn.rest.transform.LocationTransformer.LocationDetailLevel;
@@ -68,6 +69,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
+@HaHotStateRequired
 public class EntityResource extends AbstractBrooklynRestResource implements EntityApi {
 
     private static final Logger log = LoggerFactory.getLogger(EntityResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/LocationResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/LocationResource.java
@@ -37,6 +37,7 @@ import brooklyn.rest.api.LocationApi;
 import brooklyn.rest.domain.LocationSpec;
 import brooklyn.rest.domain.LocationSummary;
 import brooklyn.rest.domain.SummaryComparators;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.LocationTransformer;
 import brooklyn.rest.transform.LocationTransformer.LocationDetailLevel;
 import brooklyn.rest.util.EntityLocationUtils;
@@ -50,6 +51,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
+@HaHotStateRequired
 public class LocationResource extends AbstractBrooklynRestResource implements LocationApi {
 
     private static final Logger log = LoggerFactory.getLogger(LocationResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/PolicyConfigResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/PolicyConfigResource.java
@@ -31,6 +31,7 @@ import brooklyn.management.entitlement.Entitlements;
 import brooklyn.policy.Policy;
 import brooklyn.rest.api.PolicyConfigApi;
 import brooklyn.rest.domain.PolicyConfigSummary;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.PolicyTransformer;
 import brooklyn.rest.util.BrooklynRestResourceUtils;
 import brooklyn.rest.util.WebResourceUtils;
@@ -39,6 +40,7 @@ import brooklyn.util.flags.TypeCoercions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+@HaHotStateRequired
 public class PolicyConfigResource extends AbstractBrooklynRestResource implements PolicyConfigApi {
 
     @Override

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/PolicyResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/PolicyResource.java
@@ -35,6 +35,7 @@ import brooklyn.rest.api.PolicyApi;
 import brooklyn.rest.domain.PolicySummary;
 import brooklyn.rest.domain.Status;
 import brooklyn.rest.domain.SummaryComparators;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.ApplicationTransformer;
 import brooklyn.rest.transform.PolicyTransformer;
 import brooklyn.rest.util.WebResourceUtils;
@@ -44,6 +45,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
 
+@HaHotStateRequired
 public class PolicyResource extends AbstractBrooklynRestResource implements PolicyApi {
 
     private static final Logger log = LoggerFactory.getLogger(PolicyResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/SensorResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/SensorResource.java
@@ -36,6 +36,7 @@ import brooklyn.event.basic.BasicAttributeSensor;
 import brooklyn.management.entitlement.Entitlements;
 import brooklyn.rest.api.SensorApi;
 import brooklyn.rest.domain.SensorSummary;
+import brooklyn.rest.filter.HaHotStateRequired;
 import brooklyn.rest.transform.SensorTransformer;
 import brooklyn.rest.util.WebResourceUtils;
 import brooklyn.util.text.Strings;
@@ -44,6 +45,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+@HaHotStateRequired
 public class SensorResource extends AbstractBrooklynRestResource implements SensorApi {
 
     private static final Logger log = LoggerFactory.getLogger(SensorResource.class);

--- a/usage/rest-server/src/main/java/brooklyn/rest/util/ManagementContextProvider.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/util/ManagementContextProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.util;
+
+import javax.ws.rs.core.Context;
+
+import brooklyn.management.ManagementContext;
+
+import com.sun.jersey.spi.inject.SingletonTypeInjectableProvider;
+
+public class ManagementContextProvider extends SingletonTypeInjectableProvider<Context, ManagementContext> {
+
+    public ManagementContextProvider(ManagementContext instance) {
+        super(ManagementContext.class, instance);
+    }
+
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -329,6 +329,8 @@ public class BrooklynRestApiLauncher {
 
         // disable caching for dynamic content
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS, NoCacheFilter.class.getName());
+        // Checks if appropriate request given HA status
+        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, brooklyn.rest.filter.HaStateCheckResourceFilter.class.getName());
         // configure to match empty path, or any thing which looks like a file path with /assets/ and extension html, css, js, or png
         // and treat that as static content
         config.getProperties().put(ServletContainer.PROPERTY_WEB_PAGE_CONTENT_REGEX, "(/?|[^?]*/assets/[^?]+\\.[A-Za-z0-9_]+)");

--- a/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -54,6 +54,7 @@ import brooklyn.rest.filter.NoCacheFilter;
 import brooklyn.rest.filter.RequestTaggingFilter;
 import brooklyn.rest.security.provider.AnyoneSecurityProvider;
 import brooklyn.rest.security.provider.SecurityProvider;
+import brooklyn.rest.util.ManagementContextProvider;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.net.Networking;
 import brooklyn.util.text.WildcardGlobs;
@@ -339,6 +340,9 @@ public class BrooklynRestApiLauncher {
         // finally create this as a _filter_ which falls through to a web app or something (optionally)
         FilterHolder filterHolder = new FilterHolder(new ServletContainer(config));
         context.addFilter(filterHolder, "/*", EnumSet.allOf(DispatcherType.class));
+
+        ManagementContext mgmt = (ManagementContext) context.getAttribute(BrooklynServiceAttributes.BROOKLYN_MANAGEMENT_CONTEXT);
+        config.getSingletons().add(new ManagementContextProvider(mgmt));
     }
 
     private static void installBrooklynFilters(ServletContextHandler context, List<Class<? extends Filter>> filters) {

--- a/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -152,7 +152,7 @@ public class BrooklynRestApiLauncher {
         this.deployJsgui = false;
         return this;
     }
-    
+
     public BrooklynRestApiLauncher disableHighAvailability(boolean value) {
         this.disableHighAvailability = value;
         return this;

--- a/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -104,6 +104,7 @@ public class BrooklynRestApiLauncher {
     private ManagementContext mgmt;
     private ContextHandler customContext;
     private boolean deployJsgui = true;
+    private boolean disableHighAvailability = true;
 
     protected BrooklynRestApiLauncher() {}
 
@@ -149,6 +150,11 @@ public class BrooklynRestApiLauncher {
 
     public BrooklynRestApiLauncher withoutJsgui() {
         this.deployJsgui = false;
+        return this;
+    }
+    
+    public BrooklynRestApiLauncher disableHighAvailability(boolean value) {
+        this.disableHighAvailability = value;
         return this;
     }
 
@@ -198,7 +204,7 @@ public class BrooklynRestApiLauncher {
             ((LocalManagementContext) mgmt).setBaseClassPathForScanning(ClasspathHelper.forJavaClassPath());
         }
 
-        return startServer(mgmt, context, summary);
+        return startServer(mgmt, context, summary, disableHighAvailability);
     }
 
     private ContextHandler filterContextHandler(ManagementContext mgmt) {
@@ -254,7 +260,7 @@ public class BrooklynRestApiLauncher {
 
     /** starts a server, on all NICs if security is configured,
      * otherwise (no security) only on loopback interface */
-    public static Server startServer(ManagementContext mgmt, ContextHandler context, String summary) {
+    public static Server startServer(ManagementContext mgmt, ContextHandler context, String summary, boolean disableHighAvailability) {
         // TODO this repeats code in BrooklynLauncher / WebServer. should merge the two paths.
         boolean secure = mgmt != null && !BrooklynWebConfig.hasNoSecurityOptions(mgmt.getConfig());
         if (secure) {
@@ -266,7 +272,7 @@ public class BrooklynRestApiLauncher {
                 ((BrooklynProperties)mgmt.getConfig()).put(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME, AnyoneSecurityProvider.class.getName());
             }
         }
-        if (mgmt != null)
+        if (mgmt != null && disableHighAvailability)
             mgmt.getHighAvailabilityManager().disabled();
         InetSocketAddress bindLocation = new InetSocketAddress(
                 secure ? Networking.ANY_NIC : Networking.LOOPBACK,

--- a/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -331,7 +331,7 @@ public class BrooklynRestApiLauncher {
         // disable caching for dynamic content
         config.getProperties().put(ResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS, NoCacheFilter.class.getName());
         // Checks if appropriate request given HA status
-        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, brooklyn.rest.filter.HaStateCheckResourceFilter.class.getName());
+        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, brooklyn.rest.filter.HaHotCheckResourceFilter.class.getName());
         // configure to match empty path, or any thing which looks like a file path with /assets/ and extension html, css, js, or png
         // and treat that as static content
         config.getProperties().put(ServletContainer.PROPERTY_WEB_PAGE_CONTENT_REGEX, "(/?|[^?]*/assets/[^?]+\\.[A-Za-z0-9_]+)");

--- a/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
@@ -22,6 +22,9 @@ import static org.testng.Assert.assertEquals;
 
 import javax.ws.rs.core.MediaType;
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -43,11 +46,22 @@ public class HaHotCheckTest extends BrooklynRestResourceTest {
 
     private ManagementContextMock mgmtMock;
 
-    @Override
+    //Treat before/after class methods as before/after method
+    //otherwise they should be static.
+    @BeforeClass(alwaysRun=true)
+    public void setUpClass() {}
+    @AfterClass(alwaysRun=true)
+    public void tearDownClass() {}
+
     @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
         mgmtMock = new ManagementContextMock();
         super.setUp();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        super.tearDown();
     }
 
     @Override

--- a/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
@@ -70,6 +70,14 @@ public class HaHotCheckTest extends BrooklynRestResourceTest {
         testResourceFetch("/ha/method/ok", 200);
         testResourceFetch("/ha/method/fail", 403);
         testResourceFetch("/ha/class/fail", 403);
+
+        //forces isRunning = false
+        mgmtMock.setState(ManagementNodeState.TERMINATED);
+        assertEquals(ha.getNodeState(), ManagementNodeState.TERMINATED);
+
+        testResourceFetch("/ha/method/ok", 200);
+        testResourceFetch("/ha/method/fail", 200);
+        testResourceFetch("/ha/class/fail", 200);
     }
 
     private void testResourceFetch(String resource, int code) {

--- a/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.rest.resources;
+package brooklyn.rest;
 
 import static org.testng.Assert.assertEquals;
 
@@ -57,7 +57,7 @@ public class HaHotCheckTest extends BrooklynRestResourceTest {
     }
 
     @Test
-    public void testHaCheck() throws Exception {
+    public void testHaCheck() {
         HighAvailabilityManager ha = mgmtMock.getHighAvailabilityManager();
         assertEquals(ha.getNodeState(), ManagementNodeState.MASTER);
         testResourceFetch("/ha/method/ok", 200);

--- a/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/HaHotCheckTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertEquals;
 import javax.ws.rs.core.MediaType;
 
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -46,22 +45,22 @@ public class HaHotCheckTest extends BrooklynRestResourceTest {
 
     private ManagementContextMock mgmtMock;
 
-    //Treat before/after class methods as before/after method
-    //otherwise they should be static.
-    @BeforeClass(alwaysRun=true)
-    public void setUpClass() {}
-    @AfterClass(alwaysRun=true)
-    public void tearDownClass() {}
-
-    @BeforeMethod(alwaysRun = true)
+    @Override
+    @BeforeClass(alwaysRun = true)
     public void setUp() throws Exception {
         mgmtMock = new ManagementContextMock();
         super.setUp();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @Override
+    @AfterClass(alwaysRun = true)
     public void tearDown() throws Exception {
         super.tearDown();
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUpMethod() {
+        mgmtMock.setState(ManagementNodeState.MASTER);
     }
 
     @Override

--- a/usage/rest-server/src/test/java/brooklyn/rest/HaMasterCheckFilterTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/HaMasterCheckFilterTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import io.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
+
+import java.io.File;
+import java.net.URI;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.http.client.HttpClient;
+import org.eclipse.jetty.server.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.BasicApplication;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.entity.rebind.RebindTestUtils;
+import brooklyn.management.EntityManager;
+import brooklyn.management.ManagementContext;
+import brooklyn.management.ha.HighAvailabilityMode;
+import brooklyn.management.ha.ManagementNodeState;
+import brooklyn.rest.security.provider.AnyoneSecurityProvider;
+import brooklyn.test.Asserts;
+import brooklyn.util.http.HttpTool;
+import brooklyn.util.http.HttpToolResponse;
+import brooklyn.util.os.Os;
+import brooklyn.util.time.Duration;
+
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+
+public class HaMasterCheckFilterTest extends BrooklynRestApiLauncherTestFixture {
+    private static final Logger LOG = LoggerFactory.getLogger(HaMasterCheckFilterTest.class);
+    private static final Duration TIMEOUT = Duration.THIRTY_SECONDS;
+
+    private File mementoDir;
+    private ManagementContext writeMgmt;
+    private ManagementContext readMgmt;
+    private String appId;
+    private Server server;
+    private HttpClient client;
+
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        server.stop();
+        Entities.destroyAll(writeMgmt);
+        Entities.destroyAll(readMgmt);
+        Os.deleteRecursively(mementoDir);
+    }
+
+    @Test(groups = "Integration")
+    public void testEntitiesExistOnMasterPromotion() throws Exception {
+        initHaCluster(HighAvailabilityMode.AUTO, HighAvailabilityMode.AUTO);
+        stopWriteNode();
+        assertEntityExists(new ReturnCodeCheck());
+        assertReadIsMaster();
+    }
+
+    @Test(groups = "Integration")
+    public void testEntitiesExistOnHotStandbyAndPromotion() throws Exception {
+        initHaCluster(HighAvailabilityMode.AUTO, HighAvailabilityMode.HOT_STANDBY);
+        assertEntityExists(new ReturnCodeCheck());
+        stopWriteNode();
+        assertEntityExists(new ReturnCodeAndNodeState());
+        assertReadIsMaster();
+    }
+
+    @Test(groups = "Integration")
+    public void testEntitiesExistOnHotBackup() throws Exception {
+        initHaCluster(HighAvailabilityMode.AUTO, HighAvailabilityMode.HOT_BACKUP);
+        Asserts.continually(
+                ImmutableMap.<String,Object>of(
+                        "timeout", Duration.THIRTY_SECONDS,
+                        "period", Duration.ZERO),
+                new ReturnCodeSupplier(),
+                Predicates.or(Predicates.equalTo(200), Predicates.equalTo(403)));
+    }
+
+    private HttpClient getClient(Server server) {
+        HttpClient client = HttpTool.httpClientBuilder()
+                .uri(getBaseUri(server))
+                .build();
+        return client;
+    }
+
+    private int getAppResponseCode() {
+        HttpToolResponse response = HttpTool.httpGet(
+                client, URI.create(getBaseUri(server) + "/v1/applications/" + appId),
+                ImmutableMap.<String,String>of());
+        return response.getResponseCode();
+    }
+
+    private String createApp(ManagementContext mgmt) {
+        EntityManager entityMgr = mgmt.getEntityManager();
+        Entity app = entityMgr.createEntity(EntitySpec.create(BasicApplication.class));
+        entityMgr.manage(app);
+        return app.getId();
+    }
+
+    private ManagementContext createManagementContext(File mementoDir, HighAvailabilityMode mode) {
+        ManagementContext mgmt = RebindTestUtils.managementContextBuilder(mementoDir, getClass().getClassLoader())
+                .persistPeriodMillis(1)
+                .forLive(false)
+                .emptyCatalog(true)
+                .buildUnstarted();
+
+        mgmt.getHighAvailabilityManager().start(mode);
+
+        new BrooklynCampPlatformLauncherNoServer()
+            .useManagementContext(mgmt)
+            .launch();
+
+        return mgmt;
+    }
+
+    private void initHaCluster(HighAvailabilityMode writeMode, HighAvailabilityMode readMode) throws InterruptedException, TimeoutException {
+        mementoDir = Os.newTempDir(getClass());
+
+        writeMgmt = createManagementContext(mementoDir, writeMode);
+        appId = createApp(writeMgmt);
+        writeMgmt.getRebindManager().getPersister().waitForWritesCompleted(TIMEOUT);
+
+        readMgmt = createManagementContext(mementoDir, readMode);
+
+        server = useServerForTest(BrooklynRestApiLauncher.launcher()
+                .managementContext(readMgmt)
+                .securityProvider(AnyoneSecurityProvider.class)
+                .forceUseOfDefaultCatalogWithJavaClassPath(true)
+                .withoutJsgui()
+                .disableHighAvailability(false)
+                .start());
+        client = getClient(server);
+    }
+
+    private void assertEntityExists(Callable<Boolean> c) {
+        assertTrue(Asserts.succeedsEventually(c), "Unexpected code returned");
+    }
+
+    private void assertReadIsMaster() {
+//        Asserts.eventually(new NodeStateSupplier(readMgmt), Predicates.equalTo(ManagementNodeState.MASTER));
+        assertEquals(readMgmt.getHighAvailabilityManager().getNodeState(), ManagementNodeState.MASTER);
+    }
+
+    private void stopWriteNode() {
+        writeMgmt.getHighAvailabilityManager().stop();
+    }
+
+    private class ReturnCodeCheck implements Callable<Boolean> {
+        @Override
+        public Boolean call() {
+            int retCode = getAppResponseCode();
+            if (retCode == 200) {
+                return true;
+            } else if (retCode == 403) {
+                throw new RuntimeException("Not ready, response " + retCode);
+            } else {
+                LOG.error("Unexpected return code " + retCode);
+                return false;
+            }
+        }
+    }
+
+    private class ReturnCodeAndNodeState extends ReturnCodeCheck {
+        @Override
+        public Boolean call() {
+            Boolean ret = super.call();
+            if (ret) {
+                ManagementNodeState state = readMgmt.getHighAvailabilityManager().getNodeState();
+                if (state != ManagementNodeState.MASTER) {
+                    throw new RuntimeException("Not master yet " + state);
+                }
+            }
+            return ret;
+        }
+    }
+
+    private class ReturnCodeSupplier implements Supplier<Integer> {
+        @Override
+        public Integer get() {
+            return getAppResponseCode();
+        }
+    }
+
+    private static class NodeStateSupplier implements Supplier<ManagementNodeState> {
+        private ManagementContext node;
+        public NodeStateSupplier(ManagementContext node) {
+            this.node = node;
+        }
+
+        @Override
+        public ManagementNodeState get() {
+            return node.getHighAvailabilityManager().getNodeState();
+        }
+    }
+
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/resources/HaHotCheckTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/resources/HaHotCheckTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.resources;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.ws.rs.core.MediaType;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import brooklyn.management.ha.HighAvailabilityManager;
+import brooklyn.management.ha.ManagementNodeState;
+import brooklyn.rest.filter.HaHotCheckResourceFilter;
+import brooklyn.rest.testing.BrooklynRestResourceTest;
+import brooklyn.rest.testing.mocks.ManagementContextMock;
+import brooklyn.rest.util.HaHotStateCheckClassResource;
+import brooklyn.rest.util.HaHotStateCheckResource;
+import brooklyn.rest.util.ManagementContextProvider;
+
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.core.ResourceConfig;
+
+public class HaHotCheckTest extends BrooklynRestResourceTest {
+
+    private ManagementContextMock mgmtMock;
+
+    @Override
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() throws Exception {
+        mgmtMock = new ManagementContextMock();
+        super.setUp();
+    }
+
+    @Override
+    protected void addBrooklynResources() {
+        config.getSingletons().add(new ManagementContextProvider(mgmtMock));
+        config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES, HaHotCheckResourceFilter.class.getName());
+        addResource(new HaHotStateCheckResource());
+        addResource(new HaHotStateCheckClassResource());
+    }
+
+    @Test
+    public void testHaCheck() throws Exception {
+        HighAvailabilityManager ha = mgmtMock.getHighAvailabilityManager();
+        assertEquals(ha.getNodeState(), ManagementNodeState.MASTER);
+        testResourceFetch("/ha/method/ok", 200);
+        testResourceFetch("/ha/method/fail", 200);
+        testResourceFetch("/ha/class/fail", 200);
+
+        mgmtMock.setState(ManagementNodeState.STANDBY);
+        assertEquals(ha.getNodeState(), ManagementNodeState.STANDBY);
+
+        testResourceFetch("/ha/method/ok", 200);
+        testResourceFetch("/ha/method/fail", 403);
+        testResourceFetch("/ha/class/fail", 403);
+    }
+
+    private void testResourceFetch(String resource, int code) {
+        ClientResponse response = client().resource(resource)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get(ClientResponse.class);
+        assertEquals(response.getStatus(), code);
+    }
+
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/HighAvailabilityManagerMock.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/HighAvailabilityManagerMock.java
@@ -39,6 +39,11 @@ public class HighAvailabilityManagerMock implements HighAvailabilityManager {
     }
 
     @Override
+    public boolean isRunning() {
+        return state != ManagementNodeState.TERMINATED;
+    }
+
+    @Override
     public ManagementNodeState getNodeState() {
         return state;
     }
@@ -55,11 +60,6 @@ public class HighAvailabilityManagerMock implements HighAvailabilityManager {
 
     @Override
     public void disabled() {
-        throw fail();
-    }
-
-    @Override
-    public boolean isRunning() {
         throw fail();
     }
 

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/HighAvailabilityManagerMock.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/HighAvailabilityManagerMock.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.testing.mocks;
+
+import java.util.Map;
+
+import brooklyn.management.ha.HighAvailabilityManager;
+import brooklyn.management.ha.HighAvailabilityMode;
+import brooklyn.management.ha.ManagementNodeState;
+import brooklyn.management.ha.ManagementPlaneSyncRecord;
+import brooklyn.management.ha.ManagementPlaneSyncRecordPersister;
+
+public class HighAvailabilityManagerMock implements HighAvailabilityManager {
+
+    private ManagementNodeState state = ManagementNodeState.MASTER;
+
+    public void setState(ManagementNodeState state) {
+        this.state = state;
+    }
+
+    private static RuntimeException fail() {
+        throw new UnsupportedOperationException("Mocked method not implemented");
+    }
+
+    @Override
+    public ManagementNodeState getNodeState() {
+        return state;
+    }
+
+    @Override
+    public long getLastStateChange() {
+        return 0;
+    }
+
+    @Override
+    public HighAvailabilityManager setPersister(ManagementPlaneSyncRecordPersister persister) {
+        throw fail();
+    }
+
+    @Override
+    public void disabled() {
+        throw fail();
+    }
+
+    @Override
+    public boolean isRunning() {
+        throw fail();
+    }
+
+    @Override
+    public void start(HighAvailabilityMode startMode) {
+        throw fail();
+    }
+
+    @Override
+    public void stop() {
+        throw fail();
+    }
+
+    @Override
+    public void changeMode(HighAvailabilityMode mode) {
+        throw fail();
+    }
+
+    @Override
+    public void setPriority(long priority) {
+        throw fail();
+    }
+
+    @Override
+    public long getPriority() {
+        throw fail();
+    }
+
+    @Override
+    public void publishClearNonMaster() {
+        throw fail();
+    }
+
+    @Override
+    public ManagementPlaneSyncRecord getLastManagementPlaneSyncRecord() {
+        throw fail();
+    }
+
+    @Override
+    public ManagementPlaneSyncRecord getManagementPlaneSyncState() {
+        throw fail();
+    }
+
+    @Override
+    public ManagementPlaneSyncRecord loadManagementPlaneSyncRecord(boolean useLocalKnowledgeForThisNode) {
+        throw fail();
+    }
+
+    @Override
+    public ManagementPlaneSyncRecordPersister getPersister() {
+        throw fail();
+    }
+
+    @Override
+    public Map<String, Object> getMetrics() {
+        throw fail();
+    }
+
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/HighAvailabilityManagerStub.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/HighAvailabilityManagerStub.java
@@ -26,7 +26,7 @@ import brooklyn.management.ha.ManagementNodeState;
 import brooklyn.management.ha.ManagementPlaneSyncRecord;
 import brooklyn.management.ha.ManagementPlaneSyncRecordPersister;
 
-public class HighAvailabilityManagerMock implements HighAvailabilityManager {
+public class HighAvailabilityManagerStub implements HighAvailabilityManager {
 
     private ManagementNodeState state = ManagementNodeState.MASTER;
 

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/ManagementContextMock.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/ManagementContextMock.java
@@ -44,7 +44,7 @@ import brooklyn.management.ha.ManagementNodeState;
 import brooklyn.util.guava.Maybe;
 
 public class ManagementContextMock implements ManagementContext {
-    private HighAvailabilityManagerMock haMock = new HighAvailabilityManagerMock();
+    private HighAvailabilityManagerStub haMock = new HighAvailabilityManagerStub();
 
     public void setState(ManagementNodeState state) {
         haMock.setState(state);

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/ManagementContextMock.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/mocks/ManagementContextMock.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.testing.mocks;
+
+import java.net.URI;
+import java.util.Collection;
+
+import brooklyn.basic.BrooklynObject;
+import brooklyn.catalog.BrooklynCatalog;
+import brooklyn.config.StringConfigMap;
+import brooklyn.entity.Application;
+import brooklyn.entity.Entity;
+import brooklyn.entity.drivers.EntityDriverManager;
+import brooklyn.entity.drivers.downloads.DownloadResolverManager;
+import brooklyn.entity.rebind.RebindManager;
+import brooklyn.location.LocationRegistry;
+import brooklyn.management.AccessController;
+import brooklyn.management.EntityManager;
+import brooklyn.management.ExecutionContext;
+import brooklyn.management.ExecutionManager;
+import brooklyn.management.LocationManager;
+import brooklyn.management.ManagementContext;
+import brooklyn.management.SubscriptionContext;
+import brooklyn.management.SubscriptionManager;
+import brooklyn.management.entitlement.EntitlementManager;
+import brooklyn.management.ha.HighAvailabilityManager;
+import brooklyn.management.ha.ManagementNodeState;
+import brooklyn.util.guava.Maybe;
+
+public class ManagementContextMock implements ManagementContext {
+    private HighAvailabilityManagerMock haMock = new HighAvailabilityManagerMock();
+
+    public void setState(ManagementNodeState state) {
+        haMock.setState(state);
+    }
+
+    private static RuntimeException fail() {
+        throw new UnsupportedOperationException("Mocked method not implemented");
+    }
+
+    @Override
+    public HighAvailabilityManager getHighAvailabilityManager() {
+        return haMock;
+    }
+
+    @Override
+    public String getManagementPlaneId() {
+        throw fail();
+    }
+
+    @Override
+    public String getManagementNodeId() {
+        throw fail();
+    }
+
+    @Override
+    public Maybe<URI> getManagementNodeUri() {
+        throw fail();
+    }
+
+    @Override
+    public Collection<Application> getApplications() {
+        throw fail();
+    }
+
+    @Override
+    public EntityManager getEntityManager() {
+        throw fail();
+    }
+
+    @Override
+    public ExecutionManager getExecutionManager() {
+        throw fail();
+    }
+
+    @Override
+    public ExecutionContext getServerExecutionContext() {
+        throw fail();
+    }
+
+    @Override
+    public EntityDriverManager getEntityDriverManager() {
+        throw fail();
+    }
+
+    @Override
+    public DownloadResolverManager getEntityDownloadsManager() {
+        throw fail();
+    }
+
+    @Override
+    public SubscriptionManager getSubscriptionManager() {
+        throw fail();
+    }
+
+    @Override
+    public ExecutionContext getExecutionContext(Entity entity) {
+        throw fail();
+    }
+
+    @Override
+    public SubscriptionContext getSubscriptionContext(Entity entity) {
+        throw fail();
+    }
+
+    @Override
+    public RebindManager getRebindManager() {
+        throw fail();
+    }
+
+    @Override
+    public StringConfigMap getConfig() {
+        throw fail();
+    }
+
+    @Override
+    public boolean isRunning() {
+        throw fail();
+    }
+
+    @Override
+    public LocationRegistry getLocationRegistry() {
+        throw fail();
+    }
+
+    @Override
+    public BrooklynCatalog getCatalog() {
+        throw fail();
+    }
+
+    @Override
+    public LocationManager getLocationManager() {
+        throw fail();
+    }
+
+    @Override
+    public AccessController getAccessController() {
+        throw fail();
+    }
+
+    @Override
+    public void reloadBrooklynProperties() {
+        throw fail();
+
+    }
+
+    @Override
+    public void addPropertiesReloadListener(PropertiesReloadListener listener) {
+        throw fail();
+
+    }
+
+    @Override
+    public void removePropertiesReloadListener(PropertiesReloadListener listener) {
+        throw fail();
+    }
+
+    @Override
+    public EntitlementManager getEntitlementManager() {
+        throw fail();
+    }
+
+    @Override
+    public BrooklynObject lookup(String id) {
+        throw fail();
+    }
+
+    @Override
+    public <T extends BrooklynObject> T lookup(String id, Class<T> type) {
+        throw fail();
+    }
+
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/util/HaHotStateCheckClassResource.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/util/HaHotStateCheckClassResource.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.util;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import brooklyn.rest.filter.HaHotStateRequired;
+
+@Path("/ha/class")
+@Produces(MediaType.APPLICATION_JSON)
+@HaHotStateRequired
+public class HaHotStateCheckClassResource {
+
+    @GET
+    @Path("fail")
+    public String fail() {
+        return "FAIL";
+    }
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/util/HaHotStateCheckResource.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/util/HaHotStateCheckResource.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.util;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import brooklyn.rest.filter.HaHotStateRequired;
+
+@Path("/ha/method")
+@Produces(MediaType.APPLICATION_JSON)
+public class HaHotStateCheckResource {
+
+    @GET
+    @Path("ok")
+    public String ok() {
+        return "OK";
+    }
+
+    @GET
+    @Path("fail")
+    @HaHotStateRequired
+    public String fail() {
+        return "FAIL";
+    }
+}


### PR DESCRIPTION
... and other restart improvements.

There is a window of time when restarting Brooklyn where it returns 404 for its entities, making mirroring entities unmanage themselves. Fix it by extending the existing filtering logic to return 403 for explicitly marked endpoints while remote is STANDBY or rebinding.
I had to use a delay after master promotion because there is still a small period of time just after the node becomes master but before it starts rebinding where it will return 404 for entities and there are no flags to check for it.