### PR TITLE
Adds PersistenceObjectStore.StoreObjectAccessor.getBytes

### DIFF
--- a/core/src/main/java/brooklyn/entity/rebind/persister/FileBasedStoreObjectAccessor.java
+++ b/core/src/main/java/brooklyn/entity/rebind/persister/FileBasedStoreObjectAccessor.java
@@ -62,6 +62,16 @@ public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.Stor
     }
 
     @Override
+    public byte[] getBytes() {
+        try {
+            if (!exists()) return null;
+            return Files.asByteSource(file).read();
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
     public boolean exists() {
         return file.exists();
     }

--- a/core/src/main/java/brooklyn/entity/rebind/persister/PersistenceObjectStore.java
+++ b/core/src/main/java/brooklyn/entity/rebind/persister/PersistenceObjectStore.java
@@ -39,6 +39,7 @@ public interface PersistenceObjectStore {
     public interface StoreObjectAccessor {
         /** gets the object, or null if not found */
         String get();
+        byte[] getBytes();
         boolean exists();
         void put(String contentsToReplaceOrCreate);
         void append(String contentsToAppendOrCreate);

--- a/core/src/test/java/brooklyn/entity/rebind/persister/InMemoryObjectStore.java
+++ b/core/src/test/java/brooklyn/entity/rebind/persister/InMemoryObjectStore.java
@@ -86,6 +86,10 @@ public class InMemoryObjectStore implements PersistenceObjectStore {
             }
         }
         @Override
+        public byte[] getBytes() {
+            return get().getBytes();
+        }
+        @Override
         public boolean exists() {
             synchronized (map) {
                 return map.containsKey(key);

--- a/core/src/test/java/brooklyn/entity/rebind/persister/ListeningObjectStore.java
+++ b/core/src/test/java/brooklyn/entity/rebind/persister/ListeningObjectStore.java
@@ -238,6 +238,10 @@ public class ListeningObjectStore implements PersistenceObjectStore {
             return result;
         }
         @Override
+        public byte[] getBytes() {
+            return get().getBytes();
+        }
+        @Override
         public Date getLastModifiedDate() {
             return delegate.getLastModifiedDate();
         }


### PR DESCRIPTION
Convenience for reusing PersistenceObjectStore in slightly different context, in a downstream repo, where we still want to piggie back off the brooklyn.properties way of accessing the object store.