### PR TITLE
Riak - Fix installation from packagecloud.io on CentOS 6

### DIFF
--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -207,7 +207,7 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
     private ImmutableList<String> installRpmBased() {
         return ImmutableList.<String>builder()
                 .add("curl https://packagecloud.io/install/repositories/basho/riak/script.rpm | " + BashCommands.sudo("bash"))
-                .add(BashCommands.sudo("yum install -y riak-" + getEntity().getFullVersion() + "-1"))
+                .add(BashCommands.sudo("yum install -y riak-" + getEntity().getFullVersion() + "*"))
                 .build();
     }
 


### PR DESCRIPTION
On CentOS 6 and Redhat 6 installing needs to be done with `yum install -y riak-2.0.5` instead of `riak-2.0.5-1 ` which is written on the packagecloud website.
All tests from RiakNodeEc2LiveTest are passing