### PR TITLE
Destroys machine on expunge, even if stopped

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -583,7 +583,7 @@ public abstract class MachineLifecycleEffectorTasks {
         }
 
         Task<StopMachineDetails<Integer>> stoppingMachine = null;
-        if (canStop(stopMachineMode, isEntityStopped)) {
+        if (canStop(stopMachineMode, sshMachine.isAbsent())) {
             // Release this machine (even if error trying to stop process - we rethrow that after)
             stoppingMachine = DynamicTasks.queue("stopping (machine)", new Callable<StopMachineDetails<Integer>>() {
                 public StopMachineDetails<Integer> call() {
@@ -639,9 +639,9 @@ public abstract class MachineLifecycleEffectorTasks {
         if (log.isDebugEnabled()) log.debug("Stopped software process entity "+entity());
     }
 
-    protected static boolean canStop(StopMode stopMode, boolean isEntityStopped) {
+    protected static boolean canStop(StopMode stopMode, boolean isTargetStopped) {
         return stopMode == StopMode.ALWAYS ||
-                stopMode == StopMode.IF_NOT_STOPPED && !isEntityStopped;
+                stopMode == StopMode.IF_NOT_STOPPED && !isTargetStopped;
     }
 
     private void checkCompatibleMachineModes(Boolean isStopMachine, boolean hasStopMachineMode, StopMode stopMachineMode) {

--- a/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
@@ -28,7 +28,6 @@ import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters.StopMode;
 import brooklyn.entity.effector.Effectors;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.proxying.ImplementedBy;
-import brooklyn.entity.software.MachineLifecycleEffectorTasks;
 import brooklyn.entity.software.MachineLifecycleEffectorTasksTest;
 import brooklyn.entity.trait.Startable;
 import brooklyn.location.Location;
@@ -328,7 +327,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         } else {
             assertTrue(d.events.isEmpty());
         }
-        if (MachineLifecycleEffectorTasksTest.canStop(stopMachineMode, isEntityStopped)) {
+        if (MachineLifecycleEffectorTasksTest.canStop(stopMachineMode, machine == null)) {
             assertTrue(entity.getLocations().isEmpty());
             assertTrue(l.getAvailable().contains(machine));
         } else {


### PR DESCRIPTION
Fixes an issue where stopping an entity (with
stopMachineMode of NEVER) and then attempting
to expunge the top level application would
unmanage the entity, but not destroy the VM