### PR TITLE
UsageListener: improve API

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/Entities.java
+++ b/core/src/main/java/brooklyn/entity/basic/Entities.java
@@ -46,7 +46,6 @@ import brooklyn.basic.BrooklynObjectInternal;
 import brooklyn.config.BrooklynProperties;
 import brooklyn.config.ConfigKey;
 import brooklyn.config.ConfigKey.HasConfigKey;
-import brooklyn.enricher.basic.AbstractEnricher;
 import brooklyn.entity.Application;
 import brooklyn.entity.Effector;
 import brooklyn.entity.Entity;
@@ -55,6 +54,7 @@ import brooklyn.entity.drivers.EntityDriver;
 import brooklyn.entity.drivers.downloads.DownloadResolver;
 import brooklyn.entity.effector.Effectors;
 import brooklyn.entity.proxying.EntityProxyImpl;
+import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.trait.Startable;
 import brooklyn.entity.trait.StartableMethods;
 import brooklyn.event.AttributeSensor;
@@ -77,7 +77,6 @@ import brooklyn.management.internal.ManagementContextInternal;
 import brooklyn.management.internal.NonDeploymentManagementContext;
 import brooklyn.policy.Enricher;
 import brooklyn.policy.Policy;
-import brooklyn.policy.basic.AbstractPolicy;
 import brooklyn.util.ResourceUtils;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.config.ConfigBag;
@@ -814,6 +813,20 @@ public class Entities {
             return (AbstractEntity) e;
         }
         return (AbstractEntity) ((EntityProxyImpl)Proxy.getInvocationHandler(e)).getDelegate();
