### PR TITLE
Fix NPE in removeMember

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/AbstractGroupImpl.java
+++ b/core/src/main/java/brooklyn/entity/basic/AbstractGroupImpl.java
@@ -189,14 +189,16 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
                     Optional<Entity> result = Iterables.tryFind(getChildren(), new Predicate<Entity>() {
                         @Override
                         public boolean apply(Entity input) {
-                            return input.getConfig(DelegateEntity.DELEGATE_ENTITY).equals(member);
+                            Entity delegate = input.getConfig(DelegateEntity.DELEGATE_ENTITY);
+                            if (delegate == null) return false;
+                            return delegate.equals(member);
                         }
                     });
                     if (result.isPresent()) {
                         Entity child = result.get();
                         removeChild(child);
                         Entities.unmanage(child);
-                       }
+                    }
                 }
 
                 getManagementSupport().getEntityChangeListener().onMembersChanged();


### PR DESCRIPTION
Check that the `DELEGATE_ENTITY` attribute exists and is set before comparing it with the entity to be removed.