### PR TITLE
Initialize entity driver on rebind when on-fire

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.Entity;
+import brooklyn.entity.basic.Lifecycle.Transition;
 import brooklyn.entity.trait.Startable;
 import brooklyn.event.AttributeSensor;
 import brooklyn.event.basic.AttributeSensorAndConfigKey;
@@ -233,6 +234,7 @@ public interface SoftwareProcess extends Entity, Startable {
             "Whether the process for the service is confirmed as running");
     
     AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
+    AttributeSensor<Transition> SERVICE_STATE_EXPECTED = Attributes.SERVICE_STATE_EXPECTED;
  
     AttributeSensor<String> PID_FILE = Sensors.newStringSensor("softwareprocess.pid.file", "PID file");
 


### PR DESCRIPTION
Don't create the driver only when `SERVICE_STATE_EXPECTED=ON_FIRE` - the entity is considered permanently failed in this state. When only `SERVICE_STATE_ACTUAL=ON_FIRE` we still should be able to rebind successfully - failure was set by attached enrichers.