### PR TITLE
Fix global-web-fabric pom

### DIFF
--- a/examples/global-web-fabric/pom.xml
+++ b/examples/global-web-fabric/pom.xml
@@ -35,7 +35,6 @@
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-all</artifactId>
             <version>${project.version}</version>
-            <classifier>with-dependencies</classifier>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Was depending on brooklyn-all’s with-dependencies, but that has
been deleted. Instead just depend on brooklyn-all.