### PR TITLE
Don't retry jclouds requests on exception if unsafe request method

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -162,7 +162,8 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
         return ImmutableSet.<Module> of(
                 new SshjSshClientModule(), 
                 new SLF4JLoggingModule(),
-                new BouncyCastleCryptoModule());
+                new BouncyCastleCryptoModule(),
+                new IOExceptionSafeRetryModule());
     }
      
     protected String getDeprecatedProperty(ConfigBag conf, String key) {

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/IOExceptionSafeRetryHandler.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/IOExceptionSafeRetryHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.annotation.Resource;
+
+import org.jclouds.http.HttpCommand;
+import org.jclouds.http.IOExceptionRetryHandler;
+import org.jclouds.http.handlers.BackoffLimitedRetryHandler;
+import org.jclouds.logging.Logger;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Even if we get an exception from a request it could've already been processed
+ * by the server, so it's safe to retry only those which don't modify server state
+ * (i.e. GET, HEAD).
+ */
+public class IOExceptionSafeRetryHandler extends BackoffLimitedRetryHandler implements IOExceptionRetryHandler {
+    private static final Set<String> SAFE_METHODS = ImmutableSet.of("GET", "HEAD");
+
+    @Resource
+    protected Logger logger = Logger.NULL;
+
+    @Override
+    public boolean shouldRetryRequest(HttpCommand command, IOException error) {
+        String method = command.getCurrentRequest().getMethod();
+        if (SAFE_METHODS.contains(method)) {
+            return super.shouldRetryRequest(command, error);
+        } else {
+            logger.error("Command not considered safe to retry because request method is %1$s: %2$s", method, command);
+            return false;
+        }
+    }
+
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/IOExceptionSafeRetryModule.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/IOExceptionSafeRetryModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import org.jclouds.http.IOExceptionRetryHandler;
+
+import com.google.inject.AbstractModule;
+
+public class IOExceptionSafeRetryModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(IOExceptionRetryHandler.class).to(IOExceptionSafeRetryHandler.class);
+    }
+
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsUtil.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsUtil.java
@@ -250,7 +250,8 @@ public class JcloudsUtil implements JcloudsLocationConfig {
         return ImmutableSet.<Module> of(
                 new SshjSshClientModule(),
                 new SLF4JLoggingModule(),
-                new BouncyCastleCryptoModule());
+                new BouncyCastleCryptoModule(),
+                new IOExceptionSafeRetryModule());
     }
 
     /**


### PR DESCRIPTION
The request could have already been processed on the server when the exception occurs, retry only for request methods without side effects.

Any ideas how this could be tested?

Make sense to use the change for all providers, though the problem has been observed on Softlayer specifically: `Read timed out connecting to POST https://api.softlayer.com/rest/v3/SoftLayer_Virtual_Guest`. Because of the retries a machine has been provisioned 6 times.

@andreaturli do you think this should be filed as a bug report/patch in jclouds?