### PR TITLE
Add initial support for PaaS locations

### DIFF
--- a/core/src/main/java/brooklyn/location/paas/PaasLocation.java
+++ b/core/src/main/java/brooklyn/location/paas/PaasLocation.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.paas;
+
+import brooklyn.location.Location;
+
+/**
+ * {@link Location} representing an application container on a PaaS provider.
+ */
+public interface PaasLocation extends Location {
+    
+    String getPaasProviderName();
+}
+

--- a/core/src/test/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactoryTest.java
+++ b/core/src/test/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactoryTest.java
@@ -52,11 +52,6 @@ public class ReflectiveEntityDriverFactoryTest {
     public void tearDown() {
         // nothing to tear down; no management context created
     }
-
-    protected void assertDriverIs(Class<?> clazz) {
-        MyDriver driver = factory.build(entity, sshLocation);
-        assertTrue(driver.getClass().equals(clazz), "driver="+driver+"; should be "+clazz);
-    }
     
     protected void assertDriverIs(Class<?> clazz, Location location) {
         MyDriver driver = factory.build(entity, location);
@@ -65,7 +60,7 @@ public class ReflectiveEntityDriverFactoryTest {
     
     @Test
     public void testInstantiatesSshDriver() throws Exception {
-        assertDriverIs(MySshDriver.class);
+        assertDriverIs(MySshDriver.class, sshLocation);
     }
 
     @Test
@@ -76,40 +71,40 @@ public class ReflectiveEntityDriverFactoryTest {
     @Test
     public void testFullNameMapping() throws Exception {
         factory.addClassFullNameMapping(MyDriver.class.getName(), MyCustomDriver.class.getName());
-        assertDriverIs(MyCustomDriver.class);
+        assertDriverIs(MyCustomDriver.class, sshLocation);
     }
 
     @Test
     public void testFullNameMappingMulti() throws Exception {
         factory.addClassFullNameMapping(MyDriver.class.getName(), "X");
         factory.addClassFullNameMapping(MyDriver.class.getName(), MyCustomDriver.class.getName());
-        assertDriverIs(MyCustomDriver.class);
+        assertDriverIs(MyCustomDriver.class, sshLocation);
     }
 
 
     @Test
     public void testFullNameMappingFailure1() throws Exception {
         factory.addClassFullNameMapping(MyDriver.class.getName()+"X", MyCustomDriver.class.getName());
-        assertDriverIs(MySshDriver.class);
+        assertDriverIs(MySshDriver.class, sshLocation);
     }
 
     @Test
     public void testFullNameMappingFailure2() throws Exception {
         factory.addClassFullNameMapping(MyDriver.class.getName(), MyCustomDriver.class.getName());
         factory.addClassFullNameMapping(MyDriver.class.getName(), "X");
-        assertDriverIs(MySshDriver.class);
+        assertDriverIs(MySshDriver.class, sshLocation);
     }
 
     @Test
     public void testSimpleNameMapping() throws Exception {
         factory.addClassSimpleNameMapping(MyDriver.class.getSimpleName(), MyCustomDriver.class.getSimpleName());
-        assertDriverIs(MyCustomDriver.class);
+        assertDriverIs(MyCustomDriver.class, sshLocation);
     }
 
     @Test
     public void testSimpleNameMappingFailure() throws Exception {
         factory.addClassSimpleNameMapping(MyDriver.class.getSimpleName()+"X", MyCustomDriver.class.getSimpleName());
-        assertDriverIs(MySshDriver.class);
+        assertDriverIs(MySshDriver.class, sshLocation);
     }
     
     public static class MyDriverDependentEntity<D extends EntityDriver> extends AbstractEntity implements DriverDependentEntity<D> {

--- a/core/src/test/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactoryTest.java
+++ b/core/src/test/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactoryTest.java
@@ -18,23 +18,25 @@
  */
 package brooklyn.entity.drivers;
 
-import static org.testng.Assert.assertTrue;
-
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.AbstractEntity;
 import brooklyn.entity.basic.EntityLocal;
 import brooklyn.location.Location;
 import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.location.paas.PaasLocation;
+import brooklyn.test.location.TestPaasLocation;
 import brooklyn.util.collections.MutableMap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 public class ReflectiveEntityDriverFactoryTest {
 
     private ReflectiveEntityDriverFactory factory;
     private SshMachineLocation sshLocation;
+    private PaasLocation paasLocation;
     private DriverDependentEntity<MyDriver> entity;
     
     @BeforeMethod
@@ -42,6 +44,8 @@ public class ReflectiveEntityDriverFactoryTest {
         factory = new ReflectiveEntityDriverFactory();
         sshLocation = new SshMachineLocation(MutableMap.of("address", "localhost"));
         entity = new MyDriverDependentEntity<MyDriver>(MyDriver.class);
+
+        paasLocation = new TestPaasLocation();
     }
 
     @AfterMethod
@@ -54,11 +58,21 @@ public class ReflectiveEntityDriverFactoryTest {
         assertTrue(driver.getClass().equals(clazz), "driver="+driver+"; should be "+clazz);
     }
     
+    protected void assertDriverIs(Class<?> clazz, Location location) {
+        MyDriver driver = factory.build(entity, location);
+        assertTrue(driver.getClass().equals(clazz), "driver="+driver+"; should be "+clazz);
+    }
+    
     @Test
     public void testInstantiatesSshDriver() throws Exception {
         assertDriverIs(MySshDriver.class);
     }
 
+    @Test
+    public void testInstantiatesPaasDriver() throws Exception {
+        assertDriverIs(MyTestPaasDriver.class, paasLocation);
+    }
+    
     @Test
     public void testFullNameMapping() throws Exception {
         factory.addClassFullNameMapping(MyDriver.class.getName(), MyCustomDriver.class.getName());
@@ -137,6 +151,21 @@ public class ReflectiveEntityDriverFactoryTest {
     public static class MyCustomDriver extends MySshDriver {
         public MyCustomDriver(Entity entity, SshMachineLocation machine) {
             super(entity, machine);
+        }
+    }
+    
+    public static class MyTestPaasDriver implements MyDriver {
+        public MyTestPaasDriver(Entity entity, PaasLocation location) {
+        }
+
+        @Override
+        public Location getLocation() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EntityLocal getEntity() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/core/src/test/java/brooklyn/location/basic/PaasLocationTest.java
+++ b/core/src/test/java/brooklyn/location/basic/PaasLocationTest.java
@@ -19,7 +19,6 @@
 package brooklyn.location.basic;
 
 import brooklyn.location.paas.PaasLocation;
-import brooklyn.management.ManagementContext;
 import brooklyn.test.location.TestPaasLocation;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -27,7 +26,6 @@ import org.testng.annotations.Test;
 public class PaasLocationTest {
 
     private PaasLocation location;
-    private ManagementContext mgmt;
     
     @Test
     public void testProviderName(){

--- a/core/src/test/java/brooklyn/location/basic/PaasLocationTest.java
+++ b/core/src/test/java/brooklyn/location/basic/PaasLocationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.basic;
+
+import brooklyn.location.paas.PaasLocation;
+import brooklyn.management.ManagementContext;
+import brooklyn.test.location.TestPaasLocation;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PaasLocationTest {
+
+    private PaasLocation location;
+    private ManagementContext mgmt;
+    
+    @Test
+    public void testProviderName(){
+        location = new TestPaasLocation();
+        Assert.assertEquals(location.getPaasProviderName(), "TestPaas");
+    }
+}

--- a/core/src/test/java/brooklyn/test/location/TestPaasLocation.java
+++ b/core/src/test/java/brooklyn/test/location/TestPaasLocation.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.test.location;
+
+import brooklyn.location.basic.AbstractLocation;
+import brooklyn.location.paas.PaasLocation;
+
+/**
+ * Mock {@link brooklyn.location.paas.PaasLocation} for test purposes
+ */
+public class TestPaasLocation extends AbstractLocation implements PaasLocation {
+    @Override
+    public String getPaasProviderName() {
+        return "TestPaas";
+    }
+}


### PR DESCRIPTION
An initial support for PaaS locations is provided by adding a new inference rule to [ReflectiveEntityDriverFactory](https://github.com/mbarrientos/incubator-brooklyn/blob/f32fa3cff2174dae18758533e51bddb482eef2c2/core/src/main/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactory.java). The new location [PaasLocation](https://github.com/apache/incubator-brooklyn/blob/f32fa3cff2174dae18758533e51bddb482eef2c2/core/src/main/java/brooklyn/location/paas/PaasLocation.java) is not based on SSH access and is not supposed to be provisioned first (even though it might be the case for some PaaS provider). 

Note that this is part of an ongoing work for integrating PaaS providers, like CloudFoundry, as a Brooklyn Location, which process can be tracked [here](https://github.com/SeaCloudsEU/brooklyn-location-cloudfoundry). That work will be extending the one presented in this PR.

