### PR TITLE
Don't fail on startup in case of an isRunning exception

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -494,17 +494,26 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         CountdownTimer timer = startTimeout.countdownTimer();
         boolean isRunningResult = false;
         long delay = 100;
+        Exception firstFailure = null;
         while (!isRunningResult && !timer.isExpired()) {
             Time.sleep(delay);
             try {
                 isRunningResult = driver.isRunning();
+                if (log.isDebugEnabled()) log.debug("checked {}, 'is running' returned: {}", this, isRunningResult);
             } catch (Exception  e) {
-                ServiceStateLogic.setExpectedState(this, Lifecycle.ON_FIRE);
-                // provide extra context info, as we're seeing this happen in strange circumstances
-                if (driver==null) throw new IllegalStateException(this+" concurrent start and shutdown detected");
-                throw new IllegalStateException("Error detecting whether "+this+" is running: "+e, e);
+                Exceptions.propagateIfFatal(e);
+
+                isRunningResult = false;
+                if (driver != null) {
+                    log.error("checked " + this + ", 'is running' threw an exception", e);
+                } else {
+                    // provide extra context info, as we're seeing this happen in strange circumstances
+                    log.error(this+" concurrent start and shutdown detected", e);
+                }
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
             }
-            if (log.isDebugEnabled()) log.debug("checked {}, is running returned: {}", this, isRunningResult);
             // slow exponential delay -- 1.1^N means after 40 tries and 50s elapsed, it reaches the max of 5s intervals
             // TODO use Repeater 
             delay = Math.min(delay*11/10, 5000);
@@ -512,9 +521,12 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         if (!isRunningResult) {
             String msg = "Software process entity "+this+" did not pass is-running check within "+
                     "the required "+startTimeout+" limit ("+timer.getDurationElapsed().toStringRounded()+" elapsed)";
+            if (firstFailure != null) {
+                msg += "; check failed with exception: " + firstFailure.getMessage();
+            }
             log.warn(msg+" (throwing)");
             ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
-            throw new IllegalStateException(msg);
+            throw new IllegalStateException(msg, firstFailure);
         }
     }
 

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -505,7 +505,12 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
 
                 isRunningResult = false;
                 if (driver != null) {
-                    log.error("checked " + this + ", 'is running' threw an exception", e);
+                    String msg = "checked " + this + ", 'is running' threw an exception; logging subsequent exceptions at debug level";
+                    if (firstFailure == null) {
+                        log.error(msg, e);
+                    } else {
+                        log.debug(msg, e);
+                    }
                 } else {
                     // provide extra context info, as we're seeing this happen in strange circumstances
                     log.error(this+" concurrent start and shutdown detected", e);
@@ -522,7 +527,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             String msg = "Software process entity "+this+" did not pass is-running check within "+
                     "the required "+startTimeout+" limit ("+timer.getDurationElapsed().toStringRounded()+" elapsed)";
             if (firstFailure != null) {
-                msg += "; check failed with exception: " + firstFailure.getMessage();
+                msg += "; check failed at least once with exception: " + firstFailure.getMessage() + ", see logs for details";
             }
             log.warn(msg+" (throwing)");
             ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);


### PR DESCRIPTION
During entity startup treat isRunning exceptions as temporary failures and wait until timeout, don't propagate them on the spot. Could be caused by a temporary problem, for example connectivity issues.