### PR TITLE
Add Apache 2.0 license text to Riak documentation

### DIFF
--- a/software/nosql/src/main/resources/brooklyn/entity/nosql/riak/riak.md
+++ b/software/nosql/src/main/resources/brooklyn/entity/nosql/riak/riak.md
@@ -47,3 +47,21 @@ services:
     java.sysprops: 
       brooklyn.example.riak.nodes: $brooklyn:component("cluster").attributeWhenReady("riak.cluster.nodeList")
 ```
+
+----
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.


### PR DESCRIPTION
Add license text to make the RAT happy