+    }
+    
+    /** 
+     * Returns the proxy form (if available) of the entity. If already a proxy, returns unmodified.
+     * 
+     * If null is passed in, then null is returned.
+     * 
+     * For legacy entities (that did not use {@link EntitySpec} or YAML for creation), the
+     * proxy may not be avilable; in which case the concrete class passed in will be returned.
+     */
+    @Beta
+    @SuppressWarnings("unchecked")
+    public static <T extends Entity> T proxy(T e) {
+        return (e == null) ? null : e instanceof Proxy ? e : (T) ((AbstractEntity)e).getProxyIfAvailable();
     }
     
     /**

--- a/core/src/main/java/brooklyn/management/internal/LocalEntityManager.java
+++ b/core/src/main/java/brooklyn/management/internal/LocalEntityManager.java
@@ -211,7 +211,7 @@ public class LocalEntityManager implements EntityManagerInternal {
         Iterable<Entity> result = Iterables.filter(allentities, predicate);
         return ImmutableSet.copyOf(Iterables.transform(result, new Function<Entity, Entity>() {
             @Override public Entity apply(Entity input) {
-                return (input == null) ? null : input instanceof Proxy ? input : ((AbstractEntity)input).getProxyIfAvailable();
+                return Entities.proxy(input);
             }}));
     }
 

--- a/core/src/main/java/brooklyn/management/internal/NonDeploymentUsageManager.java
+++ b/core/src/main/java/brooklyn/management/internal/NonDeploymentUsageManager.java
@@ -100,7 +100,19 @@ public class NonDeploymentUsageManager implements UsageManager {
     }
 
     @Override
-    public void addUsageListener(UsageListener listener) {
+    @Deprecated
+    public void addUsageListener(brooklyn.management.internal.UsageManager.UsageListener listener) {
+        addUsageListener(new brooklyn.management.internal.UsageManager.UsageListener.UsageListenerAdapter(listener));
+    }
+
+    @Override
+    @Deprecated
+    public void removeUsageListener(brooklyn.management.internal.UsageManager.UsageListener listener) {
+        removeUsageListener(new brooklyn.management.internal.UsageManager.UsageListener.UsageListenerAdapter(listener));
+    }
+    
+    @Override
+    public void addUsageListener(brooklyn.management.internal.UsageListener listener) {
         if (isInitialManagementContextReal()) {
             initialManagementContext.getUsageManager().addUsageListener(listener);
         } else {
@@ -109,7 +121,7 @@ public class NonDeploymentUsageManager implements UsageManager {
     }
 
     @Override
-    public void removeUsageListener(UsageListener listener) {
+    public void removeUsageListener(brooklyn.management.internal.UsageListener listener) {
         if (isInitialManagementContextReal()) {
             initialManagementContext.getUsageManager().removeUsageListener(listener);
         } else {

--- a/core/src/main/java/brooklyn/management/internal/UsageListener.java
+++ b/core/src/main/java/brooklyn/management/internal/UsageListener.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.management.internal;
+
+import java.util.Map;
+
+import brooklyn.entity.Application;
+import brooklyn.location.Location;
+import brooklyn.management.usage.ApplicationUsage.ApplicationEvent;
+import brooklyn.management.usage.LocationUsage.LocationEvent;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public interface UsageListener {
+    
+    /**
+     * A no-op implementation of {@link UsageListener}, for users to extend.
+     * 
+     * Users are encouraged to extend this class, which will shield the user 
+     * from the addition of other usage event methods being added. If additional
+     * methods are added in a future release, a no-op implementation will be
+     * added to this class.
+     */
+    @Beta
+    public static class BasicUsageListener implements UsageListener {
+        @Override
+        public void onApplicationEvent(ApplicationMetadata app, ApplicationEvent event) {
+        }
+        
+        @Override public void onLocationEvent(LocationMetadata loc, LocationEvent event) {
+        }
+    }
+    
+    /**
+     * Users should never implement this interface directly; methods may be added in future releases
+     * without notice.
+     */
+    @Beta
+    public interface ApplicationMetadata {
+        /**
+         * Access the application directly with caution: by the time the listener fires, 
+         * the application may no longer be managed.
+         */
+        @Beta
+        Application getApplication();
+        
+        String getApplicationId();
+        
+        String getApplicationName();
+        
+        String getEntityType();
+        
+        String getCatalogItemId();
+        
+        Map<String, String> getMetadata();
+    }
+    
+    /**
+     * Users should never implement this interface directly; methods may be added in future releases
+     * without notice.
+     */
+    @Beta
+    public interface LocationMetadata {
+        /**
+         * Access the location directly with caution: by the time the listener fires, 
+         * the location may no longer be managed.
+         */
+        @Beta
+        Location getLocation();
+        
+        String getLocationId();
+        
+        Map<String, String> getMetadata();
+    }
+    
+    public static final UsageListener NOOP = new UsageListener() {
+        @Override public void onApplicationEvent(ApplicationMetadata app, ApplicationEvent event) {}
+        @Override public void onLocationEvent(LocationMetadata loc, LocationEvent event) {}
+    };
+    
+    @Beta
+    void onApplicationEvent(ApplicationMetadata app, ApplicationEvent event);
+    
+    @Beta
+    void onLocationEvent(LocationMetadata loc, LocationEvent event);
+}

--- a/core/src/main/java/brooklyn/management/internal/UsageManager.java
+++ b/core/src/main/java/brooklyn/management/internal/UsageManager.java
@@ -18,6 +18,8 @@
  */
 package brooklyn.management.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +36,7 @@ import brooklyn.management.usage.LocationUsage.LocationEvent;
 import brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
