### PR TITLE
Riak - Create Bucket type effector

### DIFF
--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakClusterImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakClusterImpl.java
@@ -83,8 +83,6 @@ public class RiakClusterImpl extends DynamicClusterImpl implements RiakCluster {
                 EntityPredicates.attributeEqualTo(RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true),
                 EntityPredicates.attributeEqualTo(RiakNode.SERVICE_UP, true)));
         if (anyNode.isPresent()) {
-            log.info("Planning and Committing cluster changes on node: {}, cluster: {}", anyNode.get().getId(), getId());
-            Entities.invokeEffector(this, anyNode.get(), RiakNode.COMMIT_RIAK_CLUSTER).blockUntilEnded();
             setAttribute(IS_CLUSTER_INIT, true);
         } else {
             log.warn("No Riak Nodes are found on the cluster: {}. Initialization Failed", getId());
@@ -152,9 +150,6 @@ public class RiakClusterImpl extends DynamicClusterImpl implements RiakCluster {
                         if (!nodes.containsKey(member) && member.getAttribute(RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER) == null) {
                             String anyNodeName = anyNodeInCluster.get().getAttribute(RiakNode.RIAK_NODE_NAME);
                             Entities.invokeEffectorWithArgs(this, member, RiakNode.JOIN_RIAK_CLUSTER, anyNodeName).blockUntilEnded();
-                            if (getAttribute(IS_CLUSTER_INIT)) {
-                                Entities.invokeEffector(this, member, RiakNode.COMMIT_RIAK_CLUSTER).blockUntilEnded();
-                            }
                             nodes.put(member, riakName);
                             setAttribute(RIAK_CLUSTER_NODES, nodes);
                             log.info("Added Riak node {}: {}; {} to cluster", new Object[] { this, member, getRiakName(member) });

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
@@ -143,7 +143,6 @@ public interface RiakNode extends SoftwareProcess {
     MethodEffector<Void> JOIN_RIAK_CLUSTER = new MethodEffector<Void>(RiakNode.class, "joinCluster");
     MethodEffector<Void> LEAVE_RIAK_CLUSTER = new MethodEffector<Void>(RiakNode.class, "leaveCluster");
     MethodEffector<Void> REMOVE_FROM_CLUSTER = new MethodEffector<Void>(RiakNode.class, "removeNode");
-    MethodEffector<Void> COMMIT_RIAK_CLUSTER = new MethodEffector<Void>(RiakNode.class, "commitCluster");
 
     AttributeSensor<Integer> RIAK_NODE_GET_FSM_TIME_MEAN = Sensors.newIntegerSensor("riak.node_get_fsm_time_mean", "Time between reception of client read request and subsequent response to client");
     AttributeSensor<Integer> RIAK_NODE_PUT_FSM_TIME_MEAN = Sensors.newIntegerSensor("riak.node_put_fsm_time_mean", "Time between reception of client write request and subsequent response to client");
@@ -182,6 +181,9 @@ public interface RiakNode extends SoftwareProcess {
 
     String getOsMajorVersion();
 
+    // TODO add commitCluster() effector and add effectors joinCluster, leaveCluster, removeNode, recoverFailedNode which do not execute commitCluster()
+    // the commit where the commitCluster effector was available is adbf2dc1cb5df98b1e52d3ab35fa6bb4983b722f
+
     @Effector(description = "Join the Riak cluster on the given node")
     void joinCluster(@EffectorParam(name = "nodeName") String nodeName);
 
@@ -193,9 +195,6 @@ public interface RiakNode extends SoftwareProcess {
 
     @Effector(description = "Recover and join the Riak cluster on the given node")
     void recoverFailedNode(@EffectorParam(name = "nodeName") String nodeName);
-
-    @Effector(description = "Commit changes made to the Riak cluster")
-    void commitCluster();
 
     @Effector(description = "Create or modify a bucket type before activation")
     void bucketTypeCreate(@EffectorParam(name = "bucketTypeName") String bucketTypeName,

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
@@ -197,7 +197,20 @@ public interface RiakNode extends SoftwareProcess {
     @Effector(description = "Commit changes made to the Riak cluster")
     void commitCluster();
 
-    @Effector(description = "Apply bucket type")
-    void applyBucketType(@EffectorParam(name = "bucketTypeName") String bucketTypeName,
-                         @EffectorParam(name = "bucketTypeProperties") String bucketTypeProperties);
+    @Effector(description = "Create bucket type")
+    void bucketTypeCreate(@EffectorParam(name = "bucketTypeName") String bucketTypeName,
+                          @EffectorParam(name = "bucketTypeProperties") String bucketTypeProperties);
+
+    @Effector(description = "List bucket types")
+    List<String> bucketTypeList();
+
+    @Effector(description = "Status bucket type")
+    List<String> bucketTypeStatus(@EffectorParam(name = "bucketTypeName") String bucketTypeName);
+
+    @Effector(description = "Update bucket type")
+    void bucketTypeUpdate(@EffectorParam(name = "bucketTypeName") String bucketTypeName,
+                          @EffectorParam(name = "bucketTypeProperties") String bucketTypeProperties);
+
+    @Effector(description = "Activate bucket type")
+    void bucketTypeActivate(@EffectorParam(name = "bucketTypeName") String bucketTypeName);
 }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
@@ -197,20 +197,20 @@ public interface RiakNode extends SoftwareProcess {
     @Effector(description = "Commit changes made to the Riak cluster")
     void commitCluster();
 
-    @Effector(description = "Create bucket type")
+    @Effector(description = "Create or modify a bucket type before activation")
     void bucketTypeCreate(@EffectorParam(name = "bucketTypeName") String bucketTypeName,
                           @EffectorParam(name = "bucketTypeProperties") String bucketTypeProperties);
 
-    @Effector(description = "List bucket types")
+    @Effector(description = "List all currently available bucket types and their activation status")
     List<String> bucketTypeList();
 
-    @Effector(description = "Status bucket type")
+    @Effector(description = "Display the status and properties of a specific bucket type")
     List<String> bucketTypeStatus(@EffectorParam(name = "bucketTypeName") String bucketTypeName);
 
-    @Effector(description = "Update bucket type")
+    @Effector(description = "Update a bucket type after activation")
     void bucketTypeUpdate(@EffectorParam(name = "bucketTypeName") String bucketTypeName,
                           @EffectorParam(name = "bucketTypeProperties") String bucketTypeProperties);
 
-    @Effector(description = "Activate bucket type")
+    @Effector(description = "Activate a bucket type")
     void bucketTypeActivate(@EffectorParam(name = "bucketTypeName") String bucketTypeName);
 }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
@@ -183,18 +183,21 @@ public interface RiakNode extends SoftwareProcess {
     String getOsMajorVersion();
 
     @Effector(description = "Join the Riak cluster on the given node")
-    public void joinCluster(@EffectorParam(name = "nodeName") String nodeName);
+    void joinCluster(@EffectorParam(name = "nodeName") String nodeName);
 
     @Effector(description = "Leave the Riak cluster")
-    public void leaveCluster();
+    void leaveCluster();
 
     @Effector(description = "Remove the given node from the Riak cluster")
-    public void removeNode(@EffectorParam(name = "nodeName") String nodeName);
+    void removeNode(@EffectorParam(name = "nodeName") String nodeName);
 
     @Effector(description = "Recover and join the Riak cluster on the given node")
-    public void recoverFailedNode(@EffectorParam(name = "nodeName") String nodeName);
+    void recoverFailedNode(@EffectorParam(name = "nodeName") String nodeName);
 
     @Effector(description = "Commit changes made to the Riak cluster")
-    public void commitCluster();
+    void commitCluster();
 
+    @Effector(description = "Apply bucket type")
+    void applyBucketType(@EffectorParam(name = "bucketTypeName") String bucketTypeName,
+                         @EffectorParam(name = "bucketTypeProperties") String bucketTypeProperties);
 }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeDriver.java
@@ -22,17 +22,19 @@ import brooklyn.entity.basic.SoftwareProcessDriver;
 
 public interface RiakNodeDriver extends SoftwareProcessDriver {
 
-    public String getRiakEtcDir();
+    String getRiakEtcDir();
 
-    public void joinCluster(String nodeName);
+    void joinCluster(String nodeName);
 
-    public void leaveCluster();
+    void leaveCluster();
 
-    public void removeNode(String nodeName);
+    void removeNode(String nodeName);
 
-    public void recoverFailedNode(String nodeName);
+    void recoverFailedNode(String nodeName);
 
-    public void commitCluster();
+    void commitCluster();
 
-    public String getOsMajorVersion();
+    String getOsMajorVersion();
+
+    void applyBucketType(String bucketTypeName, String bucketTypeProperties);
 }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeDriver.java
@@ -20,6 +20,8 @@ package brooklyn.entity.nosql.riak;
 
 import brooklyn.entity.basic.SoftwareProcessDriver;
 
+import java.util.List;
+
 public interface RiakNodeDriver extends SoftwareProcessDriver {
 
     String getRiakEtcDir();
@@ -36,5 +38,13 @@ public interface RiakNodeDriver extends SoftwareProcessDriver {
 
     String getOsMajorVersion();
 
-    void applyBucketType(String bucketTypeName, String bucketTypeProperties);
+    void bucketTypeCreate(String bucketTypeName, String bucketTypeProperties);
+
+    List<String> bucketTypeList();
+
+    List<String> bucketTypeStatus(String bucketTypeName);
+
+    void bucketTypeUpdate(String bucketTypeName, String bucketTypeProperties);
+
+    void bucketTypeActivate(String bucketTypeName);
 }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeDriver.java
@@ -34,8 +34,6 @@ public interface RiakNodeDriver extends SoftwareProcessDriver {
 
     void recoverFailedNode(String nodeName);
 
-    void commitCluster();
-
     String getOsMajorVersion();
 
     void bucketTypeCreate(String bucketTypeName, String bucketTypeProperties);

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -203,11 +203,6 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
     }
 
     @Override
-    public void commitCluster() {
-        getDriver().commitCluster();
-    }
-
-    @Override
     public void bucketTypeCreate(String bucketTypeName, String bucketTypeProperties) {
         getDriver().bucketTypeCreate(bucketTypeName, bucketTypeProperties);
     }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -208,6 +208,11 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
     }
 
     @Override
+    public void applyBucketType(String bucketTypeName, String bucketTypeProperties) {
+        getDriver().applyBucketType(bucketTypeName, bucketTypeProperties);
+    }
+
+    @Override
     public void recoverFailedNode(String nodeName) {
         getDriver().recoverFailedNode(nodeName);
     }

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -208,8 +208,28 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
     }
 
     @Override
-    public void applyBucketType(String bucketTypeName, String bucketTypeProperties) {
-        getDriver().applyBucketType(bucketTypeName, bucketTypeProperties);
+    public void bucketTypeCreate(String bucketTypeName, String bucketTypeProperties) {
+        getDriver().bucketTypeCreate(bucketTypeName, bucketTypeProperties);
+    }
+
+    @Override
+    public List<String> bucketTypeList() {
+        return getDriver().bucketTypeList();
+    }
+
+    @Override
+    public List<String> bucketTypeStatus(String bucketTypeName) {
+        return getDriver().bucketTypeStatus(bucketTypeName);
+    }
+
+    @Override
+    public void bucketTypeUpdate(String bucketTypeName, String bucketTypeProperties) {
+        getDriver().bucketTypeUpdate(bucketTypeName, bucketTypeProperties);
+    }
+
+    @Override
+    public void bucketTypeActivate(String bucketTypeName) {
+        getDriver().bucketTypeActivate(bucketTypeName);
     }
 
     @Override

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -445,24 +445,6 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
     }
 
     @Override
-    public void commitCluster() {
-        if (hasJoinedCluster()) {
-            ScriptHelper commitClusterScript = newScript("commitCluster")
-                    .body.append(sudo(format("%s cluster plan", getRiakAdminCmd())))
-                    .body.append(sudo(format("%s cluster commit", getRiakAdminCmd())))
-                    .failOnNonZeroResultCode();
-
-            if (!isRiakOnPath()) {
-                addRiakOnPath(commitClusterScript);
-            }
-            commitClusterScript.execute();
-
-        } else {
-            log.warn("entity {}: is not in the riak cluster", entity.getId());
-        }
-    }
-
-    @Override
     public void bucketTypeCreate(String bucketTypeName, String bucketTypeProperties) {
         ScriptHelper bucketTypeCreateScript = newScript("bucket-type_create " + bucketTypeName)
                 .body.append(sudo(format("%s bucket-type create %s %s",
@@ -515,7 +497,6 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
                         getRiakAdminCmd(),
                         bucketTypeName,
                         escapeLiteralForDoubleQuotedBash(bucketTypeProperties))))
-                .noExtraOutput()
                 .failOnNonZeroResultCode();
         if (!isRiakOnPath()) {
             addRiakOnPath(bucketTypeStatusScript);
@@ -527,7 +508,6 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
     public void bucketTypeActivate(String bucketTypeName) {
         ScriptHelper bucketTypeStatusScript = newScript("bucket-type_activate")
                 .body.append(sudo(format("%s bucket-type activate %s", getRiakAdminCmd(), bucketTypeName)))
-                .noExtraOutput()
                 .failOnNonZeroResultCode();
         if (!isRiakOnPath()) {
             addRiakOnPath(bucketTypeStatusScript);

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -28,6 +28,7 @@ import static brooklyn.util.ssh.BashCommands.ifExecutableElse;
 import static brooklyn.util.ssh.BashCommands.ifNotExecutable;
 import static brooklyn.util.ssh.BashCommands.ok;
 import static brooklyn.util.ssh.BashCommands.sudo;
+import static brooklyn.util.text.StringEscapes.BashStringEscapes.escapeLiteralForDoubleQuotedBash;
 import static java.lang.String.format;
 
 import java.net.URI;
@@ -54,10 +55,10 @@ import brooklyn.util.text.Strings;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
 // TODO: Alter -env ERL_CRASH_DUMP path in vm.args
 public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implements RiakNodeDriver {
 
@@ -471,6 +472,18 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
         } else {
             log.warn("entity {}: is not in the riak cluster", entity.getId());
         }
+    }
+
+    @Override
+    public void applyBucketType(String bucketTypeName, String bucketTypeProperties) {
+        newScript("bucket-type create " + bucketTypeName)
+                .body.append(sudo(format(
+                    "%s bucket-type create %s %s",
+                    getRiakAdminCmd(),
+                    bucketTypeName,
+                    escapeLiteralForDoubleQuotedBash(bucketTypeProperties))))
+                .failOnNonZeroResultCode()
+                .execute();
     }
 
     @Override

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -390,6 +390,8 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
             if (!hasJoinedCluster()) {
                 ScriptHelper joinClusterScript = newScript("joinCluster")
                         .body.append(sudo(format("%s cluster join %s", getRiakAdminCmd(), nodeName)))
+                        .body.append(sudo(format("%s cluster plan", getRiakAdminCmd())))
+                        .body.append(sudo(format("%s cluster commit", getRiakAdminCmd())))
                         .failOnNonZeroResultCode();
 
                 if (!isRiakOnPath()) {
@@ -603,7 +605,7 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
 
     private void addRiakOnPath(ScriptHelper scriptHelper) {
         Map<String, String> newPathVariable = ImmutableMap.of("PATH", sbinPath);
-        log.warn("riak command not found on PATH. Altering future commands' environment variables from {} to {}", getShellEnvironment(), newPathVariable);
+//        log.warn("riak command not found on PATH. Altering future commands' environment variables from {} to {}", getShellEnvironment(), newPathVariable);
         scriptHelper.environmentVariablesReset(newPathVariable);
     }
 }


### PR DESCRIPTION
This is the initial pull request for supporting riak bucket types in brooklyn.
http://docs.basho.com/riak/latest/dev/advanced/bucket-types/

Bucket types are more used for dynamic configurations, for example changing easily properties of a running cluster.
Riak supports adding, updating and deleting bucket types.

I added an effector which creates a bucket type.
I still can not figure out how can we add some monitoring /sensors/ to those bucket types?