### PR TITLE
Support multiple setup scripts in location config

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -709,16 +709,20 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             if (waitForSshable) {
 
                 String setupScript = setup.get(JcloudsLocationConfig.CUSTOM_MACHINE_SETUP_SCRIPT_URL);
-                if (Strings.isNonBlank(setupScript)) {
-                    customisationForLogging.add("custom setup script "+setupScript);
+                List<String> setupScripts = setup.get(JcloudsLocationConfig.CUSTOM_MACHINE_SETUP_SCRIPT_URL_LIST);
+                Collection<String> allScripts = new MutableList<String>().appendIfNotNull(setupScript).appendAll(setupScripts);
+                for (String setupScriptItem : allScripts) {
+                    if (Strings.isNonBlank(setupScriptItem)) {
+                        customisationForLogging.add("custom setup script "+setupScriptItem);
 
-                    String setupVarsString = setup.get(JcloudsLocationConfig.CUSTOM_MACHINE_SETUP_SCRIPT_VARS);
-                    Map<String, String> substitutions = (setupVarsString != null)
-                            ? Splitter.on(",").withKeyValueSeparator(":").split(setupVarsString)
-                            : ImmutableMap.<String, String>of();
-                    String scriptContent =  ResourceUtils.create(this).getResourceAsString(setupScript);
-                    String script = TemplateProcessor.processTemplateContents(scriptContent, getManagementContext(), substitutions);
-                    sshMachineLocation.execCommands("Customizing node " + this, ImmutableList.of(script));
+                        String setupVarsString = setup.get(JcloudsLocationConfig.CUSTOM_MACHINE_SETUP_SCRIPT_VARS);
+                        Map<String, String> substitutions = (setupVarsString != null)
+                                ? Splitter.on(",").withKeyValueSeparator(":").split(setupVarsString)
+                                : ImmutableMap.<String, String>of();
+                        String scriptContent =  ResourceUtils.create(this).getResourceAsString(setupScriptItem);
+                        String script = TemplateProcessor.processTemplateContents(scriptContent, getManagementContext(), substitutions);
+                        sshMachineLocation.execCommands("Customizing node " + this + " with script " + setupScriptItem, ImmutableList.of(script));
+                    }
                 }
 
                 if (setup.get(JcloudsLocationConfig.MAP_DEV_RANDOM_TO_DEV_URANDOM)) {

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -199,6 +199,9 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
     public static final ConfigKey<String> CUSTOM_MACHINE_SETUP_SCRIPT_URL = ConfigKeys.newStringConfigKey(
             "setup.script", "Custom script to customize a node");
     
+    public static final ConfigKey<List<String>> CUSTOM_MACHINE_SETUP_SCRIPT_URL_LIST = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {},
+            "setup.scripts", "A list of scripts to customize a node");
+    
     public static final ConfigKey<String> CUSTOM_MACHINE_SETUP_SCRIPT_VARS = ConfigKeys.newStringConfigKey(
             "setup.script.vars", "vars to customize a setup.script i.e.: key1:value1,key2:value2");
     


### PR DESCRIPTION
New `setup.scripts` config which accepts an array of scripts to execute on the node.