### PR TITLE
Fix AbstractEntity.config()

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/AbstractEntity.java
+++ b/core/src/main/java/brooklyn/entity/basic/AbstractEntity.java
@@ -970,7 +970,14 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         return config;
     }
 
-    private class BasicConfigurationSupport implements ConfigurationSupportInternal {
+    /**
+     * Direct use of this class is strongly discouraged. It will become private in a future release,
+     * once {@link #config()} is reverted to return {@link ConfigurationSupportInternal} instead of
+     * {@link BasicConfigurationSupport}.
+     */
+    @Beta
+    // TODO revert to private when config() is reverted to return ConfigurationSupportInternal
+    protected class BasicConfigurationSupport implements ConfigurationSupportInternal {
 
         @Override
         public <T> T get(ConfigKey<T> key) {

--- a/core/src/test/java/brooklyn/entity/basic/EntityConfigTest.java
+++ b/core/src/test/java/brooklyn/entity/basic/EntityConfigTest.java
@@ -155,6 +155,15 @@ public class EntityConfigTest {
 
         @SetFromFlag("myconfigflagname")
         public static final ConfigKey<String> MY_CONFIG_WITH_FLAGNAME = ConfigKeys.newStringConfigKey("myentity.myconfigwithflagname");
+        
+        @Override
+        public void init() {
+            super.init();
+            
+            // Just calling this to prove we can! When config() was changed to return BasicConfigurationSupport,
+            // it broke because BasicConfigurationSupport was private.
+            config().getLocalBag();
+        }
     }
     
     public static class MyChildEntity extends AbstractEntity {


### PR DESCRIPTION
- When return type of config() was changed to BasicConfigurationSupport,
  it broke any entity impls that tried to call config().set(...) etc
- Solution is to change BasicConfigurationSupport to be protected
  rather than private, and mark as @Beta because we’ll change it
  back to private at some point.