### PR TITLE
brooklyn.util.text.Strings adjustments

### DIFF
--- a/utils/common/src/main/java/brooklyn/util/exceptions/Exceptions.java
+++ b/utils/common/src/main/java/brooklyn/util/exceptions/Exceptions.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Throwables.getCausalChain;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +36,7 @@ import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 public class Exceptions {
 
@@ -69,14 +71,16 @@ public class Exceptions {
     }
 
     private static String stripBoringPrefixes(String s) {
-        String was;
-        do {
-            was = s;
-            for (Class<? extends Throwable> type: BORING_PREFIX_THROWABLE_EXACT_TYPES) {
-                s = Strings.removeAllFromStart(s, type.getCanonicalName(), type.getName(), type.getSimpleName(), ":", " ");
-            }
-        } while (!was.equals(s));
-        return s;
+        ArrayList<String> prefixes = Lists.newArrayListWithCapacity(2 + BORING_PREFIX_THROWABLE_EXACT_TYPES.size() * 3);
+        for (Class<? extends Throwable> type : BORING_PREFIX_THROWABLE_EXACT_TYPES) {
+            prefixes.add(type.getCanonicalName());
+            prefixes.add(type.getName());
+            prefixes.add(type.getSimpleName());
+        }
+        prefixes.add(":");
+        prefixes.add(" ");
+        String[] ps = prefixes.toArray(new String[prefixes.size()]);
+        return Strings.removeAllFromStart(s, ps);
     }
 
     /**

--- a/utils/common/src/main/java/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/brooklyn/util/text/Strings.java
@@ -151,20 +151,24 @@ public class Strings {
         return string;
     }
 
-    /** as removeFromEnd, but repeats until all such suffixes are gone */
-    public static String removeAllFromEnd(String string, String ...suffixes) {
+    /**
+     * As removeFromEnd, but repeats until all such suffixes are gone
+     */
+    public static String removeAllFromEnd(String string, String... suffixes) {
+        if (isEmpty(string)) return string;
+        int index = string.length();
         boolean anotherLoopNeeded = true;
         while (anotherLoopNeeded) {
             if (isEmpty(string)) return string;
             anotherLoopNeeded = false;
             for (String suffix : suffixes)
-                if (string.endsWith(suffix)) {
-                    string = string.substring(0, string.length() - suffix.length());
+                if (!isEmpty(suffix) && string.startsWith(suffix, index - suffix.length())) {
+                    index -= suffix.length();
                     anotherLoopNeeded = true;
                     break;
                 }
         }
-        return string;
+        return string.substring(0, index);
     }
 
     /**
@@ -193,20 +197,24 @@ public class Strings {
         return string;
     }
 
-    /** as removeFromStart, but repeats until all such suffixes are gone */
-    public static String removeAllFromStart(String string, String ...prefixes) {
+    /**
+     * As {@link #removeFromStart(String, String)}, repeating until all such prefixes are gone.
+     */
+    public static String removeAllFromStart(String string, String... prefixes) {
+        int index = 0;
         boolean anotherLoopNeeded = true;
         while (anotherLoopNeeded) {
             if (isEmpty(string)) return string;
             anotherLoopNeeded = false;
-            for (String prefix : prefixes)
-                if (string.startsWith(prefix)) {
-                    string = string.substring(prefix.length());
+            for (String prefix : prefixes) {
+                if (!isEmpty(prefix) && string.startsWith(prefix, index)) {
+                    index += prefix.length();
                     anotherLoopNeeded = true;
                     break;
                 }
+            }
         }
-        return string;
+        return string.substring(index);
     }
 
     /** convenience for {@link com.google.common.base.Joiner} */

--- a/utils/common/src/main/java/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/brooklyn/util/text/Strings.java
@@ -125,10 +125,25 @@ public class Strings {
         if (isEmpty(s)) throw new IllegalArgumentException(message);
     }
 
+    /**
+     * Removes suffix from the end of the string. Returns string if it does not end with suffix.
+     */
+    public static String removeFromEnd(String string, String suffix) {
+        if (isEmpty(string)) {
+            return string;
+        } else if (!isEmpty(suffix) && string.endsWith(suffix)) {
+            return string.substring(0, string.length() - suffix.length());
+        } else {
+            return string;
+        }
+    }
+
     /** removes the first suffix in the list which is present at the end of string
      * and returns that string; ignores subsequent suffixes if a matching one is found;
      * returns the original string if no suffixes are at the end
+     * @deprecated since 0.7.0 use {@link #removeFromEnd(String, String)} or {@link #removeAllFromEnd(String, String...)}
      */
+    @Deprecated
     public static String removeFromEnd(String string, String ...suffixes) {
         if (isEmpty(string)) return string;
         for (String suffix : suffixes)
@@ -152,10 +167,25 @@ public class Strings {
         return string;
     }
 
+    /**
+     * Removes prefix from the beginning of string. Returns string if it does not begin with prefix.
+     */
+    public static String removeFromStart(String string, String prefix) {
+        if (isEmpty(string)) {
+            return string;
+        } else if (!isEmpty(prefix) && string.startsWith(prefix)) {
+            return string.substring(prefix.length());
+        } else {
+            return string;
+        }
+    }
+
     /** removes the first prefix in the list which is present at the start of string
      * and returns that string; ignores subsequent prefixes if a matching one is found;
      * returns the original string if no prefixes match
+     * @deprecated since 0.7.0 use {@link #removeFromStart(String, String)}
      */
+    @Deprecated
     public static String removeFromStart(String string, String ...prefixes) {
         if (isEmpty(string)) return string;
         for (String prefix : prefixes)
@@ -180,23 +210,23 @@ public class Strings {
     }
 
     /** convenience for {@link com.google.common.base.Joiner} */
-    public static String join(Iterable<? extends Object> list, String seperator) {
+    public static String join(Iterable<? extends Object> list, String separator) {
         if (list==null) return null;
         boolean app = false;
         StringBuilder out = new StringBuilder();
         for (Object s: list) {
-            if (app) out.append(seperator);
+            if (app) out.append(separator);
             out.append(s);
             app = true;
         }
         return out.toString();
     }
     /** convenience for {@link com.google.common.base.Joiner} */
-    public static String join(Object[] list, String seperator) {
+    public static String join(Object[] list, String separator) {
         boolean app = false;
         StringBuilder out = new StringBuilder();
         for (Object s: list) {
-            if (app) out.append(seperator);
+            if (app) out.append(separator);
             out.append(s);
             app = true;
         }

--- a/utils/common/src/test/java/brooklyn/util/text/StringsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/text/StringsTest.java
@@ -80,64 +80,64 @@ public class StringsTest extends FixedLocaleTest {
     }
 
     public void makeValidJavaName() {
-        assertEquals("__null", Strings.makeValidJavaName(null));
-        assertEquals("__empty", Strings.makeValidJavaName(""));
-        assertEquals("abcdef", Strings.makeValidJavaName("abcdef"));
-        assertEquals("abcdef", Strings.makeValidJavaName("a'b'c'd'e'f"));
-        assertEquals("_12345", Strings.makeValidJavaName("12345"));
+        assertEquals(Strings.makeValidJavaName(null), "__null");
+        assertEquals(Strings.makeValidJavaName(""), "__empty");
+        assertEquals(Strings.makeValidJavaName("abcdef"), "abcdef");
+        assertEquals(Strings.makeValidJavaName("a'b'c'd'e'f"), "abcdef");
+        assertEquals(Strings.makeValidJavaName("12345"), "_12345");
     }
 
     public void makeValidUniqueJavaName() {
-        assertEquals("__null", Strings.makeValidUniqueJavaName(null));
-        assertEquals("__empty", Strings.makeValidUniqueJavaName(""));
-        assertEquals("abcdef", Strings.makeValidUniqueJavaName("abcdef"));
-        assertEquals("_12345", Strings.makeValidUniqueJavaName("12345"));
+        assertEquals(Strings.makeValidUniqueJavaName(null), "__null");
+        assertEquals(Strings.makeValidUniqueJavaName(""), "__empty");
+        assertEquals(Strings.makeValidUniqueJavaName("abcdef"), "abcdef");
+        assertEquals(Strings.makeValidUniqueJavaName("12345"), "_12345");
     }
 
     public void testRemoveFromEnd() {
-        assertEquals("", Strings.removeFromEnd("", "bar"));
-        assertEquals(null, Strings.removeFromEnd(null, "bar"));
+        assertEquals(Strings.removeFromEnd("", "bar"), "");
+        assertEquals(Strings.removeFromEnd(null, "bar"), null);
 
-        assertEquals("foo", Strings.removeFromEnd("foobar", "bar"));
-        assertEquals("foo", Strings.removeFromEnd("foo", "bar"));
-        assertEquals("foo", Strings.removeFromEnd("foobar", "foo", "bar"));
+        assertEquals(Strings.removeFromEnd("foobar", "bar"), "foo");
+        assertEquals(Strings.removeFromEnd("foo", "bar"), "foo");
+        assertEquals(Strings.removeFromEnd("foobar", "foo", "bar"), "foo");
         // test they are applied in order
-        assertEquals("foob", Strings.removeFromEnd("foobar", "ar", "bar", "b"));
+        assertEquals(Strings.removeFromEnd("foobar", "ar", "bar", "b"), "foob");
     }
 
     public void testRemoveAllFromEnd() {
-        assertEquals("", Strings.removeAllFromEnd("", "bar"));
-        assertEquals(null, Strings.removeAllFromEnd(null, "bar"));
+        assertEquals(Strings.removeAllFromEnd("", "bar"), "");
+        assertEquals(Strings.removeAllFromEnd(null, "bar"), null);
 
-        assertEquals("", Strings.removeAllFromEnd("foobar", "foo", "bar"));
-        assertEquals("f", Strings.removeAllFromEnd("foobar", "ar", "car", "b", "o"));
+        assertEquals(Strings.removeAllFromEnd("foobar", "foo", "bar"), "");
+        assertEquals(Strings.removeAllFromEnd("foobar", "ar", "car", "b", "o"), "f");
         // test they are applied in order
-        assertEquals("foo", Strings.removeAllFromEnd("foobar", "ar", "car", "b", "ob"));
-        assertEquals("foobar", Strings.removeAllFromEnd("foobar", "zz", "x"));
+        assertEquals(Strings.removeAllFromEnd("foobar", "ar", "car", "b", "ob"), "foo");
+        assertEquals(Strings.removeAllFromEnd("foobar", "zz", "x"), "foobar");
     }
 
     public void testRemoveFromStart() {
-        assertEquals("", Strings.removeFromStart("", "foo"));
-        assertEquals(null, Strings.removeFromStart(null, "foo"));
+        assertEquals(Strings.removeFromStart("", "foo"), "");
+        assertEquals(Strings.removeFromStart(null, "foo"), null);
 
-        assertEquals("bar", Strings.removeFromStart("foobar", "foo"));
-        assertEquals("foo", Strings.removeFromStart("foo", "bar"));
-        assertEquals("bar", Strings.removeFromStart("foobar", "foo", "bar"));
-        assertEquals("obar", Strings.removeFromStart("foobar", "ob", "fo", "foo", "o"));
+        assertEquals(Strings.removeFromStart("foobar", "foo"), "bar");
+        assertEquals(Strings.removeFromStart("foo", "bar"), "foo");
+        assertEquals(Strings.removeFromStart("foobar", "foo", "bar"), "bar");
+        assertEquals(Strings.removeFromStart("foobar", "ob", "fo", "foo", "o"), "obar");
     }
 
     public void testRemoveAllFromStart() {
-        assertEquals("", Strings.removeAllFromStart("", "foo"));
-        assertEquals(null, Strings.removeAllFromStart(null, "foo"));
+        assertEquals(Strings.removeAllFromStart("", "foo"), "");
+        assertEquals(Strings.removeAllFromStart(null, "foo"), null);
 
-        assertEquals("bar", Strings.removeAllFromStart("foobar", "foo"));
-        assertEquals("foo", Strings.removeAllFromStart("foo", "bar"));
-        assertEquals("", Strings.removeAllFromStart("foobar", "foo", "bar"));
+        assertEquals(Strings.removeAllFromStart("foobar", "foo"), "bar");
+        assertEquals(Strings.removeAllFromStart("foo", "bar"), "foo");
+        assertEquals(Strings.removeAllFromStart("foobar", "foo", "bar"), "");
 
-        assertEquals("ar", Strings.removeAllFromStart("foobar", "fo", "ob", "o"));
-        assertEquals("ar", Strings.removeAllFromStart("foobar", "ob", "fo", "o"));
+        assertEquals(Strings.removeAllFromStart("foobar", "fo", "ob", "o"), "ar");
+        assertEquals(Strings.removeAllFromStart("foobar", "ob", "fo", "o"), "ar");
         // test they are applied in order, "ob" doesn't match because "o" eats the o
-        assertEquals("bar", Strings.removeAllFromStart("foobar", "o", "fo", "ob"));
+        assertEquals(Strings.removeAllFromStart("foobar", "o", "fo", "ob"), "bar");
     }
 
     public void testRemoveFromStart2() {

--- a/utils/common/src/test/java/brooklyn/util/text/StringsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/text/StringsTest.java
@@ -108,12 +108,15 @@ public class StringsTest extends FixedLocaleTest {
     public void testRemoveAllFromEnd() {
         assertEquals(Strings.removeAllFromEnd("", "bar"), "");
         assertEquals(Strings.removeAllFromEnd(null, "bar"), null);
+        assertEquals(Strings.removeAllFromEnd("foo", ""), "foo");
 
         assertEquals(Strings.removeAllFromEnd("foobar", "foo", "bar"), "");
         assertEquals(Strings.removeAllFromEnd("foobar", "ar", "car", "b", "o"), "f");
         // test they are applied in order
         assertEquals(Strings.removeAllFromEnd("foobar", "ar", "car", "b", "ob"), "foo");
         assertEquals(Strings.removeAllFromEnd("foobar", "zz", "x"), "foobar");
+        assertEquals(Strings.removeAllFromEnd("foobarbaz", "bar", "baz"), "foo");
+        assertEquals(Strings.removeAllFromEnd("foobarbaz", "baz", "", "foo", "bar", "baz"), "");
     }
 
     public void testRemoveFromStart() {
@@ -129,6 +132,7 @@ public class StringsTest extends FixedLocaleTest {
     public void testRemoveAllFromStart() {
         assertEquals(Strings.removeAllFromStart("", "foo"), "");
         assertEquals(Strings.removeAllFromStart(null, "foo"), null);
+        assertEquals(Strings.removeAllFromStart("foo", ""), "foo");
 
         assertEquals(Strings.removeAllFromStart("foobar", "foo"), "bar");
         assertEquals(Strings.removeAllFromStart("foo", "bar"), "foo");
@@ -138,6 +142,8 @@ public class StringsTest extends FixedLocaleTest {
         assertEquals(Strings.removeAllFromStart("foobar", "ob", "fo", "o"), "ar");
         // test they are applied in order, "ob" doesn't match because "o" eats the o
         assertEquals(Strings.removeAllFromStart("foobar", "o", "fo", "ob"), "bar");
+        assertEquals(Strings.removeAllFromStart("foobarbaz", "bar", "foo"), "baz");
+        assertEquals(Strings.removeAllFromStart("foobarbaz", "baz", "bar", "foo"), "");
     }
 
     public void testRemoveFromStart2() {


### PR DESCRIPTION
Prompted by the chance observation in VisualVM that way too much CPU time was spent in `Strings.removeFromStart/End ` via `Exceptions.stripBoringPrefixes` and `PropagatedRuntimeException`. Please check a with careful eye.

For more on the time complexity of `String.substring` see http://stackoverflow.com/questions/4679746/time-complexity-of-javas-substring and http://stackoverflow.com/questions/16123446/java-7-string-substring-complexity.