### PR TITLE
propogates http/https ports to ControlledDynamicWebAppCluster entity

### DIFF
--- a/software/webapp/src/main/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterImpl.java
@@ -130,6 +130,7 @@ public class ControlledDynamicWebAppClusterImpl extends DynamicGroupImpl impleme
                 log.debug("creating controller using custom spec for {}", this);
             }
             controller = addChild(controllerSpec);
+            addEnricher(Enrichers.builder().propagating(LoadBalancer.PROXY_HTTP_PORT, LoadBalancer.PROXY_HTTPS_PORT).from(controller).build());
             if (Entities.isManaged(this)) Entities.manage(controller);
             setAttribute(CONTROLLER, controller);
         }

--- a/software/webapp/src/test/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterIntegrationTest.java
+++ b/software/webapp/src/test/java/brooklyn/entity/webapp/ControlledDynamicWebAppClusterIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import brooklyn.test.TestResourceUnavailableException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
@@ -49,6 +50,7 @@ import brooklyn.test.entity.TestJavaWebAppEntity;
 import brooklyn.util.collections.CollectionFunctionals;
 import brooklyn.util.collections.MutableMap;
 
+import com.google.common.base.Predicates;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -73,7 +75,17 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/hello-world.war");
         return "classpath://hello-world.war";
     }
+    
+    @Test(groups="Integration")
+    public void testPropogateHttpPorts() {
+        ControlledDynamicWebAppCluster cluster = app.createAndManageChild(EntitySpec.create(ControlledDynamicWebAppCluster.class)
+                .configure("initialSize", 1));
+        app.start(locs);
 
+        EntityTestUtils.assertAttributeEventuallyNonNull(cluster, LoadBalancer.PROXY_HTTP_PORT);
+        EntityTestUtils.assertAttributeEventuallyNonNull(cluster, LoadBalancer.PROXY_HTTPS_PORT);
+    }
+    
     @Test(groups="Integration")
     public void testConfiguresController() {
         ControlledDynamicWebAppCluster cluster = app.createAndManageChild(EntitySpec.create(ControlledDynamicWebAppCluster.class)


### PR DESCRIPTION
Advertises http and https ports to parent level application enabling them to be forwarded (for example).