### PR TITLE
Fix delete location from catalog

### DIFF
--- a/core/src/test/java/brooklyn/entity/rebind/RebindCatalogItemTest.java
+++ b/core/src/test/java/brooklyn/entity/rebind/RebindCatalogItemTest.java
@@ -146,7 +146,7 @@ public class RebindCatalogItemTest extends RebindTestFixtureWithApp {
     }
 
     @Test
-    public void testAddAndRebindLocation() {
+    public void testAddAndRebindAndDeleteLocation() {
         String yaml = Joiner.on("\n").join(ImmutableList.of(
                 "name: Test Location",
                 "brooklyn.catalog:",
@@ -159,6 +159,11 @@ public class RebindCatalogItemTest extends RebindTestFixtureWithApp {
                 "    cfg2: 222"));
         CatalogItem<?, ?> added = addItem(origManagementContext, yaml);
         assertEquals(added.getCatalogItemType(), CatalogItemType.LOCATION);
+        rebindAndAssertCatalogsAreEqual();
+        
+        deleteItem(newManagementContext, added.getSymbolicName(), added.getVersion());
+        
+        switchOriginalToNewManagementContext();
         rebindAndAssertCatalogsAreEqual();
     }
 
@@ -237,6 +242,12 @@ public class RebindCatalogItemTest extends RebindTestFixtureWithApp {
         LOG.info("Added item to catalog: {}, id={}", added, added.getId());
         assertCatalogContains(mgmt.getCatalog(), added);
         return added;
+    }
+    
+    protected void deleteItem(ManagementContext mgmt, String symbolicName, String version) {
+        mgmt.getCatalog().deleteCatalogItem(symbolicName, version);
+        LOG.info("Deleted item from catalog: {}:{}", symbolicName, version);
+        assertCatalogDoesNotContain(mgmt.getCatalog(), symbolicName, version);
     }
     
     private void rebindAndAssertCatalogsAreEqual() {

--- a/core/src/test/java/brooklyn/entity/rebind/RebindTestFixture.java
+++ b/core/src/test/java/brooklyn/entity/rebind/RebindTestFixture.java
@@ -20,6 +20,7 @@ package brooklyn.entity.rebind;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import java.io.File;
 import java.util.List;
@@ -315,5 +316,10 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
         CatalogItem<?, ?> found = catalog.getCatalogItem(item.getSymbolicName(), item.getVersion());
         assertNotNull(found);
         assertCatalogItemsEqual(found, item);
+    }
+    
+    protected void assertCatalogDoesNotContain(BrooklynCatalog catalog, String symbolicName, String version) {
+        CatalogItem<?, ?> found = catalog.getCatalogItem(symbolicName, version);
+        assertNull(found);
     }
 }

--- a/usage/rest-api/src/main/java/brooklyn/rest/api/CatalogApi.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/api/CatalogApi.java
@@ -37,6 +37,8 @@ import javax.ws.rs.core.Response;
 import brooklyn.rest.apidoc.Apidoc;
 import brooklyn.rest.domain.CatalogEntitySummary;
 import brooklyn.rest.domain.CatalogItemSummary;
+import brooklyn.rest.domain.CatalogLocationSummary;
+import brooklyn.rest.domain.CatalogPolicySummary;
 
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
@@ -52,7 +54,7 @@ import com.wordnik.swagger.core.ApiParam;
 public interface CatalogApi {
 
     @POST
-    @ApiOperation(value = "Add a catalog item (e.g. new entity or policy type) by uploading YAML descriptor from browser using multipart/form-data",
+    @ApiOperation(value = "Add a catalog item (e.g. new type of entity, policy or location) by uploading YAML descriptor from browser using multipart/form-data",
         responseClass = "String")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response createFromMultipart(
@@ -62,7 +64,7 @@ public interface CatalogApi {
 
     @Consumes
     @POST
-    @ApiOperation(value = "Add a catalog item (e.g. new entity or policy type) by uploading YAML descriptor", responseClass = "String")
+    @ApiOperation(value = "Add a catalog item (e.g. new type of entity, policy or location) by uploading YAML descriptor", responseClass = "String")
     public Response create(
             @ApiParam(name = "yaml", value = "YAML descriptor of catalog item", required = true)
             @Valid String yaml);
@@ -75,7 +77,7 @@ public interface CatalogApi {
             @ApiParam(name = "xml", value = "XML descriptor of the entire catalog to install", required = true)
             @Valid String xml);
 
-    /** @deprecated since 0.7.0 use {@link #getEntity(String, String)} */
+    /** @deprecated since 0.7.0 use {@link #deleteEntity(String, String)} */
     @Deprecated
     @DELETE
     @Path("/entities/{entityId}")
@@ -100,10 +102,36 @@ public interface CatalogApi {
         @ApiParam(name = "version", value = "The version identifier of the entity or template to delete", required = true)
         @PathParam("version") String version) throws Exception;
 
+    @DELETE
+    @Path("/policies/{policyId}/{version}")
+    @ApiOperation(value = "Deletes a specific version of an policy's definition from the catalog")
+    @ApiErrors(value = {
+        @ApiError(code = 404, reason = "Policy not found")
+    })
+    public void deletePolicy(
+        @ApiParam(name = "policyId", value = "The ID of the policy to delete", required = true)
+        @PathParam("policyId") String policyId,
+
+        @ApiParam(name = "version", value = "The version identifier of the policy to delete", required = true)
+        @PathParam("version") String version) throws Exception;
+
+    @DELETE
+    @Path("/locations/{locationId}/{version}")
+    @ApiOperation(value = "Deletes a specific version of an location's definition from the catalog")
+    @ApiErrors(value = {
+        @ApiError(code = 404, reason = "Location not found")
+    })
+    public void deleteLocation(
+        @ApiParam(name = "locationId", value = "The ID of the location to delete", required = true)
+        @PathParam("locationId") String locationId,
+
+        @ApiParam(name = "version", value = "The version identifier of the location to delete", required = true)
+        @PathParam("version") String version) throws Exception;
+
     @GET
     @Path("/entities")
     @ApiOperation(value = "List available entity types optionally matching a query", responseClass = "CatalogItemSummary", multiValueResponse = true)
-    public List<CatalogItemSummary> listEntities(
+    public List<CatalogEntitySummary> listEntities(
         @ApiParam(name = "regex", value = "Regular expression to search for")
         @QueryParam("regex") @DefaultValue("") String regex,
         @ApiParam(name = "fragment", value = "Substring case-insensitive to search for")
@@ -170,14 +198,14 @@ public interface CatalogApi {
 
     @GET
     @Path("/policies")
-    @ApiOperation(value = "List available policies optionally matching a query", responseClass = "CatalogItemSummary", multiValueResponse = true)
-    public List<CatalogItemSummary> listPolicies(
+    @ApiOperation(value = "List available policies optionally matching a query", responseClass = "CatalogPolicySummary", multiValueResponse = true)
+    public List<CatalogPolicySummary> listPolicies(
             @ApiParam(name = "regex", value = "Regular expression to search for")
             @QueryParam("regex") @DefaultValue("") String regex,
             @ApiParam(name = "fragment", value = "Substring case-insensitive to search for")
             @QueryParam("fragment") @DefaultValue("") String fragment);
     
-    /** @deprecated since 0.7.0 use {@link #getEntity(String, String)} */
+    /** @deprecated since 0.7.0 use {@link #getPolicy(String, String)} */
     @Deprecated
     @GET
     @Path("/policies/{policyId}")
@@ -201,6 +229,39 @@ public interface CatalogApi {
         @ApiParam(name = "version", value = "The version identifier of the application to retrieve", required = true)
         @PathParam("version") String version) throws Exception;
     
+    @GET
+    @Path("/locations")
+    @ApiOperation(value = "List available locations optionally matching a query", responseClass = "CatalogLocationSummary", multiValueResponse = true)
+    public List<CatalogLocationSummary> listLocations(
+            @ApiParam(name = "regex", value = "Regular expression to search for")
+            @QueryParam("regex") @DefaultValue("") String regex,
+            @ApiParam(name = "fragment", value = "Substring case-insensitive to search for")
+            @QueryParam("fragment") @DefaultValue("") String fragment);
+    
+    /** @deprecated since 0.7.0 use {@link #getLocation(String, String)} */
+    @Deprecated
+    @GET
+    @Path("/locations/{locationId}")
+    @ApiOperation(value = "Fetch a location's definition from the catalog", responseClass = "CatalogItemSummary", multiValueResponse = true)
+    @ApiErrors(value = {
+        @ApiError(code = 404, reason = "Entity not found")
+    })
+    public CatalogItemSummary getLocation(
+        @ApiParam(name = "locationId", value = "The ID of the location to retrieve", required = true)
+        @PathParam("locationId") String locationId) throws Exception;
+    
+    @GET
+    @Path("/locations/{locationId}/{version}")
+    @ApiOperation(value = "Fetch a location's definition from the catalog", responseClass = "CatalogItemSummary", multiValueResponse = true)
+    @ApiErrors(value = {
+        @ApiError(code = 404, reason = "Entity not found")
+    })
+    public CatalogItemSummary getLocation(
+        @ApiParam(name = "locationId", value = "The ID of the location to retrieve", required = true)
+        @PathParam("locationId") String locationId,
+        @ApiParam(name = "version", value = "The version identifier of the application to retrieve", required = true)
+        @PathParam("version") String version) throws Exception;
+    
     /** @deprecated since 0.7.0 use {@link #getIcon(String, String)} */
     @Deprecated
     @GET
@@ -211,7 +272,7 @@ public interface CatalogApi {
         })
     @Produces("application/image")
     public Response getIcon(
-        @ApiParam(name = "itemId", value = "ID of catalog item (application, entity, policy)")
+        @ApiParam(name = "itemId", value = "ID of catalog item (application, entity, policy, location)")
         @PathParam("itemId") @DefaultValue("") String itemId);
 
     @GET
@@ -222,10 +283,10 @@ public interface CatalogApi {
         })
     @Produces("application/image")
     public Response getIcon(
-        @ApiParam(name = "itemId", value = "ID of catalog item (application, entity, policy)", required=true)
+        @ApiParam(name = "itemId", value = "ID of catalog item (application, entity, policy, location)", required=true)
         @PathParam("itemId") String itemId,
 
-        @ApiParam(name = "version", value = "version identifier of catalog item (application, entity, policy)", required=true)
+        @ApiParam(name = "version", value = "version identifier of catalog item (application, entity, policy, location)", required=true)
         @PathParam("version") String version);
 
     @POST

--- a/usage/rest-api/src/main/java/brooklyn/rest/api/LocationApi.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/api/LocationApi.java
@@ -47,10 +47,14 @@ import com.wordnik.swagger.core.ApiParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface LocationApi {
 
+    /**
+     * @deprecated since 0.7.0; use {@link CatalogApi#listLocations(String, String)}
+     */
     @GET
-    @ApiOperation(value = "Fetch the list of locations",
+    @ApiOperation(value = "Fetch the list of location definitions",
             responseClass = "brooklyn.rest.domain.LocationSummary",
             multiValueResponse = true)
+    @Deprecated
     public List<LocationSummary> list();
 
     // this is here to support the web GUI's circles
@@ -59,9 +63,13 @@ public interface LocationApi {
     @ApiOperation(value = "Return a summary of all usage", notes="interim API, expected to change")
     public Map<String,Map<String,Object>> getLocatedLocations();
 
+    /**
+     * WARNING: behaviour will change in a future release; this will only return location instances.
+     * See {@link CatalogApi#getLocation(String, String)} for retrieving location definitions.
+     */
     @GET
     @Path("/{locationId}")
-    @ApiOperation(value = "Fetch details about a location",
+    @ApiOperation(value = "Fetch details about a location instance, or a location definition",
             responseClass = "brooklyn.rest.domain.LocationSummary",
             multiValueResponse = true)
     public LocationSummary get(
@@ -71,15 +79,23 @@ public interface LocationApi {
             @DefaultValue("false")
             @QueryParam("full") String fullConfig);
 
+    /**
+     * @deprecated since 0.7.0; use {@link CatalogApi#create(String)}
+     */
     @POST
-    @ApiOperation(value = "Create a new location", responseClass = "String")
+    @ApiOperation(value = "Create a new location definition", responseClass = "String")
+    @Deprecated
     public Response create(
             @ApiParam(name = "locationSpec", value = "Location specification object", required = true)
             @Valid LocationSpec locationSpec);
 
+    /**
+     * @deprecated since 0.7.0; use {@link CatalogApi#deleteLocation(String, String)}
+     */
     @DELETE
     @Path("/{locationId}")
-    @ApiOperation(value = "Delete a location object by id")
+    @ApiOperation(value = "Deletes a location definition by id")
+    @Deprecated
     public void delete(
             @ApiParam(value = "Location id to delete", required = true)
             @PathParam("locationId") String locationId);

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogLocationSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogLocationSummary.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.domain;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.google.common.collect.ImmutableSet;
+
+public class CatalogLocationSummary extends CatalogItemSummary {
+
+    private final Set<LocationConfigSummary> config;
+
+    public CatalogLocationSummary(
+            @JsonProperty("symbolicName") String symbolicName,
+            @JsonProperty("version") String version,
+            @JsonProperty("name") String name,
+            @JsonProperty("javaType") String javaType,
+            @JsonProperty("planYaml") String planYaml,
+            @JsonProperty("description") String description,
+            @JsonProperty("iconUrl") String iconUrl,
+            @JsonProperty("config") Set<LocationConfigSummary> config,
+            @JsonProperty("deprecated") boolean deprecated,
+            @JsonProperty("links") Map<String, URI> links
+        ) {
+        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, deprecated, links);
+        // TODO expose config from policies
+        this.config = (config == null) ? ImmutableSet.<LocationConfigSummary>of() : config;
+    }
+    
+    public Set<LocationConfigSummary> getConfig() {
+        return config;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString()+"["+
+                "config="+getConfig()+"]";
+    }
+}

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/LocationConfigSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/LocationConfigSummary.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.domain;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+
+import com.google.common.collect.ImmutableMap;
+
+public class LocationConfigSummary extends ConfigSummary {
+
+    @JsonSerialize(include = Inclusion.NON_NULL)
+    private final Map<String, URI> links;
+
+    public LocationConfigSummary(
+            @JsonProperty("name") String name,
+            @JsonProperty("type") String type,
+            @JsonProperty("description") String description,
+            @JsonProperty("defaultValue") Object defaultValue,
+            @JsonProperty("reconfigurable") boolean reconfigurable,
+            @JsonProperty("label") String label,
+            @JsonProperty("priority") Double priority,
+            @JsonProperty("possibleValues") List<Map<String, String>> possibleValues,
+            @JsonProperty("links") Map<String, URI> links) {
+        super(name, type, description, defaultValue, reconfigurable, label, priority, possibleValues);
+        this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
+    }
+
+    @Override
+    public Map<String, URI> getLinks() {
+        return links;
+    }
+
+    @Override
+    public String toString() {
+        return "LocationConfigSummary{"
+                + "name='" + getName() + '\''
+                + ", type='" + getType() + '\''
+                + '}';
+  }
+}

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/LocationResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/LocationResource.java
@@ -149,7 +149,9 @@ public class LocationResource extends AbstractBrooklynRestResource implements Lo
                   .build();
     }
 
+    @Override
+    @Deprecated
     public void delete(String locationId) {
-        brooklyn().getLocationRegistry().removeDefinedLocation(locationId);
+        brooklyn().getCatalog().deleteCatalogItem(locationId);
     }
 }

--- a/usage/rest-server/src/main/java/brooklyn/rest/transform/CatalogTransformer.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/transform/CatalogTransformer.java
@@ -33,13 +33,17 @@ import brooklyn.entity.EntityType;
 import brooklyn.entity.basic.EntityDynamicType;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.event.Sensor;
+import brooklyn.location.Location;
+import brooklyn.location.LocationSpec;
 import brooklyn.policy.Policy;
 import brooklyn.policy.PolicySpec;
 import brooklyn.rest.domain.CatalogEntitySummary;
 import brooklyn.rest.domain.CatalogItemSummary;
+import brooklyn.rest.domain.CatalogLocationSummary;
 import brooklyn.rest.domain.CatalogPolicySummary;
 import brooklyn.rest.domain.EffectorSummary;
 import brooklyn.rest.domain.EntityConfigSummary;
+import brooklyn.rest.domain.LocationConfigSummary;
 import brooklyn.rest.domain.PolicyConfigSummary;
 import brooklyn.rest.domain.SensorSummary;
 import brooklyn.rest.domain.SummaryComparators;
@@ -86,6 +90,14 @@ public class CatalogTransformer {
     public static CatalogPolicySummary catalogPolicySummary(BrooklynRestResourceUtils b, CatalogItem<? extends Policy,PolicySpec<?>> item) {
         Set<PolicyConfigSummary> config = ImmutableSet.of();
         return new CatalogPolicySummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
+                item.getJavaType(), item.getPlanYaml(),
+                item.getDescription(), tidyIconLink(b, item, item.getIconUrl()), config,
+                item.isDeprecated(), makeLinks(item));
+    }
+
+    public static CatalogLocationSummary catalogLocationSummary(BrooklynRestResourceUtils b, CatalogItem<? extends Location,LocationSpec<?>> item) {
+        Set<LocationConfigSummary> config = ImmutableSet.of();
+        return new CatalogLocationSummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
                 item.getJavaType(), item.getPlanYaml(),
                 item.getDescription(), tidyIconLink(b, item, item.getIconUrl()), config,
                 item.isDeprecated(), makeLinks(item));

--- a/usage/rest-server/src/test/java/brooklyn/rest/resources/ApiDocResourceTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/resources/ApiDocResourceTest.java
@@ -98,7 +98,7 @@ public class ApiDocResourceTest extends BrooklynRestResourceTest {
     @Test
     public void testCatalogDetails() throws Exception {
         ApidocRoot response = client().resource("/v1/apidoc/brooklyn.rest.resources.CatalogResource").get(ApidocRoot.class);
-        assertEquals(countOperations(response), 16, "ops="+getOperations(response));
+        assertEquals(countOperations(response), 21, "ops="+getOperations(response));
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
- On REST api (LocationResource.delete), when location is deleted
  then delete from catalog as well as from LocationRegistry.
  (Otherwise on rebind it will come back again!)
- Adds LocationApi.delete(symbolicName, version);
  Previously just had delete(id))
- Adds to CatalogApi:
   - deletePolicy
   - deleteLocation
   - listLocations
- Change CatalogApi.listEntities return type to List<CatalogEntitySummary>
  instead of List<CatalogItemSummary>
- Cleanup LocationApi: deprecated methods to do with definitions,
  preferring CatalogApi usage.
- Adds CatalogLocationSummary and LocationConfigSummary