### PR TITLE
Allows for lists in templateOptions

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1050,42 +1050,59 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     public void apply(TemplateOptions t, ConfigBag props, Object v) {
                         t.networks((String)v);
                     }})
-              .put(TEMPLATE_OPTIONS, new CustomizeTemplateOptions() {
-                  @Override
-                  public void apply(TemplateOptions options, ConfigBag config, Object v) {
-                      if (v == null) return;
-                      @SuppressWarnings("unchecked") Map<String, String> optionsMap = (Map<String, String>) v;
-                      if (optionsMap.isEmpty()) return;
+            .put(TEMPLATE_OPTIONS, new CustomizeTemplateOptions() {
+                @Override
+                public void apply(TemplateOptions options, ConfigBag config, Object v) {
+                    if (v == null) return;
+                    @SuppressWarnings("unchecked") Map<String, Object> optionsMap = (Map<String, Object>) v;
+                    if (optionsMap.isEmpty()) return;
 
-                      Class<? extends TemplateOptions> clazz = options.getClass();
-                      Iterable<Method> methods = Arrays.asList(clazz.getMethods());
-                      for(final Map.Entry<String, String> option : optionsMap.entrySet()) {
-                          Optional<Method> methodOptional = Iterables.tryFind(methods, new Predicate<Method>() {
-                              @Override
-                              public boolean apply(@Nullable Method input) {
-                                  // Matches a method with the expected name, and a single parameter that TypeCoercions
-                                  // can coerce to
-                                  if (input == null) return false;
-                                  if (!input.getName().equals(option.getKey())) return false;
-                                  Type[] parameterTypes = input.getGenericParameterTypes();
-                                  return parameterTypes.length == 1
-                                          && TypeCoercions.tryCoerce(option.getValue(), TypeToken.of(parameterTypes[0])).isPresentAndNonNull();
-                              }
-                          });
-                          if(methodOptional.isPresent()) {
-                              try {
-                                  Method method = methodOptional.get();
-                                  method.invoke(options, TypeCoercions.coerce(option.getValue(), TypeToken.of(method.getGenericParameterTypes()[0])));
-                              } catch (IllegalAccessException e) {
-                                  throw Exceptions.propagate(e);
-                              } catch (InvocationTargetException e) {
-                                  throw Exceptions.propagate(e);
-                              }
-                          } else {
-                              LOG.warn("Ignoring request to set template option {} because this is not supported by {}", new Object[] { option.getKey(), clazz.getCanonicalName() });
-                          }
-                      }
-                  }
+                    Class<? extends TemplateOptions> clazz = options.getClass();
+                    Iterable<Method> methods = Arrays.asList(clazz.getMethods());
+                    for(final Map.Entry<String, Object> option : optionsMap.entrySet()) {
+                        Optional<Method> methodOptional = Iterables.tryFind(methods, new Predicate<Method>() {
+                            @Override
+                            public boolean apply(@Nullable Method input) {
+                                // Matches a method with the expected name, and a single parameter that TypeCoercions
+                                // can coerce to
+                                if (input == null) return false;
+                                if (!input.getName().equals(option.getKey())) return false;
+                                int numOptionParams = option.getValue() instanceof List ? ((List)option.getValue()).size() : 1;
+                                Type[] parameterTypes = input.getGenericParameterTypes();
+                                if (parameterTypes.length != numOptionParams) return false;
+                                if (numOptionParams == 1 && !(option.getValue() instanceof List) && parameterTypes.length == 1) {
+                                    return true;
+                                }
+                                for (int paramCount = 0; paramCount < numOptionParams; paramCount ++) {
+                                    if (!TypeCoercions.tryCoerce(((List)option.getValue()).get(paramCount),
+                                            TypeToken.of(parameterTypes[paramCount])).isPresentAndNonNull()) return false;
+                                }
+                                return true;
+                            }
+                        });
+                        if(methodOptional.isPresent()) {
+                            try {
+                                Method method = methodOptional.get();
+                                if (option.getValue() instanceof List) {
+                                    List<Object> parameters = Lists.newArrayList();
+                                    int numOptionParams = ((List)option.getValue()).size();
+                                    for (int paramCount = 0; paramCount < numOptionParams; paramCount++) {
+                                        parameters.add(TypeCoercions.coerce(((List)option.getValue()).get(paramCount), TypeToken.of(method.getGenericParameterTypes()[paramCount])));
+                                    }
+                                    method.invoke(options, parameters.toArray());
+                                } else {
+                                    method.invoke(options, TypeCoercions.coerce(option.getValue(), TypeToken.of(method.getGenericParameterTypes()[0])));
+                                }
+                            } catch (IllegalAccessException e) {
+                                throw Exceptions.propagate(e);
+                            } catch (InvocationTargetException e) {
+                                throw Exceptions.propagate(e);
+                            }
+                        } else {
+                            LOG.warn("Ignoring request to set template option {} because this is not supported by {}", new Object[] { option.getKey(), clazz.getCanonicalName() });
+                        }
+                    }
+                }
               })
             .build();
 

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -250,8 +250,8 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
             "Registry/Factory for creating jclouds ComputeService; default is almost always fine, except where tests want to customize behaviour",
             ComputeServiceRegistryImpl.INSTANCE);
     
-    public static final ConfigKey<Map<String,String>> TEMPLATE_OPTIONS = ConfigKeys.newConfigKey(
-            new TypeToken<Map<String, String>>() {}, "templateOptions", "Additional jclouds template options");
+    public static final ConfigKey<Map<String,Object>> TEMPLATE_OPTIONS = ConfigKeys.newConfigKey(
+            new TypeToken<Map<String, Object>>() {}, "templateOptions", "Additional jclouds template options");
 
     // TODO
     


### PR DESCRIPTION
Allows more complex templateOptions in brooklyn.properties such as the following:

```
brooklyn.location.named.AWS\ Oregon.templateOptions={ subnetId: subnet-a10e96c4 , securityGroupIds: [['sg-a2d0c2c7']], mapNewVolumeToDeviceName: ["/dev/sda1", 100, true]}
```