### PR TITLE
REST api domain objects Serializable

### DIFF
--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/AccessSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/AccessSummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -28,8 +29,10 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
 @Beta
-public class AccessSummary {
+public class AccessSummary implements Serializable {
 
+    private static final long serialVersionUID = 5097292906225042890L;
+    
     private final boolean locationProvisioningAllowed;
     private final Map<String, URI> links;
 

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/ApiError.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/ApiError.java
@@ -20,6 +20,8 @@ package brooklyn.rest.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.Serializable;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -34,7 +36,9 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 
-public class ApiError {
+public class ApiError implements Serializable {
+
+    private static final long serialVersionUID = -8244515572813244686L;
 
     public static Builder builder() {
         return new Builder();

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/ApplicationSpec.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/ApplicationSpec.java
@@ -20,6 +20,7 @@ package brooklyn.rest.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -32,7 +33,9 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class ApplicationSpec implements HasName {
+public class ApplicationSpec implements HasName, Serializable {
+
+    private static final long serialVersionUID = -7090404504233835343L;
 
     public static Builder builder() {
         return new Builder();

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/ApplicationSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/ApplicationSummary.java
@@ -20,6 +20,7 @@ package brooklyn.rest.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -27,7 +28,9 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 import com.google.common.collect.ImmutableMap;
 
-public class ApplicationSummary implements HasId {
+public class ApplicationSummary implements HasId, Serializable {
+
+    private static final long serialVersionUID = -247411021540729088L;
 
     private final static Map<Status, Status> validTransitions =
             ImmutableMap.<Status, Status>builder()

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogEntitySummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogEntitySummary.java
@@ -26,6 +26,8 @@ import org.codehaus.jackson.annotate.JsonProperty;
 
 public class CatalogEntitySummary extends CatalogItemSummary {
 
+    private static final long serialVersionUID = 1063908984191424539L;
+    
     private final Set<EntityConfigSummary> config;
     private final Set<SensorSummary> sensors;
     private final Set<EffectorSummary> effectors;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogItemSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogItemSummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -31,8 +32,10 @@ import com.google.common.collect.ImmutableMap;
 
 /** variant of Catalog*ItemDto objects for JS/JSON serialization;
  * see also, subclasses */
-public class CatalogItemSummary implements HasId, HasName {
+public class CatalogItemSummary implements HasId, HasName, Serializable {
 
+    private static final long serialVersionUID = -823483595879417681L;
+    
     private final String id;
     private final String symbolicName;
     private final String version;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogPolicySummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/CatalogPolicySummary.java
@@ -28,6 +28,8 @@ import com.google.common.collect.ImmutableSet;
 
 public class CatalogPolicySummary extends CatalogItemSummary {
 
+    private static final long serialVersionUID = -588856488327394445L;
+    
     private final Set<PolicyConfigSummary> config;
 
     public CatalogPolicySummary(

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/ConfigSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/ConfigSummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -36,8 +37,10 @@ import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 
-public abstract class ConfigSummary implements HasName {
+public abstract class ConfigSummary implements HasName, Serializable {
 
+    private static final long serialVersionUID = -2831796487073496730L;
+    
     private final String name;
     private final String type;
     @JsonSerialize(include = Inclusion.NON_NULL)

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/EffectorSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/EffectorSummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -29,9 +30,13 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
-public class EffectorSummary implements HasName {
+public class EffectorSummary implements HasName, Serializable {
 
-    public static class ParameterSummary<T> implements HasName {
+    private static final long serialVersionUID = 8103535211378449509L;
+
+    public static class ParameterSummary<T> implements HasName, Serializable {
+        private static final long serialVersionUID = -6393686096290306153L;
+        
         private final String name;
         private final String type;
         @JsonSerialize(include = Inclusion.NON_NULL)

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/EntityConfigSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/EntityConfigSummary.java
@@ -30,6 +30,8 @@ import java.util.Map;
 
 public class EntityConfigSummary extends ConfigSummary {
 
+    private static final long serialVersionUID = -1336134336883426030L;
+    
     @JsonSerialize(include = Inclusion.NON_NULL)
     private final Map<String, URI> links;
 

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/EntitySpec.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/EntitySpec.java
@@ -19,14 +19,19 @@
 package brooklyn.rest.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.ImmutableMap;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
-public class EntitySpec implements HasName {
+public class EntitySpec implements HasName, Serializable {
 
+    private static final long serialVersionUID = -3882575609132757188L;
+    
     private final String name;
     private final String type;
     private final Map<String, String> config;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/EntitySummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/EntitySummary.java
@@ -30,6 +30,8 @@ import java.util.Map;
 
 public class EntitySummary implements HasId, HasName, Serializable {
 
+    private static final long serialVersionUID = 100490507982229165L;
+    
     private final String id;
     private final String name;
     private final String type;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/HighAvailabilitySummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/HighAvailabilitySummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -26,9 +27,13 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
-public class HighAvailabilitySummary {
+public class HighAvailabilitySummary implements Serializable {
 
-    public static class HaNodeSummary {
+    private static final long serialVersionUID = -317333127094471223L;
+
+    public static class HaNodeSummary implements Serializable {
+        private static final long serialVersionUID = 9205960988226816539L;
+        
         private final String nodeId;
         private final URI nodeUri;
         private final String status;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/LinkWithMetadata.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/LinkWithMetadata.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -28,9 +29,11 @@ import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 
 @Beta
-public class LinkWithMetadata {
+public class LinkWithMetadata implements Serializable {
 
     // TODO remove 'metadata' and promote its contents to be top-level fields; then unmark as Beta
+
+    private static final long serialVersionUID = 3146368899471495143L;
     
     private final String link;
     private final Map<String,Object> metadata;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/LocationSpec.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/LocationSpec.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -32,8 +33,10 @@ import com.google.common.collect.ImmutableMap;
 
 // FIXME change name, due to confusion with brooklyn.location.LocationSpec <- no need, as we can kill the class instead soon!
 /** @deprecated since 0.7.0 location spec objects will not be used from the client, instead pass yaml location spec strings */
-public class LocationSpec implements HasName, HasConfig {
+public class LocationSpec implements HasName, HasConfig, Serializable {
 
+    private static final long serialVersionUID = -1562824224808185255L;
+    
     @JsonSerialize(include = Inclusion.NON_NULL)
     private final String name;
     @JsonSerialize(include = Inclusion.NON_NULL)

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/LocationSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/LocationSummary.java
@@ -34,6 +34,8 @@ import com.google.common.collect.ImmutableMap;
 
 public class LocationSummary extends LocationSpec implements HasName, HasId {
 
+    private static final long serialVersionUID = -4559153719273573670L;
+
     private final String id;
 
     /** only intended for instantiated Locations, not definitions */

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/PolicyConfigSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/PolicyConfigSummary.java
@@ -29,6 +29,8 @@ import com.google.common.collect.ImmutableMap;
 
 public class PolicyConfigSummary extends ConfigSummary {
 
+    private static final long serialVersionUID = 4339330833863794513L;
+    
     @JsonSerialize(include = Inclusion.NON_NULL)
     private final Map<String, URI> links;
 

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/PolicySummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/PolicySummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -27,8 +28,10 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 import com.google.common.collect.ImmutableMap;
 
-public class PolicySummary implements HasName, HasId {
+public class PolicySummary implements HasName, HasId, Serializable {
 
+    private static final long serialVersionUID = -5086680835225136768L;
+    
     private final String id;
     private final String name;
     @JsonSerialize(include = Inclusion.NON_NULL)

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/ScriptExecutionSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/ScriptExecutionSummary.java
@@ -18,12 +18,16 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
-public class ScriptExecutionSummary {
+public class ScriptExecutionSummary implements Serializable {
 
+    private static final long serialVersionUID = -7707936602991185960L;
+    
     @JsonSerialize(include = Inclusion.NON_NULL)
     private final Object result;
     @JsonSerialize(include = Inclusion.NON_EMPTY)

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/SensorSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/SensorSummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -27,8 +28,10 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 import com.google.common.collect.ImmutableMap;
 
-public class SensorSummary implements HasName {
+public class SensorSummary implements HasName, Serializable {
 
+    private static final long serialVersionUID = 1154308408351165426L;
+    
     private final String name;
     private final String type;
     @JsonSerialize(include = Inclusion.NON_NULL)

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/TaskSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/TaskSummary.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,8 +36,10 @@ import brooklyn.util.collections.Jsonya;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-public class TaskSummary implements HasId {
+public class TaskSummary implements HasId, Serializable {
 
+    private static final long serialVersionUID = 4637850742127078158L;
+    
     private final String id;
     private final String displayName;
     private final String entityId;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/UsageStatistic.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/UsageStatistic.java
@@ -23,6 +23,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -31,7 +32,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * @author Adam Lowe
  */
-public class UsageStatistic implements HasId {
+public class UsageStatistic implements HasId, Serializable {
+    
+    private static final long serialVersionUID = 5701414937003064442L;
+    
     private final Status status;
     private final String id;
     private final String applicationId;

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/UsageStatistics.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/UsageStatistics.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.rest.domain;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +32,10 @@ import com.google.common.collect.ImmutableMap;
 /**
  * @author Aled Sage
  */
-public class UsageStatistics {
+public class UsageStatistics implements Serializable {
 
+    private static final long serialVersionUID = -1842301852728290967L;
+    
     // TODO populate links with /apps endpoint to link to /usage/applications/{id}, to make it more
     // RESTy
 

--- a/usage/rest-api/src/main/java/brooklyn/rest/domain/VersionSummary.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/domain/VersionSummary.java
@@ -20,13 +20,17 @@ package brooklyn.rest.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.Serializable;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
-public class VersionSummary {
+public class VersionSummary implements Serializable {
 
+    private static final long serialVersionUID = 7275038546963638540L;
+    
     private final String version;
     private final String buildSha1;
     private final String buildBranch;


### PR DESCRIPTION
- Makes everything in brooklyn.rest.domain.* serialisable
- Useful for users of brooklyn.rest.client.BrooklynApi, where
  they use these Java objects. Serialisable is not necessary,
  but for subsequent usage (e.g. in a mule flow) then it is
  useful if they are.

See related PR #583 which has already been merged.