@@ -42,10 +45,10 @@ import com.google.common.reflect.TypeToken;
 public interface UsageManager {
 
     @SuppressWarnings("serial")
-    public static final ConfigKey<List<UsageListener>> USAGE_LISTENERS = ConfigKeys.newConfigKey(
-            new TypeToken<List<UsageListener>>() {},
+    public static final ConfigKey<List<brooklyn.management.internal.UsageListener>> USAGE_LISTENERS = ConfigKeys.newConfigKey(
+            new TypeToken<List<brooklyn.management.internal.UsageListener>>() {},
             "brooklyn.usageManager.listeners", "Optional usage listeners (i.e. for metering)",
-            ImmutableList.<UsageListener>of());
+            ImmutableList.<brooklyn.management.internal.UsageListener>of());
     
     public static final ConfigKey<Duration> USAGE_LISTENER_TERMINATION_TIMEOUT = ConfigKeys.newConfigKey(
             Duration.class,
@@ -53,12 +56,44 @@ public interface UsageManager {
             "Timeout on termination, to wait for queue of usage listener events to be processed",
             Duration.TEN_SECONDS);
 
+    /**
+     * @since 0.7.0
+     * @deprecated since 0.7.0; use {@link brooklyn.management.internal.UsageListener}; see {@link UsageListenerAdapter} 
+     */
     public interface UsageListener {
         public static final UsageListener NOOP = new UsageListener() {
             @Override public void onApplicationEvent(String applicationId, String applicationName, String entityType, 
                     String catalogItemId, Map<String, String> metadata, ApplicationEvent event) {}
             @Override public void onLocationEvent(String locationId, Map<String, String> metadata, LocationEvent event) {}
         };
+        
+        public static class UsageListenerAdapter implements brooklyn.management.internal.UsageListener {
+            private final UsageListener listener;
+
+            public UsageListenerAdapter(UsageListener listener) {
+                this.listener = checkNotNull(listener, "listener");
+            }
+            
+            @Override
+            public void onApplicationEvent(ApplicationMetadata app, ApplicationEvent event) {
+                listener.onApplicationEvent(app.getApplicationId(), app.getApplicationName(), app.getEntityType(), app.getCatalogItemId(), app.getMetadata(), event);
+            }
+
+            @Override
+            public void onLocationEvent(LocationMetadata loc, LocationEvent event) {
+                listener.onLocationEvent(loc.getLocationId(), loc.getMetadata(), event);
+            }
+            
+            @Override
+            public boolean equals(Object obj) {
+                return (obj instanceof UsageListenerAdapter) && listener.equals(((UsageListenerAdapter)obj).listener);
+            }
+            
+            @Override
+            public int hashCode() {
+                return Objects.hashCode(listener);
+            }
+        }
         
         void onApplicationEvent(String applicationId, String applicationName, String entityType, String catalogItemId,
                 Map<String, String> metadata, ApplicationEvent event);
@@ -101,16 +136,30 @@ public interface UsageManager {
     Set<ApplicationUsage> getApplicationUsage(Predicate<? super ApplicationUsage> filter);
 
     /**
+     * @since 0.7.0
+     * @deprecated since 0.7.0; use {@link #removeUsageListener(brooklyn.management.internal.UsageListener)};
+     *             see {@link brooklyn.management.internal.UsageManager.UsageListener.UsageListenerAdapter} 
+     */
+    void addUsageListener(brooklyn.management.internal.UsageManager.UsageListener listener);
+
+    /**
+     * @since 0.7.0
+     * @deprecated since 0.7.0; use {@link #removeUsageListener(brooklyn.management.internal.UsageListener)}
+     */
+    @Deprecated
+    void removeUsageListener(brooklyn.management.internal.UsageManager.UsageListener listener);
+    
+    /**
      * Adds the given listener, to be notified on recording of application/location events.
      * The listener notifications may be asynchronous.
      * 
      * As of 0.7.0, the listener is not persisted so will be lost on restart/rebind. This
      * behaviour may change in a subsequent release. 
      */
-    void addUsageListener(UsageListener listener);
+    void addUsageListener(brooklyn.management.internal.UsageListener listener);
 
     /**
      * Removes the given listener.
      */
-    void removeUsageListener(UsageListener listener);
+    void removeUsageListener(brooklyn.management.internal.UsageListener listener);
 }

--- a/software/base/src/test/java/brooklyn/management/usage/RecordingLegacyUsageListener.java
+++ b/software/base/src/test/java/brooklyn/management/usage/RecordingLegacyUsageListener.java
@@ -19,6 +19,7 @@
 package brooklyn.management.usage;
 
 import java.util.List;
+import java.util.Map;
 
 import brooklyn.management.usage.ApplicationUsage.ApplicationEvent;
 import brooklyn.management.usage.LocationUsage.LocationEvent;
@@ -27,18 +28,20 @@ import brooklyn.util.collections.MutableList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-public class RecordingUsageListener implements brooklyn.management.internal.UsageListener {
+@Deprecated
+public class RecordingLegacyUsageListener implements brooklyn.management.internal.UsageManager.UsageListener {
 
     private final List<List<?>> events = Lists.newCopyOnWriteArrayList();
     
     @Override
-    public void onApplicationEvent(ApplicationMetadata app, ApplicationEvent event) {
-        events.add(MutableList.of("application", app, event));
+    public void onApplicationEvent(String applicationId, String applicationName, String entityType, 
+            String catalogItemId, Map<String, String> metadata, ApplicationEvent event) {
+        events.add(MutableList.of("application", applicationId, applicationName, entityType, catalogItemId, metadata, event));
     }
 
     @Override
-    public void onLocationEvent(LocationMetadata loc, LocationEvent event) {
-        events.add(MutableList.of("location", loc, event));
+    public void onLocationEvent(String locationId, Map<String, String> metadata, LocationEvent event) {
+        events.add(MutableList.of("location", locationId, metadata, event));
     }
     
     public void clearEvents() {

--- a/software/base/src/test/java/brooklyn/management/usage/UsageListenerTest.java
+++ b/software/base/src/test/java/brooklyn/management/usage/UsageListenerTest.java
@@ -33,7 +33,6 @@ import brooklyn.entity.basic.Entities;
 import brooklyn.location.Location;
 import brooklyn.management.internal.ManagementContextInternal;
 import brooklyn.management.internal.UsageManager;
-import brooklyn.management.internal.UsageManager.UsageListener;
 import brooklyn.test.Asserts;
 import brooklyn.test.entity.LocalManagementContextForTests;
 import brooklyn.test.entity.TestApplication;
@@ -57,6 +56,7 @@ public class UsageListenerTest {
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
+        RecordingStaticLegacyUsageListener.clearInstances();
         RecordingStaticUsageListener.clearInstances();
     }
 
@@ -68,10 +68,27 @@ public class UsageListenerTest {
             LOG.error("Caught exception in tearDown method", t);
         } finally {
             mgmt = null;
+            RecordingStaticLegacyUsageListener.clearInstances();
             RecordingStaticUsageListener.clearInstances();
         }
     }
 
+    @Test
+    public void testAddLegacyUsageListenerViaProperties() throws Exception {
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
+        brooklynProperties.put(UsageManager.USAGE_LISTENERS, RecordingStaticLegacyUsageListener.class.getName());
+        mgmt = LocalManagementContextForTests.newInstance(brooklynProperties);
+        
+        app = TestApplication.Factory.newManagedInstanceForTests(mgmt);
+        app.start(ImmutableList.<Location>of());
+
+        Asserts.succeedsEventually(new Runnable() {
+            @Override public void run() {
+                List<List<?>> events = RecordingStaticLegacyUsageListener.getInstance().getApplicationEvents();
+                assertTrue(events.size() > 0, "events="+events); // expect some events
+            }});
+    }
+    
     @Test
     public void testAddUsageListenerViaProperties() throws Exception {
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
@@ -88,7 +105,25 @@ public class UsageListenerTest {
             }});
     }
     
-    public static class RecordingStaticUsageListener extends RecordingUsageListener implements UsageListener {
+    public static class RecordingStaticLegacyUsageListener extends RecordingLegacyUsageListener implements brooklyn.management.internal.UsageManager.UsageListener {
+        private static final List<RecordingStaticLegacyUsageListener> STATIC_INSTANCES = Lists.newCopyOnWriteArrayList();
+        
+        public static RecordingStaticLegacyUsageListener getInstance() {
+            return Iterables.getOnlyElement(STATIC_INSTANCES);
+        }
+
+        public static void clearInstances() {
+            STATIC_INSTANCES.clear();
+        }
+        
+        public RecordingStaticLegacyUsageListener() {
+            // Bad to leak a ref to this before constructor finished, but we'll live with it because
+            // it's just test code!
+            STATIC_INSTANCES.add(this);
+        }
+    }
+    
+    public static class RecordingStaticUsageListener extends RecordingUsageListener implements brooklyn.management.internal.UsageListener {
         private static final List<RecordingStaticUsageListener> STATIC_INSTANCES = Lists.newCopyOnWriteArrayList();
         
         public static RecordingStaticUsageListener getInstance() {


### PR DESCRIPTION
- Deprecates old interface
- Adds new UsageListener interface that is more flexible and more backwards compatible.
- Marks new interface as @Beta
- Adds tests for new UsageListener, and refactors old tests for old-style UsageListener.
- Adds Entities.proxy(Entity)