### PR TITLE
Riak bugfix

### DIFF
--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
@@ -46,7 +46,7 @@ public interface RiakNode extends SoftwareProcess {
 
     @SetFromFlag("version")
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION,
-            "Version to install (Default 2.1.0)", "2.1.0");
+            "Version to install (Default 2.0.5)", "2.0.5");
 
     @SetFromFlag("optimizeNetworking")
     ConfigKey<Boolean> OPTIMIZE_HOST_NETWORKING  = ConfigKeys.newBooleanConfigKey("riak.networking.optimize", "Optimize host networking when running in a VM", Boolean.TRUE);

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -198,14 +198,14 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
 
     private ImmutableList<String> installDebianBased() {
         return ImmutableList.<String>builder()
-                .add("curl https://packagecloud.io/install/repositories/basho/riak/script.deb | " + BashCommands.sudo("bash"))
+                .add("curl https://packagecloud.io/install/repositories/basho/riak/script.deb.sh | " + BashCommands.sudo("bash"))
                 .add(BashCommands.sudo("apt-get install --assume-yes riak=" + getEntity().getFullVersion() + "-1"))
                 .build();
     }
 
     private ImmutableList<String> installRpmBased() {
         return ImmutableList.<String>builder()
-                .add("curl https://packagecloud.io/install/repositories/basho/riak/script.rpm | " + BashCommands.sudo("bash"))
+                .add("curl https://packagecloud.io/install/repositories/basho/riak/script.rpm.sh | " + BashCommands.sudo("bash"))
                 .add(BashCommands.sudo("yum install -y riak-" + getEntity().getFullVersion() + "*"))
                 .build();
     }


### PR DESCRIPTION
- Basho pulled out 2.1.0, reverted default version to 2.0.5
- packagecloud url was changed