### PR TITLE
Parse service types in YAML using pluggable resolver impls

### DIFF
--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
@@ -88,7 +88,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
 
     public static class PolicySpecResolver extends BrooklynEntityDecorationResolver<PolicySpec<?>> {
         
-        protected PolicySpecResolver(BrooklynYamlTypeInstantiator.Factory loader) { super(loader); }
+        public PolicySpecResolver(BrooklynYamlTypeInstantiator.Factory loader) { super(loader); }
         @Override protected String getDecorationKind() { return "Policy"; }
 
         @Override
@@ -134,7 +134,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
 
     public static class EnricherSpecResolver extends BrooklynEntityDecorationResolver<EnricherSpec<?>> {
         
-        protected EnricherSpecResolver(BrooklynYamlTypeInstantiator.Factory loader) { super(loader); }
+        public EnricherSpecResolver(BrooklynYamlTypeInstantiator.Factory loader) { super(loader); }
         @Override protected String getDecorationKind() { return "Enricher"; }
 
         @Override
@@ -157,7 +157,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
     
     public static class InitializerResolver extends BrooklynEntityDecorationResolver<EntityInitializer> {
         
-        protected InitializerResolver(BrooklynYamlTypeInstantiator.Factory loader) { super(loader); }
+        public InitializerResolver(BrooklynYamlTypeInstantiator.Factory loader) { super(loader); }
         @Override protected String getDecorationKind() { return "Entity initializer"; }
 
         @Override

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/BrooklynServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/BrooklynServiceTypeResolver.java
@@ -39,7 +39,7 @@ import brooklyn.util.text.Strings;
  */
 public class BrooklynServiceTypeResolver implements ServiceTypeResolver {
 
-    private static final Logger log = LoggerFactory.getLogger(ServiceTypeResolver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceTypeResolver.class);
 
     @Override
     public String getTypePrefix() { return DEFAULT_TYPE_PREFIX; }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/BrooklynServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/BrooklynServiceTypeResolver.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.brooklyn.camp.brooklyn.spi.creation.service;
+
+import io.brooklyn.camp.brooklyn.spi.creation.BrooklynComponentTemplateResolver;
+import io.brooklyn.camp.brooklyn.spi.creation.BrooklynEntityDecorationResolver;
+import io.brooklyn.camp.spi.PlatformComponentTemplate;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import brooklyn.catalog.CatalogItem;
+import brooklyn.catalog.internal.CatalogUtils;
+import brooklyn.entity.Entity;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.util.text.Strings;
+
+/**
+ * This converts {@link PlatformComponentTemplate} instances whose type is prefixed {@code brooklyn:}
+ * to Brooklyn {@link EntitySpec} instances.
+ */
+public class BrooklynServiceTypeResolver implements ServiceTypeResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(ServiceTypeResolver.class);
+
+    @Override
+    public String getTypePrefix() { return DEFAULT_TYPE_PREFIX; }
+
+    @Override
+    public String getBrooklynType(String serviceType) {
+        String type = Strings.removeFromStart(serviceType, getTypePrefix() + ":").trim();
+        if (type == null) return null;
+        return type;
+    }
+
+    @Nullable
+    @Override
+    public CatalogItem<Entity,EntitySpec<?>> getCatalogItem(BrooklynComponentTemplateResolver resolver, String serviceType) {
+        String type = getBrooklynType(serviceType);
+        if (type != null) {
+            return CatalogUtils.getCatalogItemOptionalVersion(resolver.getManagementContext(), Entity.class,  type);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public <T extends Entity> void decorateSpec(BrooklynComponentTemplateResolver resolver, EntitySpec<T> spec) {
+        new BrooklynEntityDecorationResolver.PolicySpecResolver(resolver.getYamlLoader()).decorate(spec, resolver.getAttrs());
+        new BrooklynEntityDecorationResolver.EnricherSpecResolver(resolver.getYamlLoader()).decorate(spec, resolver.getAttrs());
+        new BrooklynEntityDecorationResolver.InitializerResolver(resolver.getYamlLoader()).decorate(spec, resolver.getAttrs());
+    }
+
+}

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/CatalogServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/CatalogServiceTypeResolver.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.brooklyn.camp.brooklyn.spi.creation.service;
+
+import io.brooklyn.camp.spi.PlatformComponentTemplate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import brooklyn.entity.basic.VanillaSoftwareProcess;
+import brooklyn.entity.group.DynamicCluster;
+import brooklyn.entity.group.DynamicRegionsFabric;
+import brooklyn.entity.proxying.EntitySpec;
+
+/**
+ * This converts {@link PlatformComponentTemplate} instances whose type is prefixed {@code catalog:}
+ * to Brooklyn {@link EntitySpec} instances.
+ */
+public class CatalogServiceTypeResolver extends BrooklynServiceTypeResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(ServiceTypeResolver.class);
+
+    @Override
+    public String getTypePrefix() { return "catalog"; }
+
+    @Override
+    public String getBrooklynType(String serviceType) {
+        String type = super.getBrooklynType(serviceType);
+        if (type == null) return null;
+
+        // TODO currently a hardcoded list of aliases; would like that to come from mgmt somehow
+        if (type.equals("cluster") || type.equals("Cluster")) return DynamicCluster.class.getName();
+        if (type.equals("fabric") || type.equals("Fabric")) return DynamicRegionsFabric.class.getName();
+        if (type.equals("vanilla") || type.equals("Vanilla")) return VanillaSoftwareProcess.class.getName();
+        if (type.equals("web-app-cluster") || type.equals("WebAppCluster"))
+            // TODO use service discovery; currently included as string to avoid needing a reference to it
+            return "brooklyn.entity.webapp.ControlledDynamicWebAppCluster";
+
+        return type;
+    }
+
+}

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ChefServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ChefServiceTypeResolver.java
@@ -16,42 +16,47 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.brooklyn.camp.brooklyn.spi.creation;
+package io.brooklyn.camp.brooklyn.spi.creation.service;
 
-import io.brooklyn.camp.spi.AbstractResource;
+import io.brooklyn.camp.brooklyn.spi.creation.BrooklynComponentTemplateResolver;
+import io.brooklyn.camp.spi.PlatformComponentTemplate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import brooklyn.catalog.CatalogItem;
 import brooklyn.entity.Entity;
 import brooklyn.entity.chef.ChefConfig;
 import brooklyn.entity.chef.ChefEntity;
 import brooklyn.entity.proxying.EntitySpec;
-import brooklyn.management.classloading.BrooklynClassLoadingContext;
-import brooklyn.util.config.ConfigBag;
 import brooklyn.util.text.Strings;
 
-public class ChefComponentTemplateResolver extends BrooklynComponentTemplateResolver {
+/**
+ * This converts {@link PlatformComponentTemplate} instances whose type is prefixed {@code chef:}
+ * to Brooklyn {@link EntitySpec} instances.
+ */
+public class ChefServiceTypeResolver extends BrooklynServiceTypeResolver {
 
-    public ChefComponentTemplateResolver(BrooklynClassLoadingContext loader, ConfigBag attrs, AbstractResource optionalTemplate) {
-        super(loader, attrs, optionalTemplate);
-    }
+    private static final Logger log = LoggerFactory.getLogger(ServiceTypeResolver.class);
 
     @Override
-    protected String getBrooklynType() {
+    public String getTypePrefix() { return "chef"; }
+
+    @Override
+    public String getBrooklynType(String serviceType) {
         return ChefEntity.class.getName();
     }
 
     // chef: items are not in catalog
     @Override
-    public CatalogItem<Entity, EntitySpec<?>> getCatalogItem() {
+    public CatalogItem<Entity, EntitySpec<?>> getCatalogItem(BrooklynComponentTemplateResolver resolver, String serviceType) {
         return null;
     }
-    
+
     @Override
-    protected <T extends Entity> void decorateSpec(EntitySpec<T> spec) {
-        if (getDeclaredType().startsWith("chef:")) {
-            spec.configure(ChefConfig.CHEF_COOKBOOK_PRIMARY_NAME, Strings.removeFromStart(getDeclaredType(), "chef:"));
-        }
-        
-        super.decorateSpec(spec);
+    public <T extends Entity> void decorateSpec(BrooklynComponentTemplateResolver resolver, EntitySpec<T> spec) {
+        spec.configure(ChefConfig.CHEF_COOKBOOK_PRIMARY_NAME, Strings.removeFromStart(resolver.getDeclaredType(), "chef:"));
+        super.decorateSpec(resolver, spec);
     }
     
 }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ChefServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ChefServiceTypeResolver.java
@@ -37,7 +37,7 @@ import brooklyn.util.text.Strings;
  */
 public class ChefServiceTypeResolver extends BrooklynServiceTypeResolver {
 
-    private static final Logger log = LoggerFactory.getLogger(ServiceTypeResolver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceTypeResolver.class);
 
     @Override
     public String getTypePrefix() { return "chef"; }
@@ -47,7 +47,7 @@ public class ChefServiceTypeResolver extends BrooklynServiceTypeResolver {
         return ChefEntity.class.getName();
     }
 
-    // chef: items are not in catalog
+    /** Chef items are not in the catalog. */
     @Override
     public CatalogItem<Entity, EntitySpec<?>> getCatalogItem(BrooklynComponentTemplateResolver resolver, String serviceType) {
         return null;

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/JavaServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/JavaServiceTypeResolver.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.brooklyn.camp.brooklyn.spi.creation.service;
+
+/**
+ * This converts {@link PlatformComponentTemplate} instances whose type is prefixed {@code java:}
+ * to Brooklyn {@link EntitySpec} instances.
+ */
+public class JavaServiceTypeResolver extends BrooklynServiceTypeResolver {
+
+    @Override
+    public String getTypePrefix() { return "java"; }
+    
+}

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/JavaServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/JavaServiceTypeResolver.java
@@ -18,11 +18,20 @@
  */
 package io.brooklyn.camp.brooklyn.spi.creation.service;
 
+import io.brooklyn.camp.spi.PlatformComponentTemplate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import brooklyn.entity.proxying.EntitySpec;
+
 /**
  * This converts {@link PlatformComponentTemplate} instances whose type is prefixed {@code java:}
  * to Brooklyn {@link EntitySpec} instances.
  */
 public class JavaServiceTypeResolver extends BrooklynServiceTypeResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceTypeResolver.class);
 
     @Override
     public String getTypePrefix() { return "java"; }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ServiceTypeResolver.java
@@ -18,17 +18,40 @@
  */
 package io.brooklyn.camp.brooklyn.spi.creation.service;
 
+import java.util.ServiceLoader;
+
 import io.brooklyn.camp.brooklyn.spi.creation.BrooklynComponentTemplateResolver;
 import brooklyn.catalog.CatalogItem;
 import brooklyn.entity.Entity;
 import brooklyn.entity.proxying.EntitySpec;
 
+/**
+ * Resolves and decorates {@link EntitySpec entity specifications} based on the {@code serviceType} in a template.
+ * <p>
+ * The {@link #getTypePrefix()} method returns a string that should match the beginning of the
+ * service type. The resolver implementation will use the rest of the service type information
+ * to create and decorate an approprate {@link EntitySpec entity}.
+ * <p>
+ * The resolvers are loaded using the {@link ServiceLoader} mechanism, allowing external libraries
+ * to add extra service type implementations that will be picked up at runtime.
+ *
+ * @see BrooklynServiceTypeResolver
+ * @see ChefServiceTypeResolver
+ */
 public interface ServiceTypeResolver {
 
     String DEFAULT_TYPE_PREFIX = "brooklyn";
 
+    /**
+     * The service type prefix the resolver is responsible for.
+     */
     String getTypePrefix();
 
+    /**
+     * The name of the Java type that Brooklyn will instantiate to create the
+     * service. This can be generated from parts of the service type information
+     * or may be a fixed value.
+     */
     String getBrooklynType(String serviceType);
 
     /**
@@ -38,6 +61,13 @@ public interface ServiceTypeResolver {
      */
     CatalogItem<Entity, EntitySpec<?>> getCatalogItem(BrooklynComponentTemplateResolver resolver, String serviceType);
 
+    /**
+     * Takes the provided {@link EntitySpec} and decorates it appropriately for the service type.
+     * <p>
+     * This includes setting configuration and adding policies, enrichers and initializers.
+     *
+     * @see BrooklynServiceTypeResolver#decorateSpec(BrooklynComponentTemplateResolver, EntitySpec)
+     */
     <T extends Entity> void decorateSpec(BrooklynComponentTemplateResolver resolver, EntitySpec<T> spec);
 
 }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ServiceTypeResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/service/ServiceTypeResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.brooklyn.camp.brooklyn.spi.creation.service;
+
+import io.brooklyn.camp.brooklyn.spi.creation.BrooklynComponentTemplateResolver;
+import brooklyn.catalog.CatalogItem;
+import brooklyn.entity.Entity;
+import brooklyn.entity.proxying.EntitySpec;
+
+public interface ServiceTypeResolver {
+
+    String DEFAULT_TYPE_PREFIX = "brooklyn";
+
+    String getTypePrefix();
+
+    String getBrooklynType(String serviceType);
+
+    /**
+     * Returns the {@link CatalogItem} if there is one for the given type.
+     * <p>
+     * If no type, callers should fall back to default classloading.
+     */
+    CatalogItem<Entity, EntitySpec<?>> getCatalogItem(BrooklynComponentTemplateResolver resolver, String serviceType);
+
+    <T extends Entity> void decorateSpec(BrooklynComponentTemplateResolver resolver, EntitySpec<T> spec);
+
+}

--- a/usage/camp/src/main/resources/META-INF/services/io.brooklyn.camp.brooklyn.spi.creation.service.ServiceTypeResolver
+++ b/usage/camp/src/main/resources/META-INF/services/io.brooklyn.camp.brooklyn.spi.creation.service.ServiceTypeResolver
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+io.brooklyn.camp.brooklyn.spi.creation.service.BrooklynServiceTypeResolver
+io.brooklyn.camp.brooklyn.spi.creation.service.CatalogServiceTypeResolver
+io.brooklyn.camp.brooklyn.spi.creation.service.ChefServiceTypeResolver
+io.brooklyn.camp.brooklyn.spi.creation.service.JavaServiceTypeResolver


### PR DESCRIPTION
Adds a `ServiceLoader` plugin capability for parsing the `serviceType: xxx:yyy` part of the YAML blueprint. Includes `brooklyn:`, `java:`, `catalog:` and `chef:` implementations. This will be useful for a `docker:` service type prefix in Clocker.

This is based on my comment on #436 and @neykov's suggestions there.