### PR TITLE
Switch to Tomcat for ControlledDynamicWebAppCluster

### DIFF
--- a/software/webapp/src/main/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterImpl.java
@@ -33,20 +33,20 @@ import brooklyn.entity.basic.DynamicGroupImpl;
 import brooklyn.entity.basic.Entities;
 import brooklyn.entity.basic.EntityPredicates;
 import brooklyn.entity.basic.Lifecycle;
-import brooklyn.entity.basic.QuorumCheck.QuorumChecks;
 import brooklyn.entity.basic.ServiceStateLogic;
 import brooklyn.entity.proxy.LoadBalancer;
 import brooklyn.entity.proxy.nginx.NginxController;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.trait.Startable;
 import brooklyn.entity.trait.StartableMethods;
-import brooklyn.entity.webapp.jboss.JBoss7Server;
+import brooklyn.entity.webapp.tomcat.TomcatServer;
 import brooklyn.event.SensorEvent;
 import brooklyn.event.SensorEventListener;
 import brooklyn.event.feed.ConfigToAttributes;
 import brooklyn.location.Location;
 import brooklyn.util.collections.MutableList;
 import brooklyn.util.collections.MutableMap;
+import brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import brooklyn.util.exceptions.Exceptions;
 
 import com.google.common.collect.ImmutableMap;
@@ -87,7 +87,7 @@ public class ControlledDynamicWebAppClusterImpl extends DynamicGroupImpl impleme
         EntitySpec<? extends WebAppService> webServerSpec = getAttribute(MEMBER_SPEC);
         if (webServerFactory == null && webServerSpec == null) {
             log.debug("creating default web server spec for {}", this);
-            webServerSpec = EntitySpec.create(JBoss7Server.class);
+            webServerSpec = EntitySpec.create(TomcatServer.class);
             setAttribute(MEMBER_SPEC, webServerSpec);
         }
         
@@ -139,8 +139,8 @@ public class ControlledDynamicWebAppClusterImpl extends DynamicGroupImpl impleme
 
     @Override
     protected void initEnrichers() {
-        if (getConfigRaw(UP_QUORUM_CHECK, false).isAbsent()) {
-            setConfig(UP_QUORUM_CHECK, QuorumChecks.newInstance(2, 1.0, false));
+        if (config().getLocalRaw(UP_QUORUM_CHECK).isAbsent()) {
+            config().set(UP_QUORUM_CHECK, QuorumChecks.newInstance(2, 1.0, false));
         }
         super.initEnrichers();
         ServiceStateLogic.newEnricherFromChildrenUp().checkChildrenOnly().requireUpChildren(getConfig(UP_QUORUM_CHECK)).addTo(this);

--- a/software/webapp/src/test/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterIntegrationTest.java
+++ b/software/webapp/src/test/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterIntegrationTest.java
@@ -39,7 +39,6 @@ import brooklyn.entity.proxy.LoadBalancer;
 import brooklyn.entity.proxy.nginx.NginxController;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.webapp.ControlledDynamicWebAppClusterTest.RecordingSensorEventListener;
-import brooklyn.entity.webapp.jboss.JBoss7Server;
 import brooklyn.entity.webapp.tomcat.TomcatServer;
 import brooklyn.location.basic.LocalhostMachineProvisioningLocation;
 import brooklyn.test.Asserts;
@@ -78,7 +77,7 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
     public void testConfiguresController() {
         ControlledDynamicWebAppCluster cluster = app.createAndManageChild(EntitySpec.create(ControlledDynamicWebAppCluster.class)
                 .configure("initialSize", 1)
-                .configure("memberSpec", EntitySpec.create(JBoss7Server.class).configure("war", getTestWar())));
+                .configure("memberSpec", EntitySpec.create(TomcatServer.class).configure("war", getTestWar())));
         app.start(locs);
 
         String url = cluster.getController().getAttribute(NginxController.ROOT_URL);
@@ -90,7 +89,7 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
     public void testSetsToplevelHostnameFromController() {
         ControlledDynamicWebAppCluster cluster = app.createAndManageChild(EntitySpec.create(ControlledDynamicWebAppCluster.class)
                 .configure("initialSize", 1)
-                .configure("memberSpec", EntitySpec.create(JBoss7Server.class).configure("war", getTestWar())));
+                .configure("memberSpec", EntitySpec.create(TomcatServer.class).configure("war", getTestWar())));
         app.start(locs);
 
         String expectedHostname = cluster.getController().getAttribute(LoadBalancer.HOSTNAME);
@@ -109,8 +108,8 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
     public void testCustomWebClusterSpecGetsMemberSpec() {
         ControlledDynamicWebAppCluster cluster = app.createAndManageChild(EntitySpec.create(ControlledDynamicWebAppCluster.class)
                 .configure("initialSize", 1)
-                .configure(ControlledDynamicWebAppCluster.MEMBER_SPEC, EntitySpec.create(JBoss7Server.class)
-                        .configure(JBoss7Server.ROOT_WAR, getTestWar()))
+                .configure(ControlledDynamicWebAppCluster.MEMBER_SPEC, EntitySpec.create(TomcatServer.class)
+                        .configure(TomcatServer.ROOT_WAR, getTestWar()))
                 .configure(ControlledDynamicWebAppCluster.WEB_CLUSTER_SPEC, EntitySpec.create(DynamicWebAppCluster.class)
                         .displayName("mydisplayname")));
         app.start(locs);


### PR DESCRIPTION
- Was previously a cluster of AS7 nodes; now Tomcat
- The reasons are:
  - Tomcat is a popular Apache project; Brooklyn is also in Apache
  - AS7 doesn’t support Java 8