### PR TITLE
Catalogitemsummaryfix

### DIFF
--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogItemSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogItemSummary.java
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+/* This class is placed here as a workaround to an issue where registeredType was missing */
 package brooklyn.rest.domain;
 
 import java.net.URI;
@@ -78,6 +80,32 @@ public class CatalogItemSummary implements HasId, HasName {
         this.deprecated = deprecated;
         this.registeredType=registeredType;
     }
+
+    public CatalogItemSummary(
+            @JsonProperty("symbolicName") String symbolicName,
+            @JsonProperty("version") String version,
+            @JsonProperty("name") String displayName,
+            @JsonProperty("javaType") String javaType,
+            @JsonProperty("planYaml") String planYaml,
+            @JsonProperty("description") String description,
+            @JsonProperty("iconUrl") String iconUrl,
+            @JsonProperty("deprecated") boolean deprecated,
+            @JsonProperty("links") Map<String, URI> links
+    ) {
+        this.id = symbolicName + ":" + version;
+        this.symbolicName = symbolicName;
+        this.type = symbolicName;
+        this.version = version;
+        this.name = displayName;
+        this.javaType = javaType;
+        this.planYaml = planYaml;
+        this.description = description;
+        this.iconUrl = iconUrl;
+        this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
+        this.deprecated = deprecated;
+        this.registeredType=null;
+    }
+
 
     @Override
     public String getId() {

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogItemSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogItemSummary.java
@@ -40,9 +40,9 @@ public class CatalogItemSummary implements HasId, HasName {
     //needed for backwards compatibility only (json serializer works on fields, not getters)
     @Deprecated
     private final String type;
-    
+
     private final String javaType;
-    
+
     private final String name;
     @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final String description;
@@ -50,7 +50,7 @@ public class CatalogItemSummary implements HasId, HasName {
     private final String iconUrl;
     private final String planYaml;
     private final boolean deprecated;
-    
+    private final String registeredType;
     private final Map<String, URI> links;
 
     public CatalogItemSummary(
@@ -62,8 +62,9 @@ public class CatalogItemSummary implements HasId, HasName {
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
             @JsonProperty("deprecated") boolean deprecated,
-            @JsonProperty("links") Map<String, URI> links
-            ) {
+            @JsonProperty("links") Map<String, URI> links,
+            @JsonProperty("registeredType") String registeredType
+    ) {
         this.id = symbolicName + ":" + version;
         this.symbolicName = symbolicName;
         this.type = symbolicName;
@@ -75,11 +76,16 @@ public class CatalogItemSummary implements HasId, HasName {
         this.iconUrl = iconUrl;
         this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
         this.deprecated = deprecated;
+        this.registeredType=registeredType;
     }
 
     @Override
     public String getId() {
         return id;
+    }
+
+    public String getRegisteredType(){
+        return registeredType;
     }
 
     public String getSymbolicName() {
@@ -136,10 +142,10 @@ public class CatalogItemSummary implements HasId, HasName {
     public int hashCode() {
         return Objects.hashCode(symbolicName, version, name, javaType, deprecated);
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         return EqualsBuilder.reflectionEquals(this, obj);
     }
-    
+
 }


### PR DESCRIPTION
Not sure if this is the correct way to resolve this issue:

- There are some code that is using this POJO that are providing the registeredType and others that do not. 
- If the registeredType is present and the constructor does not take it , the mapping would fail, if registeredType is not present and the constructor expects the registeredType the number of arguments would not match.
- I ended up adding a new constructor that takes the registeredType, and leaving the one that does not in place
