### PR TITLE
Props given as arguments to SshMachineLocation.connectSsh trump others

### DIFF
--- a/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
@@ -529,8 +529,7 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
             ConfigBag args = new ConfigBag()
                 .configure(SshTool.PROP_USER, user)
                 // default value of host, overridden if SSH_HOST is supplied
-                .configure(SshTool.PROP_HOST, address.getHostName())
-                .putAll(props);
+                .configure(SshTool.PROP_HOST, address.getHostName());
 
             for (Map.Entry<String,Object> entry: config().getBag().getAllConfig().entrySet()) {
                 String key = entry.getKey();
@@ -550,6 +549,10 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
                 }
                 args.putStringKey(key, entry.getValue());
             }
+
+            // Explicit props trump all.
+            args.putAll(props);
+
             if (LOG.isTraceEnabled()) LOG.trace("creating ssh session for "+args);
             if (!user.equals(args.get(SshTool.PROP_USER))) {
                 LOG.warn("User mismatch configuring ssh for "+this+": preferring user "+args.get(SshTool.PROP_USER)+" over "+user);


### PR DESCRIPTION
So, for example, the user that the SSH connection is made as can be overridden by providing `PROP_USER` in the flags. Previously it was overwritten by the inclusion of the values in `config().getBag()`.

Happy to be informed that there's already a way to switch the user that the SSH connection is made as.