### PR TITLE
Fixes to Brooklyn site documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,8 @@ familiarise yourself with the standard workflow for Apache Brooklyn:
 * [Guide for contributors][CONTRIB]
 * [Guide for committers][COMMIT]
 
-[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute-docs.html
-[COMMIT]: https://brooklyn.incubator.apache.org/community/committers.html
+[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute-docs.htmlq
+[COMMIT]: https://brooklyn.incubator.apache.org/developers/committers/index.html
 
 
 Workstation Setup

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ familiarise yourself with the standard workflow for Apache Brooklyn:
 * [Guide for contributors][CONTRIB]
 * [Guide for committers][COMMIT]
 
-[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute-docs.htmlq
+[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute-docs.html
 [COMMIT]: https://brooklyn.incubator.apache.org/developers/committers/index.html
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ familiarise yourself with the standard workflow for Apache Brooklyn:
 * [Guide for contributors][CONTRIB]
 * [Guide for committers][COMMIT]
 
-[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute.html
+[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute-docs.html
 [COMMIT]: https://brooklyn.incubator.apache.org/community/committers.html
 
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,6 +6,7 @@ breadcrumbs:
 - index.md
 children:
 - { path: /guide/start/index.md }
+- { path: /guide/misc/download.md }
 - { path: /guide/concepts/index.md }
 - { path: /guide/yaml/index.md }
 - { path: /guide/java/index.md }

--- a/docs/guide/ops/locations/index.md
+++ b/docs/guide/ops/locations/index.md
@@ -237,8 +237,8 @@ brooklyn.location.named.my-aws.KEY=VAL5
 
 ### Localhost
 
-If passwordless ssh login to `localhost` is enabled on your machine,
-you should be able to deploy blueprints with no special configuration,
+If passwordless ssh login to `localhost` and passwordless `sudo` is enabled on your 
+machine, you should be able to deploy blueprints with no special configuration,
 just by specifying `location: localhost` in YAML.
 
 If you use a passpharse or prefer a different key, these can be configured as follows: 


### PR DESCRIPTION
* Fixed broken links
* Added download link for improved ease of navigation
* Added passwordless `sudo` requirement to deploying on `localhost`