### PR TITLE
jclouds location customizer supports pre-release and post-release callback

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
@@ -55,4 +55,15 @@ public class BasicJcloudsLocationCustomizer implements JcloudsLocationCustomizer
     public void customize(JcloudsLocation location, ComputeService computeService, JcloudsSshMachineLocation machine) {
         // no-op
     }
+
+    @Override
+    public void preRelease(JcloudsSshMachineLocation machine) {
+        // no-op
+    }
+
+    @Override
+    public void postRelease(JcloudsSshMachineLocation machine) {
+        // no-op
+    }
+    
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
@@ -65,4 +65,15 @@ public interface JcloudsLocationCustomizer {
      * machine is guaranteed to be SSHable when this method is called.
      */
     void customize(JcloudsLocation location, ComputeService computeService, JcloudsSshMachineLocation machine);
+    
+    /**
+     * Override to handle machine-related cleanup before Jclouds is called to release (destroy) the machine.
+     */
+    void preRelease(JcloudsSshMachineLocation machine);
+
+    /**
+     * Override to handle machine-related cleanup after Jclouds is called to release (destroy) the machine.
+     */
+    void postRelease(JcloudsSshMachineLocation machine);
+
 }


### PR DESCRIPTION
useful when the customizer is e.g. setting up then clearing external setup, e.g. DNS