### PR TITLE
Support for deployment to windows (strike 2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 *.sh text eol=lf
 *.bat text eol=crlf
 *.ps1 text eol=crlf
-
+*.ini text eol=crlf

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -65,7 +65,11 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.cloudsoft.windows</groupId>
+            <artifactId>winrm4j</artifactId>
+            <version>${winrm4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>net.schmizz</groupId>
             <artifactId>sshj</artifactId>

--- a/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
+++ b/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
@@ -145,6 +145,7 @@ public class BrooklynConfigKeys {
 
     public static final ConfigKey<Boolean> START_LATCH = newBooleanConfigKey("start.latch", "Latch for blocking start until ready");
     public static final ConfigKey<Boolean> SETUP_LATCH = newBooleanConfigKey("setup.latch", "Latch for blocking setup until ready");
+    public static final ConfigKey<Boolean> PRE_INSTALL_RESOURCES_LATCH = newBooleanConfigKey("resources.preInstall.latch", "Latch for blocking pre-install resources until ready");
     public static final ConfigKey<Boolean> INSTALL_RESOURCES_LATCH = newBooleanConfigKey("resources.install.latch", "Latch for blocking install resources until ready");
     public static final ConfigKey<Boolean> INSTALL_LATCH = newBooleanConfigKey("install.latch", "Latch for blocking install until ready");
     public static final ConfigKey<Boolean> RUNTIME_RESOURCES_LATCH = newBooleanConfigKey("resources.runtime.latch", "Latch for blocking runtime resources until ready");

--- a/core/src/main/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactory.java
+++ b/core/src/main/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactory.java
@@ -183,7 +183,7 @@ public class ReflectiveEntityDriverFactory {
             return Strings.removeFromEnd(driverInterfaceName, "Driver") + ((PaasLocation) location).getPaasProviderName() + "Driver";
         }
     }
-    
+
     public static class DriverInferenceForWinRmLocation extends AbstractDriverInferenceRule {
 
         public static final String DEFAULT_IDENTIFIER = "winrm-location-driver-inference-rule";

--- a/core/src/main/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactory.java
+++ b/core/src/main/java/brooklyn/entity/drivers/ReflectiveEntityDriverFactory.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import brooklyn.location.Location;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.location.paas.PaasLocation;
+import brooklyn.location.basic.WinRmMachineLocation;
 import brooklyn.util.collections.MutableList;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.exceptions.Exceptions;
@@ -56,6 +57,7 @@ public class ReflectiveEntityDriverFactory {
     public ReflectiveEntityDriverFactory() {
         addRule(DriverInferenceForSshLocation.DEFAULT_IDENTIFIER, new DriverInferenceForSshLocation());
         addRule(DriverInferenceForPaasLocation.DEFAULT_IDENTIFIER, new DriverInferenceForPaasLocation());
+        addRule(DriverInferenceForWinRmLocation.DEFAULT_IDENTIFIER, new DriverInferenceForWinRmLocation());
     }
     
     public interface DriverInferenceRule {
@@ -169,17 +171,32 @@ public class ReflectiveEntityDriverFactory {
 
     public static class DriverInferenceForPaasLocation extends AbstractDriverInferenceRule {
 
-            public static final String DEFAULT_IDENTIFIER = "paas-location-driver-inference-rule";
+        public static final String DEFAULT_IDENTIFIER = "paas-location-driver-inference-rule";
 
-            @Override
-            public <D extends EntityDriver> String inferDriverClassName(DriverDependentEntity<D> entity, Class<D> driverInterface, Location location) {
-                String driverInterfaceName = driverInterface.getName();
-                if (!(location instanceof PaasLocation)) return null;
-                if (!driverInterfaceName.endsWith("Driver")) {
-                    throw new IllegalArgumentException(String.format("Driver name [%s] doesn't end with 'Driver'; cannot auto-detect PaasDriver class name", driverInterfaceName));
-                }
-                return Strings.removeFromEnd(driverInterfaceName, "Driver")+ ((PaasLocation) location).getPaasProviderName() + "Driver";
+        @Override
+        public <D extends EntityDriver> String inferDriverClassName(DriverDependentEntity<D> entity, Class<D> driverInterface, Location location) {
+            String driverInterfaceName = driverInterface.getName();
+            if (!(location instanceof PaasLocation)) return null;
+            if (!driverInterfaceName.endsWith("Driver")) {
+                throw new IllegalArgumentException(String.format("Driver name [%s] doesn't end with 'Driver'; cannot auto-detect PaasDriver class name", driverInterfaceName));
             }
+            return Strings.removeFromEnd(driverInterfaceName, "Driver") + ((PaasLocation) location).getPaasProviderName() + "Driver";
+        }
+    }
+    
+    public static class DriverInferenceForWinRmLocation extends AbstractDriverInferenceRule {
+
+        public static final String DEFAULT_IDENTIFIER = "winrm-location-driver-inference-rule";
+
+        @Override
+        public <D extends EntityDriver> String inferDriverClassName(DriverDependentEntity<D> entity, Class<D> driverInterface, Location location) {
+            String driverInterfaceName = driverInterface.getName();
+            if (!(location instanceof WinRmMachineLocation)) return null;
+            if (!driverInterfaceName.endsWith("Driver")) {
+                throw new IllegalArgumentException(String.format("Driver name [%s] doesn't end with 'Driver'; cannot auto-detect WinRmDriver class name", driverInterfaceName));
+            }
+            return Strings.removeFromEnd(driverInterfaceName, "Driver")+"WinRmDriver";
+        }
     }
 
     /** adds a rule; possibly replacing an old one if one exists with the given identifier. the new rule is added after all previous ones.
@@ -190,17 +207,17 @@ public class ReflectiveEntityDriverFactory {
         LOG.debug("Added driver mapping rule "+rule);
         return oldRule;
     }
-    
+
     public DriverInferenceRule addClassFullNameMapping(String expectedClassFullName, String newClassFullName) {
         DriverInferenceByRenamingClassFullName rule = new DriverInferenceByRenamingClassFullName(expectedClassFullName, newClassFullName);
         return addRule(rule.getIdentifier(), rule);
     }
-    
+
     public DriverInferenceRule addClassSimpleNameMapping(String expectedClassSimpleName, String newClassSimpleName) {
         DriverInferenceByRenamingClassSimpleName rule = new DriverInferenceByRenamingClassSimpleName(expectedClassSimpleName, newClassSimpleName);
         return addRule(rule.getIdentifier(), rule);
     }
-    
+
     public <D extends EntityDriver> D build(DriverDependentEntity<D> entity, Location location){
         Class<D> driverInterface = entity.getDriverInterface();
         Class<? extends D> driverClass = null;
@@ -227,7 +244,7 @@ public class ReflectiveEntityDriverFactory {
             driverClass = driverInterface;
         }
         LOG.debug("Driver for "+driverInterface.getName()+" in "+location+" is: "+driverClass);
-        
+
         if (driverClass==null) {
             if (exceptions.isEmpty())
                 throw new RuntimeException("No drivers could be found for "+driverInterface.getName()+"; "
@@ -244,7 +261,7 @@ public class ReflectiveEntityDriverFactory {
             throw Exceptions.propagate(e);
         }
     }
-    
+
     @SuppressWarnings("unchecked")
     private <D extends EntityDriver> Constructor<D> getConstructor(Class<D> driverClass) {
         for (Constructor<?> constructor : driverClass.getConstructors()) {
@@ -255,5 +272,5 @@ public class ReflectiveEntityDriverFactory {
 
         throw new RuntimeException(String.format("Class [%s] has no constructor with 2 arguments", driverClass.getName()));
     }
-    
+
 }

--- a/core/src/main/java/brooklyn/entity/effector/EffectorTasks.java
+++ b/core/src/main/java/brooklyn/entity/effector/EffectorTasks.java
@@ -33,6 +33,7 @@ import brooklyn.entity.basic.BrooklynTaskTags;
 import brooklyn.entity.basic.ConfigKeys;
 import brooklyn.location.basic.Machines;
 import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.location.basic.WinRmMachineLocation;
 import brooklyn.management.Task;
 import brooklyn.management.TaskAdaptable;
 import brooklyn.management.internal.EffectorUtils;
@@ -217,4 +218,13 @@ public class EffectorTasks {
         }
     }
 
+    /** Finds a unique {@link WinRmMachineLocation} attached to the supplied entity
+     * @throws IllegalStateException if there is not a unique such {@link WinRmMachineLocation} */
+    public static WinRmMachineLocation getWinRmMachine(Entity entity) {
+        try {
+            return Machines.findUniqueWinRmMachineLocation(entity.getLocations()).get();
+        } catch (Exception e) {
+            throw new IllegalStateException("Entity "+entity+" (in "+Tasks.current()+") requires a single WinRmMachineLocation, but has "+entity.getLocations(), e);
+        }
+    }
 }

--- a/core/src/main/java/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/brooklyn/entity/group/DynamicClusterImpl.java
@@ -588,16 +588,22 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
 
         // choose locations to be deployed to
         List<Location> chosenLocations;
-        if (isAvailabilityZoneEnabled()) {
-            List<Location> subLocations = getNonFailedSubLocations();
-            Multimap<Location, Entity> membersByLocation = getMembersByLocation();
-            chosenLocations = getZonePlacementStrategy().locationsForAdditions(membersByLocation, subLocations, delta);
-            if (chosenLocations.size() != delta) {
-                throw new IllegalStateException("Node placement strategy chose " + Iterables.size(chosenLocations)
-                        + ", when expected delta " + delta + " in " + this);
+        chosenLocations = getMemberSpec().getLocations();
+        if (chosenLocations == null) {
+            if (isAvailabilityZoneEnabled()) {
+                List<Location> subLocations = getNonFailedSubLocations();
+                Multimap<Location, Entity> membersByLocation = getMembersByLocation();
+                chosenLocations = getZonePlacementStrategy().locationsForAdditions(membersByLocation, subLocations, delta);
+                if (chosenLocations.size() != delta) {
+                    throw new IllegalStateException("Node placement strategy chose " + Iterables.size(chosenLocations)
+                            + ", when expected delta " + delta + " in " + this);
+                }
+            } else {
+                chosenLocations = Collections.nCopies(delta, getLocation());
             }
         } else {
-            chosenLocations = Collections.nCopies(delta, getLocation());
+            // FIXME: Tidy this up!
+            chosenLocations = Collections.nCopies(delta, chosenLocations.get(0));
         }
 
         // create and start the entities

--- a/core/src/main/java/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/brooklyn/entity/group/DynamicClusterImpl.java
@@ -588,8 +588,8 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
 
         // choose locations to be deployed to
         List<Location> chosenLocations;
-        chosenLocations = getMemberSpec().getLocations();
-        if (chosenLocations == null) {
+        chosenLocations = getMemberSpec() == null ? null : getMemberSpec().getLocations();
+        if (chosenLocations == null || chosenLocations.size() == 0) {
             if (isAvailabilityZoneEnabled()) {
                 List<Location> subLocations = getNonFailedSubLocations();
                 Multimap<Location, Entity> membersByLocation = getMembersByLocation();

--- a/core/src/main/java/brooklyn/event/feed/windows/WindowsPerformanceCounterPollConfig.java
+++ b/core/src/main/java/brooklyn/event/feed/windows/WindowsPerformanceCounterPollConfig.java
@@ -31,6 +31,7 @@ public class WindowsPerformanceCounterPollConfig<T> extends PollConfig<Object, T
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public WindowsPerformanceCounterPollConfig(AttributeSensor<T> sensor) {
         super(sensor);
+        description(sensor.getDescription());
         onSuccess((Function)Functions.identity());
     }
 

--- a/core/src/main/java/brooklyn/location/basic/Machines.java
+++ b/core/src/main/java/brooklyn/location/basic/Machines.java
@@ -95,6 +95,10 @@ public class Machines {
         return findUniqueElement(locations, SshMachineLocation.class);
     }
 
+    public static Maybe<WinRmMachineLocation> findUniqueWinRmMachineLocation(Iterable<? extends Location> locations) {
+        return findUniqueElement(locations, WinRmMachineLocation.class);
+    }
+
     public static Maybe<String> findSubnetHostname(Iterable<? extends Location> ll) {
         Maybe<MachineLocation> l = findUniqueMachineLocation(ll);
         if (!l.isPresent()) {
@@ -169,5 +173,5 @@ public class Machines {
         }
         return false;
     }
-    
+
 }

--- a/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
@@ -91,10 +91,18 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
         return null;
     }
 
+    public int executeScript(String script) {
+        return executeScript(ImmutableList.of(script));
+    }
+
     public int executeScript(List<String> script) {
         WinRmTool winRmTool = WinRmTool.connect(getHostname(), getUsername(), getPassword());
         WinRmToolResponse response = winRmTool.executeScript(script);
         return response.getStatusCode();
+    }
+
+    public int executePsScript(String psScript) {
+        return executePsScript(ImmutableList.of(psScript));
     }
 
     public int executePsScript(List<String> psScript) {

--- a/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.basic;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.location.MachineDetails;
+import brooklyn.location.MachineLocation;
+import brooklyn.location.OsDetails;
+import brooklyn.util.flags.SetFromFlag;
+import io.cloudsoft.winrm4j.winrm.WinRmTool;
+import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
+
+public class WinRmMachineLocation extends AbstractLocation implements MachineLocation {
+
+    public static final ConfigKey<String> WINDOWS_USERNAME = ConfigKeys.newStringConfigKey("windows.username",
+            "Username to use when connecting to the remote machine");
+
+    public static final ConfigKey<String> WINDOWS_PASSWORD = ConfigKeys.newStringConfigKey("windows.password",
+            "Password to use when connecting to the remote machine");
+
+    @SetFromFlag
+    protected String user;
+
+    @SetFromFlag(nullable = false)
+    protected InetAddress address;
+
+    @Override
+    public InetAddress getAddress() {
+        return address;
+    }
+
+    @Override
+    public OsDetails getOsDetails() {
+        return null;
+    }
+
+    @Override
+    public MachineDetails getMachineDetails() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getHostname() {
+        return address.getHostAddress();
+    }
+
+    @Override
+    public Set<String> getPublicAddresses() {
+        return null;
+    }
+
+    @Override
+    public Set<String> getPrivateAddresses() {
+        return null;
+    }
+
+    public int executeScript(List<String> script) {
+        WinRmTool winRmTool = WinRmTool.connect(getHostname(), getUsername(), getPassword());
+        WinRmToolResponse response = winRmTool.executeScript(script);
+        return response.getStatusCode();
+    }
+
+    public int executePsScript(List<String> psScript) {
+        WinRmTool winRmTool = WinRmTool.connect(getHostname(), getUsername(), getPassword());
+        WinRmToolResponse response = winRmTool.executePs(psScript);
+        return response.getStatusCode();
+    }
+
+    public String getUsername() {
+        return config().get(WINDOWS_USERNAME);
+    }
+
+    private String getPassword() {
+        return config().get(WINDOWS_PASSWORD);
+    }
+
+}

--- a/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
@@ -101,17 +101,17 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
         return null;
     }
 
-    public int executeScript(String script) {
+    public WinRmToolResponse executeScript(String script) {
         return executeScript(ImmutableList.of(script));
     }
 
-    public int executeScript(List<String> script) {
+    public WinRmToolResponse executeScript(List<String> script) {
         Collection<Throwable> exceptions = Lists.newArrayList();
         for (int i = 0; i < 10; i++) {
             try {
                 WinRmTool winRmTool = WinRmTool.connect(getHostname(), getUsername(), getPassword());
                 WinRmToolResponse response = winRmTool.executeScript(script);
-                return response.getStatusCode();
+                return response;
             } catch (Exception e) {
                 LOG.warn("ignoring winrm exception and retrying:", e);
                 exceptions.add(e);
@@ -120,17 +120,17 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
         throw Exceptions.propagate("failed to execute powershell script", exceptions);
     }
 
-    public int executePsScript(String psScript) {
+    public WinRmToolResponse executePsScript(String psScript) {
         return executePsScript(ImmutableList.of(psScript));
     }
 
-    public int executePsScript(List<String> psScript) {
+    public WinRmToolResponse executePsScript(List<String> psScript) {
         Collection<Throwable> exceptions = Lists.newArrayList();
         for (int i = 0; i < 10; i++) {
             try {
                 WinRmTool winRmTool = WinRmTool.connect(getHostname(), getUsername(), getPassword());
                 WinRmToolResponse response = winRmTool.executePs(psScript);
-                return response.getStatusCode();
+                return response;
             } catch (Exception e) {
                 LOG.warn("ignoring winrm exception and retrying after 5 seconds:", e);
                 Time.sleep(Duration.FIVE_SECONDS);
@@ -187,7 +187,7 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
         String unencodePowershell =
                 "$RDP = Get-WmiObject -Class Win32_TerminalServiceSetting -ComputerName $env:computername -Namespace root\\CIMV2\\TerminalServices -Authentication PacketPrivacy\r\n" +
                 "$RDP.SetAllowTSConnections(1,1)\r\n" +
-                "Set-ExecutionPolicy Unrestricted\r\n" +
+                "Set-ExecutionPolicy Unrestricted -Force\r\n" +
                 "Set-Item WSMan:\\localhost\\Shell\\MaxConcurrentUsers 100\r\n" +
                 "Set-Item WSMan:\\localhost\\Shell\\MaxMemoryPerShellMB 0\r\n" +
                 "Set-Item WSMan:\\localhost\\Shell\\MaxProcessesPerShell 0\r\n" +

--- a/core/src/main/java/brooklyn/location/cloud/AbstractCloudMachineProvisioningLocation.java
+++ b/core/src/main/java/brooklyn/location/cloud/AbstractCloudMachineProvisioningLocation.java
@@ -21,8 +21,8 @@ package brooklyn.location.cloud;
 import java.util.Collection;
 import java.util.Map;
 
-import brooklyn.location.Location;
 import brooklyn.location.LocationSpec;
+import brooklyn.location.MachineLocation;
 import brooklyn.location.MachineProvisioningLocation;
 import brooklyn.location.basic.AbstractLocation;
 import brooklyn.location.basic.SshMachineLocation;
@@ -30,8 +30,8 @@ import brooklyn.util.collections.MutableMap;
 import brooklyn.util.config.ConfigBag;
 import brooklyn.util.internal.ssh.SshTool;
 
-public abstract class AbstractCloudMachineProvisioningLocation extends AbstractLocation 
-implements MachineProvisioningLocation<SshMachineLocation>, CloudLocationConfig 
+public abstract class AbstractCloudMachineProvisioningLocation extends AbstractLocation
+implements MachineProvisioningLocation<MachineLocation>, CloudLocationConfig
 {
    public AbstractCloudMachineProvisioningLocation() {
       super();

--- a/core/src/main/java/brooklyn/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/brooklyn/location/cloud/CloudLocationConfig.java
@@ -69,6 +69,10 @@ public interface CloudLocationConfig {
             "Whether and how long to wait for a newly provisioned VM to be accessible via ssh; " +
             "if 'false', won't check; if 'true' uses default duration; otherwise accepts a time string e.g. '5m' (the default) or a number of milliseconds", "5m");
 
+    public static final ConfigKey<String> WAIT_FOR_WINRM_AVAILABLE = ConfigKeys.newStringConfigKey("waitForWinRmAvailable",
+            "Whether and how long to wait for a newly provisioned VM to be accessible via WinRm; " +
+                    "if 'false', won't check; if 'true' uses default duration; otherwise accepts a time string e.g. '30m' (the default) or a number of milliseconds", "30m");
+
     public static final ConfigKey<Boolean> LOG_CREDENTIALS = ConfigKeys.newBooleanConfigKey(
             "logCredentials", 
             "Whether to log credentials of a new VM - strongly recommended never be used in production, as it is a big security hole!",

--- a/core/src/main/java/brooklyn/util/flags/TypeCoercions.java
+++ b/core/src/main/java/brooklyn/util/flags/TypeCoercions.java
@@ -31,6 +31,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -707,6 +708,13 @@ public class TypeCoercions {
             @Override
             public QuorumCheck apply(final String input) {
                 return QuorumChecks.of(input);
+            }
+        });
+        registerAdapter(ArrayList.class, String[].class, new Function<ArrayList, String[]>() {
+            @Nullable
+            @Override
+            public String[] apply(@Nullable ArrayList arrayList) {
+                return (String[]) arrayList.toArray(new String[]{});
             }
         });
         registerAdapter(String.class, Map.class, new Function<String,Map>() {

--- a/core/src/main/java/brooklyn/util/flags/TypeCoercions.java
+++ b/core/src/main/java/brooklyn/util/flags/TypeCoercions.java
@@ -31,7 +31,6 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +72,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -710,11 +710,43 @@ public class TypeCoercions {
                 return QuorumChecks.of(input);
             }
         });
-        registerAdapter(ArrayList.class, String[].class, new Function<ArrayList, String[]>() {
+        registerAdapter(Iterable.class, String[].class, new Function<Iterable, String[]>() {
             @Nullable
             @Override
-            public String[] apply(@Nullable ArrayList arrayList) {
-                return (String[]) arrayList.toArray(new String[]{});
+            public String[] apply(@Nullable Iterable list) {
+                if (list == null) return null;
+                String[] result = new String[Iterables.size(list)];
+                int count = 0;
+                for (Object element : list) {
+                    result[count++] = coerce(element, String.class);
+                }
+                return result;
+            }
+        });
+        registerAdapter(Iterable.class, Integer[].class, new Function<Iterable, Integer[]>() {
+            @Nullable
+            @Override
+            public Integer[] apply(@Nullable Iterable list) {
+                if (list == null) return null;
+                Integer[] result = new Integer[Iterables.size(list)];
+                int count = 0;
+                for (Object element : list) {
+                    result[count++] = coerce(element, Integer.class);
+                }
+                return result;
+            }
+        });
+        registerAdapter(Iterable.class, int[].class, new Function<Iterable, int[]>() {
+            @Nullable
+            @Override
+            public int[] apply(@Nullable Iterable list) {
+                if (list == null) return null;
+                int[] result = new int[Iterables.size(list)];
+                int count = 0;
+                for (Object element : list) {
+                    result[count++] = coerce(element, int.class);
+                }
+                return result;
             }
         });
         registerAdapter(String.class, Map.class, new Function<String,Map>() {

--- a/core/src/main/java/brooklyn/util/text/TemplateProcessor.java
+++ b/core/src/main/java/brooklyn/util/text/TemplateProcessor.java
@@ -30,8 +30,12 @@ import org.slf4j.LoggerFactory;
 
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.Entities;
 import brooklyn.entity.basic.EntityInternal;
 import brooklyn.entity.drivers.EntityDriver;
+import brooklyn.event.AttributeSensor;
+import brooklyn.event.basic.DependentConfiguration;
+import brooklyn.event.basic.Sensors;
 import brooklyn.location.Location;
 import brooklyn.management.ManagementContext;
 import brooklyn.management.internal.ManagementContextInternal;
@@ -225,6 +229,40 @@ public class TemplateProcessor {
         }
     }
 
+    protected final static class EntityAttributeTemplateModel implements TemplateHashModel {
+        protected final EntityInternal entity;
+
+        protected EntityAttributeTemplateModel(EntityInternal entity) {
+            this.entity = entity;
+        }
+
+        @Override
+        public boolean isEmpty() throws TemplateModelException {
+            return false;
+        }
+
+        @Override
+        public TemplateModel get(String key) throws TemplateModelException {
+            Object result;
+            try {
+                result = Entities.submit(entity, DependentConfiguration.attributeWhenReady(entity,
+                        Sensors.builder(Object.class, key).persistence(AttributeSensor.SensorPersistenceMode.NONE).build())).get();
+            } catch (Exception e) {
+                throw Exceptions.propagate(e);
+            }
+            if (result == null) {
+                return null;
+            } else {
+                return wrapAsTemplateModel(result);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getName()+"["+entity+"]";
+        }
+    }
+
     /**
      * Provides access to config on an entity or management context, using
      * <code>${config['entity.config.key']}</code> or <code>${mgmt['brooklyn.properties.key']}</code> notation,
@@ -286,6 +324,9 @@ public class TemplateProcessor {
                     return wrapAsTemplateModel( driver.getLocation() );
                 if (entity!=null)
                     return wrapAsTemplateModel( Iterables.getOnlyElement( entity.getLocations() ) );
+            }
+            if ("attribute".equals(key)) {
+                return new EntityAttributeTemplateModel(entity);
             }
             
             if (mgmt!=null) {

--- a/core/src/test/java/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/brooklyn/entity/group/DynamicClusterTest.java
@@ -936,6 +936,21 @@ public class DynamicClusterTest extends BrooklynAppUnitTestSupport {
         assertFirstAndNonFirstCounts(cluster.getMembers(), 1, 2);
     }
 
+    @Test
+    public void testPrefersMemberSpecLocation() throws Exception {
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class)
+                        .location(loc2))
+                .configure(DynamicCluster.INITIAL_SIZE, 1));
+        
+        cluster.start(ImmutableList.of(loc));
+        assertEquals(ImmutableList.copyOf(cluster.getLocations()), ImmutableList.of(loc));
+        
+        Entity member = Iterables.getOnlyElement(cluster.getMembers());
+        assertEquals(ImmutableList.copyOf(member.getLocations()), ImmutableList.of(loc2));
+    }
+
+
     private void assertFirstAndNonFirstCounts(Collection<Entity> members, int expectedFirstCount, int expectedNonFirstCount) {
         Set<Entity> found = MutableSet.of();
         for (Entity e: members) {

--- a/core/src/test/java/brooklyn/location/basic/ByonLocationResolverTest.java
+++ b/core/src/test/java/brooklyn/location/basic/ByonLocationResolverTest.java
@@ -60,8 +60,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-public class
-        ByonLocationResolverTest {
+public class ByonLocationResolverTest {
 
     private static final Logger log = LoggerFactory.getLogger(ByonLocationResolverTest.class);
     
@@ -316,19 +315,19 @@ public class
 
     @Test
     public void testWindowsMachines() throws Exception {
-        brooklynProperties.put("brooklyn.location.byon.windows.username", "myuser");
-        brooklynProperties.put("brooklyn.location.byon.windows.password", "mypassword");
+        brooklynProperties.put("brooklyn.location.byon.user", "myuser");
+        brooklynProperties.put("brooklyn.location.byon.password", "mypassword");
         String spec = "byon";
         Map<String, ?> flags = ImmutableMap.of(
                 "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),
                 "osfamily", "windows"
         );
         MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
-        MachineLocation location = provisioner.obtain(ImmutableMap.of());
+        WinRmMachineLocation location = (WinRmMachineLocation) provisioner.obtain(ImmutableMap.of());
 
-        assertEquals(location.config().get(WinRmMachineLocation.WINDOWS_USERNAME), "myuser");
-        assertEquals(location.config().get(WinRmMachineLocation.WINDOWS_PASSWORD), "mypassword");
-        Assert.assertNotNull(provisioner);
+        assertEquals(location.config().get(WinRmMachineLocation.USER), "myuser");
+        assertEquals(location.config().get(WinRmMachineLocation.PASSWORD), "mypassword");
+        assertEquals(location.config().get(WinRmMachineLocation.ADDRESS).getHostAddress(), "1.1.1.1");
     }
 
     @Test

--- a/core/src/test/java/brooklyn/location/basic/ByonLocationResolverTest.java
+++ b/core/src/test/java/brooklyn/location/basic/ByonLocationResolverTest.java
@@ -60,7 +60,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-public class ByonLocationResolverTest {
+public class
+        ByonLocationResolverTest {
 
     private static final Logger log = LoggerFactory.getLogger(ByonLocationResolverTest.class);
     
@@ -101,14 +102,14 @@ public class ByonLocationResolverTest {
     public void testNamedByonLocation() throws Exception {
         brooklynProperties.put("brooklyn.location.named.mynamed", "byon(hosts=\"1.1.1.1\")");
         
-        FixedListMachineProvisioningLocation<SshMachineLocation> loc = resolve("named:mynamed");
+        FixedListMachineProvisioningLocation<MachineLocation> loc = resolve("named:mynamed");
         assertEquals(loc.obtain().getAddress(), InetAddress.getByName("1.1.1.1"));
     }
 
     @Test
     public void testPropertiesInSpec() throws Exception {
-        FixedListMachineProvisioningLocation<SshMachineLocation> loc = resolve("byon(privateKeyFile=myprivatekeyfile,hosts=\"1.1.1.1\")");
-        SshMachineLocation machine = loc.obtain();
+        FixedListMachineProvisioningLocation<MachineLocation> loc = resolve("byon(privateKeyFile=myprivatekeyfile,hosts=\"1.1.1.1\")");
+        SshMachineLocation machine = (SshMachineLocation)loc.obtain();
         
         assertEquals(machine.config().getBag().getStringKey("privateKeyFile"), "myprivatekeyfile");
         assertEquals(machine.getAddress(), Networking.getInetAddressWithFixedName("1.1.1.1"));
@@ -188,7 +189,7 @@ public class ByonLocationResolverTest {
     public void testNiceError() throws Exception {
         Asserts.assertFailsWith(new Runnable() {
             @Override public void run() {
-                FixedListMachineProvisioningLocation<SshMachineLocation> x = 
+                FixedListMachineProvisioningLocation<MachineLocation> x =
                         resolve("byon(hosts=\"1.1.1.{1,2}}\")");
                 log.error("got "+x+" but should have failed (your DNS is giving an IP for hostname '1.1.1.1}' (with the extra '}')");
             }
@@ -224,8 +225,8 @@ public class ByonLocationResolverTest {
     @Test
     public void testResolvesUserArg2() throws Exception {
         String spec = "byon(hosts=\"1.1.1.1\",user=bob)";
-        FixedListMachineProvisioningLocation<SshMachineLocation> ll = resolve(spec);
-        SshMachineLocation l = ll.obtain();
+        FixedListMachineProvisioningLocation<MachineLocation> ll = resolve(spec);
+        SshMachineLocation l = (SshMachineLocation)ll.obtain();
         Assert.assertEquals("bob", l.getUser());
     }
 
@@ -281,8 +282,8 @@ public class ByonLocationResolverTest {
         String localTempDir = Os.mergePaths(Os.tmp(), "testResolvesUsernameAtHost");
         brooklynProperties.put("brooklyn.location.byon.localTempDir", localTempDir);
 
-        FixedListMachineProvisioningLocation<SshMachineLocation> byon = resolve("byon(hosts=\"1.1.1.1\")");
-        SshMachineLocation machine = byon.obtain();
+        FixedListMachineProvisioningLocation<MachineLocation> byon = resolve("byon(hosts=\"1.1.1.1\",osFamily=\"windows\")");
+        MachineLocation machine = byon.obtain();
         assertEquals(machine.getConfig(SshMachineLocation.LOCAL_TEMP_DIR), localTempDir);
     }
 
@@ -291,10 +292,10 @@ public class ByonLocationResolverTest {
         List<String> ips = ImmutableList.of("1.1.1.1", "1.1.1.6", "1.1.1.3", "1.1.1.4", "1.1.1.5");
         String spec = "byon(hosts=\""+Joiner.on(",").join(ips)+"\")";
         
-        MachineProvisioningLocation<SshMachineLocation> ll = resolve(spec);
+        MachineProvisioningLocation<MachineLocation> ll = resolve(spec);
 
         for (String expected : ips) {
-            SshMachineLocation obtained = ll.obtain(ImmutableMap.of());
+            MachineLocation obtained = ll.obtain(ImmutableMap.of());
             assertEquals(obtained.getAddress().getHostAddress(), expected);
         }
     }
@@ -307,10 +308,39 @@ public class ByonLocationResolverTest {
                 "name", "foo",
                 "user", "myuser"
         );
-        MachineProvisioningLocation<SshMachineLocation> provisioner = resolve(spec, flags);
-        SshMachineLocation location1 = provisioner.obtain(ImmutableMap.of());
+        MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
+        SshMachineLocation location1 = (SshMachineLocation)provisioner.obtain(ImmutableMap.of());
         Assert.assertEquals("myuser", location1.getUser());
         Assert.assertEquals("1.1.1.1", location1.getAddress().getHostAddress());
+    }
+
+    @Test
+    public void testWindowsMachines() throws Exception {
+        brooklynProperties.put("brooklyn.location.byon.windows.username", "myuser");
+        brooklynProperties.put("brooklyn.location.byon.windows.password", "mypassword");
+        String spec = "byon";
+        Map<String, ?> flags = ImmutableMap.of(
+                "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),
+                "osfamily", "windows"
+        );
+        MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
+        MachineLocation location = provisioner.obtain(ImmutableMap.of());
+
+        assertEquals(location.config().get(WinRmMachineLocation.WINDOWS_USERNAME), "myuser");
+        assertEquals(location.config().get(WinRmMachineLocation.WINDOWS_PASSWORD), "mypassword");
+        Assert.assertNotNull(provisioner);
+    }
+
+    @Test
+    public void testNoneWindowsMachines() throws Exception {
+        String spec = "byon";
+        Map<String, ?> flags = ImmutableMap.of(
+                "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),
+                "osfamily", "linux"
+        );
+        MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
+        MachineLocation location = provisioner.obtain(ImmutableMap.of());
+        assertTrue(location instanceof SshMachineLocation, "Expected location to be SshMachineLocation, found " + location);
     }
 
     private void assertByonClusterEquals(FixedListMachineProvisioningLocation<? extends MachineLocation> cluster, Set<String> expectedHosts) {
@@ -362,15 +392,15 @@ public class ByonLocationResolverTest {
     }
     
     @SuppressWarnings("unchecked")
-    private FixedListMachineProvisioningLocation<SshMachineLocation> resolve(String val) {
-        return (FixedListMachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationRegistry().resolve(val);
+    private FixedListMachineProvisioningLocation<MachineLocation> resolve(String val) {
+        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().resolve(val);
     }
     
     @SuppressWarnings("unchecked")
-    private FixedListMachineProvisioningLocation<SshMachineLocation> resolve(String val, Map<?, ?> locationFlags) {
-        return (FixedListMachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationRegistry().resolve(val, locationFlags);
+    private FixedListMachineProvisioningLocation<MachineLocation> resolve(String val, Map<?, ?> locationFlags) {
+        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().resolve(val, locationFlags);
     }
-    
+
     private static class UserHostTuple {
         final String username;
         final String hostname;

--- a/core/src/test/java/brooklyn/util/internal/TypeCoercionsTest.java
+++ b/core/src/test/java/brooklyn/util/internal/TypeCoercionsTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +43,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
 public class TypeCoercionsTest {
@@ -305,6 +307,11 @@ public class TypeCoercionsTest {
     public void testCoerceStringToNumber() {
         assertEquals(TypeCoercions.coerce("1", Number.class), (Number) Double.valueOf(1));
         assertEquals(TypeCoercions.coerce("1.0", Number.class), (Number) Double.valueOf(1.0));
+    }
+
+    @Test
+    public void testArrayListToArray() {
+        assertEquals(TypeCoercions.coerce(Lists.newArrayList("Foo", "Bar", "Baz"), String[].class), new String[] {"Foo", "Bar", "Baz"});
     }
 
     @Test(expectedExceptions = ClassCoercionException.class)

--- a/core/src/test/java/brooklyn/util/internal/TypeCoercionsTest.java
+++ b/core/src/test/java/brooklyn/util/internal/TypeCoercionsTest.java
@@ -22,7 +22,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +35,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import brooklyn.entity.basic.Lifecycle;
+import brooklyn.util.collections.MutableSet;
 import brooklyn.util.flags.ClassCoercionException;
 import brooklyn.util.flags.TypeCoercions;
 import brooklyn.util.text.StringPredicates;
@@ -43,7 +44,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
 public class TypeCoercionsTest {
@@ -188,6 +188,21 @@ public class TypeCoercionsTest {
     }
     
     @Test
+    public void testIterableToArrayCoercion() {
+        String[] s = TypeCoercions.coerce(ImmutableList.of("a", "b"), String[].class);
+        Assert.assertTrue(Arrays.equals(s, new String[] {"a", "b"}), "result="+Arrays.toString(s));
+        
+        Integer[] i = TypeCoercions.coerce(ImmutableList.of(1, 2), Integer[].class);
+        Assert.assertTrue(Arrays.equals(i, new Integer[] {1, 2}), "result="+Arrays.toString(i));
+        
+        int[] i2 = TypeCoercions.coerce(ImmutableList.of(1, 2), int[].class);
+        Assert.assertTrue(Arrays.equals(i2, new int[] {1, 2}), "result="+Arrays.toString(i2));
+        
+        int[] i3 = TypeCoercions.coerce(MutableSet.of("1", 2), int[].class);
+        Assert.assertTrue(Arrays.equals(i3, new int[] {1, 2}), "result="+Arrays.toString(i3));
+    }
+
+    @Test
     public void testListEntryCoercion() {
         List<?> s = TypeCoercions.coerce(ImmutableList.of("java.lang.Integer", "java.lang.Double"), new TypeToken<List<Class<?>>>() { });
         Assert.assertEquals(s, ImmutableList.of(Integer.class, Double.class));
@@ -204,7 +219,7 @@ public class TypeCoercionsTest {
         Collection<?> s = TypeCoercions.coerce(ImmutableList.of("java.lang.Integer", "java.lang.Double"), new TypeToken<Collection<Class<?>>>() { });
         Assert.assertEquals(s, ImmutableList.of(Integer.class, Double.class));
     }
-    
+
     @Test
     public void testMapValueCoercion() {
         Map<?,?> s = TypeCoercions.coerce(ImmutableMap.of("int", "java.lang.Integer", "double", "java.lang.Double"), new TypeToken<Map<String, Class<?>>>() { });
@@ -307,11 +322,6 @@ public class TypeCoercionsTest {
     public void testCoerceStringToNumber() {
         assertEquals(TypeCoercions.coerce("1", Number.class), (Number) Double.valueOf(1));
         assertEquals(TypeCoercions.coerce("1.0", Number.class), (Number) Double.valueOf(1.0));
-    }
-
-    @Test
-    public void testArrayListToArray() {
-        assertEquals(TypeCoercions.coerce(Lists.newArrayList("Foo", "Bar", "Baz"), String[].class), new String[] {"Foo", "Bar", "Baz"});
     }
 
     @Test(expectedExceptions = ClassCoercionException.class)

--- a/docs/guide/yaml/winrm/index.md
+++ b/docs/guide/yaml/winrm/index.md
@@ -1,0 +1,17 @@
+---
+title: Windows blueprints using WinRM
+layout: website-normal
+children:
+- about-winrm.md
+- re-authentication.md
+- stdout-and-stderr.md
+---
+
+This guide describes how Brooklyn entities can be easily created from Chef cookbooks.
+As of this writing (May 2014) some of the integration points are under active development,
+and comments are welcome.
+A plan for the full integration is online [here](https://docs.google.com/a/cloudsoftcorp.com/document/d/18ZwzmncbJgJeQjnSvMapTWg6N526cvGMz5jaqdkxMf8).  
+
+This guide assumes you are familiar with the basics of [creating YAML blueprints](../).
+
+{% include list-children.html %}

--- a/docs/guide/yaml/winrm/re-authentication.md
+++ b/docs/guide/yaml/winrm/re-authentication.md
@@ -1,0 +1,38 @@
+---
+title: Re-authenticating within a powershell script
+title_in_menu: Re-authentication
+layout: website-normal
+---
+
+## How and Why to re-authenticate withing a powershell script
+
+Brooklyn will run powershell scripts by making a WinRM call over HTTP. For most scripts this will work, however for
+some scripts (e.g. MSSQL installation), this will fail even if the script can be run locally (e.g. by using RDP to
+connect to the machine and running the script manually)
+
+In the case of MS SQL server installation, there was no clear indication of why this would not work. The only clue was
+a security exception in the installation log
+
+It appears that when a script is run over WinRM over HTTP, the credentials under which the script are run are marked as
+'remote' credentials, which are prohibited from running certain security-related operations. The solution was to obtain
+a new set of credentials within the script and use those credentials to exeute the installer, so this:
+
+```
+( $driveLetter + "setup.exe") /ConfigurationFile=C:\ConfigurationFile.ini
+```
+
+became this:
+
+$pass = '${attribute['windows.password']}'
+$secpasswd = ConvertTo-SecureString $pass -AsPlainText -Force
+$mycreds = New-Object System.Management.Automation.PSCredential ($($env:COMPUTERNAME + "\Administrator"), $secpasswd)
+
+Invoke-Command -ComputerName localhost -credential $mycreds -scriptblock {
+    param($driveLetter)
+    Start-Process ( $driveLetter + "setup.exe") -ArgumentList "/ConfigurationFile=C:\ConfigurationFile.ini" -RedirectStandardOutput "C:\sqlout.txt" -RedirectStandardError "C:\sqlerr.txt" -Wait
+} -Authentication CredSSP -argumentlist $driveLetter
+
+The `$pass=` line simply reads the Windows password from the entity before the script is copied to the server. This is
+then encrypted on the next line before being used to create a new credential object. Then, rather than calling the executable
+directly, the `Start-Process` scriptlet is used. This allows us to pass in the newly created credentials, under which
+the process will be run

--- a/docs/guide/yaml/winrm/stdout-and-stderr.md
+++ b/docs/guide/yaml/winrm/stdout-and-stderr.md
@@ -1,0 +1,27 @@
+---
+title: Redirecting stdout and stderr
+title_in_menu: Redirecting stdout/stderr
+layout: website-normal
+---
+
+## Redirecting stdout and stderr in a powershell script
+
+When calling an executable in a powershell script, the stdout and stderr will usually be output to the console,
+which is not currently captured by Brooklyn. In order to facilitate debugging, it is usually possible to redirect
+stdout and stderr to a file by using the Start-Process scriptlet. So instead of running the following:
+
+```
+D:\setup.exe /ConfigurationFile=C:\ConfigurationFile.ini
+```
+
+You would run the following:
+
+```
+Start-Process D:\setup.exe -ArgumentList "/ConfigurationFile=C:\ConfigurationFile.ini" -RedirectStandardOutput "C:\sqlout.txt" -RedirectStandardError "C:\sqlerr.txt" -PassThru -Wait
+```
+
+The -ArgumentList is simply the arguments that are to be passed to the executable, -RedirectStandardOutput and -RedirectStandardError take file locations for the output (if
+the file already exists, it will be overwritten). The -PassThru argument indicates that PowerShell should write to the file *in addition* to the console, rather than *instead* of the console.
+The -Wait augument will cause the scriptlet to block until the process is complete
+
+Further details can be found here: https://technet.microsoft.com/en-us/library/hh849848.aspx

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
@@ -52,16 +52,46 @@ public class BasicJcloudsLocationCustomizer implements JcloudsLocationCustomizer
     }
 
     @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+        if (machine instanceof JcloudsSshMachineLocation) {
+            customize(location, computeService, (JcloudsSshMachineLocation)machine);
+        } else {
+            // no-op
+        }
+    }
+    
+    @Override
+    public void preRelease(JcloudsMachineLocation machine) {
+        if (machine instanceof JcloudsSshMachineLocation) {
+            preRelease((JcloudsSshMachineLocation)machine);
+        } else {
+            // no-op
+        }
+    }
+
+    @Override
+    public void postRelease(JcloudsMachineLocation machine) {
+        if (machine instanceof JcloudsSshMachineLocation) {
+            postRelease((JcloudsSshMachineLocation)machine);
+        } else {
+            // no-op
+        }
+    }
+    
+    @Override
+    @Deprecated
     public void customize(JcloudsLocation location, ComputeService computeService, JcloudsSshMachineLocation machine) {
         // no-op
     }
 
     @Override
+    @Deprecated
     public void preRelease(JcloudsSshMachineLocation machine) {
         // no-op
     }
 
     @Override
+    @Deprecated
     public void postRelease(JcloudsSshMachineLocation machine) {
         // no-op
     }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/BrooklynMachinePool.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/BrooklynMachinePool.java
@@ -31,7 +31,9 @@ import org.slf4j.LoggerFactory;
 
 import brooklyn.entity.Entity;
 import brooklyn.entity.trait.Startable;
+import brooklyn.location.MachineLocation;
 import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.location.basic.WinRmMachineLocation;
 import brooklyn.location.jclouds.pool.MachinePool;
 import brooklyn.location.jclouds.pool.MachineSet;
 import brooklyn.location.jclouds.pool.ReusableMachineTemplate;
@@ -117,7 +119,13 @@ public class BrooklynMachinePool extends MachinePool {
             // TODO this in parallel
             JcloudsSshMachineLocation m;
             try {
-                m = location.obtain(MutableMap.of("callerContext", ""+this+"("+template+")"), template);
+                MachineLocation machineLocation = location.obtain(MutableMap.of("callerContext", ""+this+"("+template+")"), template);
+                // Class has been deprecated since 0.6.0, and prior to that, obtain would have returned a JcloudsSshMachineLocation
+                if (machineLocation instanceof JcloudsSshMachineLocation) {
+                    m = (JcloudsSshMachineLocation) machineLocation;
+                } else {
+                    throw new UnsupportedOperationException("Cannot create WinRmMachineLocation");
+                }
             } catch (Exception e) {
                 throw Throwables.propagate(e);
             }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2017,7 +2017,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         try {
             // FIXME: Needs to release port forwarding for WinRmMachineLocations
-            if (machine.getMachineDetails() != null && machine.getMachineDetails().getOsDetails() != null && !machine.getMachineDetails().getOsDetails().isWindows()) {
+            if (machine instanceof SshMachineLocation) {
                 releasePortForwarding((SshMachineLocation)machine);
             }
         } catch (Exception e) {

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1255,8 +1255,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                             LOG.warn("Ignoring request to set template option {} because this is not supported by {}", new Object[] { option.getKey(), clazz.getCanonicalName() });
                         }
                     }
-                }
-              })
+                }})
             .build();
 
     /** hook whereby template customizations can be made for various clouds */
@@ -2018,7 +2017,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         try {
             // FIXME: Needs to release port forwarding for WinRmMachineLocations
-            if (machine.getMachineDetails().getOsDetails() != null && !machine.getMachineDetails().getOsDetails().isWindows()) {
+            if (machine.getMachineDetails() != null && machine.getMachineDetails().getOsDetails() != null && !machine.getMachineDetails().getOsDetails().isWindows()) {
                 releasePortForwarding((SshMachineLocation)machine);
             }
         } catch (Exception e) {

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -707,7 +707,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             if (windows) {
                 // FIMXE: Need to write WinRM equivalent of getPublicHostname
                 String hostName = node.getPublicAddresses().iterator().next();
-                winRmMachineLocation = registerWinRmMachineLocation(hostName, setup);
+                winRmMachineLocation = registerWinRmMachineLocation(hostName, setup, node.getId());
                 machineLocation = winRmMachineLocation;
             } else {
                 jcloudsSshMachineLocation = registerJcloudsSshMachineLocation(computeService, node, userCredentials, sshHostAndPortOverride, setup);
@@ -1933,9 +1933,10 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         }
     }
 
-    protected WinRmMachineLocation registerWinRmMachineLocation(String vmHostname, ConfigBag setup) {
+    protected WinRmMachineLocation registerWinRmMachineLocation(String vmHostname, ConfigBag setup, String nodeId) {
         WinRmMachineLocation winRmMachineLocation = createWinRmMachineLocation(vmHostname, setup);
         winRmMachineLocation.setParent(this);
+        vmInstanceIds.put(winRmMachineLocation, nodeId);
         return winRmMachineLocation;
     }
 

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2017,7 +2017,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         }
 
         try {
-            if (!machine.getMachineDetails().getOsDetails().isWindows()) {
+            // FIXME: Needs to release port forwarding for WinRmMachineLocations
+            if (machine.getMachineDetails().getOsDetails() != null && !machine.getMachineDetails().getOsDetails().isWindows()) {
                 releasePortForwarding((SshMachineLocation)machine);
             }
         } catch (Exception e) {

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -257,8 +257,8 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
             ComputeServiceRegistryImpl.INSTANCE);
     
     @SuppressWarnings("serial")
-    public static final ConfigKey<Map<String,String>> TEMPLATE_OPTIONS = ConfigKeys.newConfigKey(
-            new TypeToken<Map<String, String>>() {}, "templateOptions", "Additional jclouds template options");
+    public static final ConfigKey<Map<String,Object>> TEMPLATE_OPTIONS = ConfigKeys.newConfigKey(
+            new TypeToken<Map<String, Object>>() {}, "templateOptions", "Additional jclouds template options");
 
     // TODO
     

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
@@ -63,17 +63,43 @@ public interface JcloudsLocationCustomizer {
      * <p/>
      * If {@link brooklyn.location.jclouds.JcloudsLocationConfig#WAIT_FOR_SSHABLE} is true the
      * machine is guaranteed to be SSHable when this method is called.
+     * 
+     * @since 0.7.0; use {@link #customize(JcloudsLocation, ComputeService, JcloudsMachineLocation)}
      */
+    @Deprecated
     void customize(JcloudsLocation location, ComputeService computeService, JcloudsSshMachineLocation machine);
     
     /**
      * Override to handle machine-related cleanup before Jclouds is called to release (destroy) the machine.
+     * 
+     * @since 0.7.0; use {@link #preRelease(JcloudsMachineLocation)}
      */
+    @Deprecated
     void preRelease(JcloudsSshMachineLocation machine);
 
     /**
      * Override to handle machine-related cleanup after Jclouds is called to release (destroy) the machine.
+     * 
+     * @since 0.7.0; use {@link #postRelesae(JcloudsMachineLocation)}
      */
+    @Deprecated
     void postRelease(JcloudsSshMachineLocation machine);
 
+    /**
+     * Override to configure the given machine once it has been created and started by Jclouds.
+     * <p/>
+     * If {@link brooklyn.location.jclouds.JcloudsLocationConfig#WAIT_FOR_SSHABLE} is true the
+     * machine is guaranteed to be SSHable when this method is called.
+     */
+    void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine);
+    
+    /**
+     * Override to handle machine-related cleanup before Jclouds is called to release (destroy) the machine.
+     */
+    void preRelease(JcloudsMachineLocation machine);
+
+    /**
+     * Override to handle machine-related cleanup after Jclouds is called to release (destroy) the machine.
+     */
+    void postRelease(JcloudsMachineLocation machine);
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsMachineLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsMachineLocation.java
@@ -16,7 +16,30 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.basic;
+package brooklyn.location.jclouds;
 
-public interface AbstractVanillaProcessDriver extends SoftwareProcessDriver {
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.Template;
+
+import brooklyn.location.MachineLocation;
+import brooklyn.location.basic.HasSubnetHostname;
+
+public interface JcloudsMachineLocation extends MachineLocation, HasSubnetHostname {
+    
+    @Override
+    public JcloudsLocation getParent();
+    
+    public NodeMetadata getNode();
+    
+    public Template getTemplate();
+
+    public String getJcloudsId();
+
+    /** In most clouds, the public hostname is the only way to ensure VMs in different zones can access each other. */
+    @Override
+    public String getSubnetHostname();
+
+    String getUser();
+
+    int getPort();
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -68,7 +68,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ListenableFuture;
 
-public class JcloudsSshMachineLocation extends SshMachineLocation implements HasSubnetHostname {
+public class JcloudsSshMachineLocation extends SshMachineLocation implements JcloudsMachineLocation {
     
     private static final Logger LOG = LoggerFactory.getLogger(JcloudsSshMachineLocation.class);
     private static final long serialVersionUID = -443866395634771659L;
@@ -133,14 +133,17 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Has
                 .toString();
     }
 
+    @Override
     public NodeMetadata getNode() {
         return node;
     }
     
+    @Override
     public Template getTemplate() {
         return template;
     }
     
+    @Override
     public JcloudsLocation getParent() {
         return jcloudsParent;
     }
@@ -199,6 +202,7 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Has
         return Optional.absent();
     }
     
+    @Override
     public String getJcloudsId() {
         return node.getId();
     }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.jclouds;
+
+import brooklyn.location.basic.WinRmMachineLocation;
+
+public class JcloudsWinRmMachineLocation extends WinRmMachineLocation {
+
+}

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/SudoTtyFixingCustomizer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/SudoTtyFixingCustomizer.java
@@ -21,7 +21,9 @@ package brooklyn.location.jclouds;
 import org.jclouds.compute.ComputeService;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
 
+import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.util.task.DynamicTasks;
 import brooklyn.util.task.ssh.SshTasks;
 import brooklyn.util.task.ssh.SshTasks.OnFailingTask;
@@ -48,9 +50,9 @@ import brooklyn.util.task.ssh.SshTasks.OnFailingTask;
 public class SudoTtyFixingCustomizer extends BasicJcloudsLocationCustomizer {
 
     @Override
-    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsSshMachineLocation machine) {
-        DynamicTasks.queueIfPossible(SshTasks.dontRequireTtyForSudo(machine, OnFailingTask.FAIL)).orSubmitAndBlock();
+    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+        Preconditions.checkArgument(machine instanceof SshMachineLocation, "machine must be SshMachineLocation, but is %s", machine.getClass());
+        DynamicTasks.queueIfPossible(SshTasks.dontRequireTtyForSudo((SshMachineLocation)machine, OnFailingTask.FAIL)).orSubmitAndBlock();
         DynamicTasks.waitForLast();
     }
-
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
@@ -38,7 +38,7 @@ import brooklyn.entity.Entity;
 import brooklyn.location.geo.LocalhostExternalIpLoader;
 import brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
 import brooklyn.location.jclouds.JcloudsLocation;
-import brooklyn.location.jclouds.JcloudsSshMachineLocation;
+import brooklyn.location.jclouds.JcloudsMachineLocation;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.task.Tasks;
 import brooklyn.util.time.Duration;
@@ -112,8 +112,8 @@ public final class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLo
         return getInstance(entity.getApplicationId());
     }
 
-    /** @see #addPermissionsToLocation(brooklyn.location.jclouds.JcloudsSshMachineLocation, java.util.Collection)  */
-    public void addPermissionsToLocation(final JcloudsSshMachineLocation location, IpPermission... permissions) {
+    /** @see #addPermissionsToLocation(brooklyn.location.jclouds.JcloudsMachineLocation, java.util.Collection)  */
+    public void addPermissionsToLocation(final JcloudsMachineLocation location, IpPermission... permissions) {
         addPermissionsToLocation(location, ImmutableList.copyOf(permissions));
     }
 
@@ -124,7 +124,7 @@ public final class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLo
      * @param permissions The set of permissions to be applied to the location
      * @param location Location to gain permissions
      */
-    public void addPermissionsToLocation(final JcloudsSshMachineLocation location, final Collection<IpPermission> permissions) {
+    public void addPermissionsToLocation(final JcloudsMachineLocation location, final Collection<IpPermission> permissions) {
         ComputeService computeService = location.getParent().getComputeService();
         String nodeId = location.getNode().getId();
         addPermissionsToLocation(permissions, nodeId, computeService);

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
@@ -141,7 +141,7 @@ public class AbstractJcloudsLiveTest {
     // Use this utility method to ensure machines are released on tearDown
     protected JcloudsSshMachineLocation obtainMachine(Map<?, ?> conf) throws Exception {
         assertNotNull(jcloudsLocation);
-        JcloudsSshMachineLocation result = jcloudsLocation.obtain(conf);
+        JcloudsSshMachineLocation result = (JcloudsSshMachineLocation)jcloudsLocation.obtain(conf);
         machines.add(checkNotNull(result, "result"));
         return result;
     }

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsByonLocationResolverAwsLiveTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsByonLocationResolverAwsLiveTest.java
@@ -54,7 +54,7 @@ public class JcloudsByonLocationResolverAwsLiveTest extends AbstractJcloudsLiveT
     public void setUpClass() throws Exception {
         classManagementContext = newManagementContext();
         classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().resolve(AWS_LOCATION_SPEC);
-        classEc2Vm = classEc2Loc.obtain(MutableMap.<String,Object>builder()
+        classEc2Vm = (JcloudsSshMachineLocation)classEc2Loc.obtain(MutableMap.<String,Object>builder()
                 .put("hardwareId", AWS_EC2_SMALL_HARDWARE_ID)
                 .put("inboundPorts", ImmutableList.of(22))
                 .build());

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsByonLocationResolverSoftlayerLiveTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsByonLocationResolverSoftlayerLiveTest.java
@@ -52,7 +52,7 @@ public class JcloudsByonLocationResolverSoftlayerLiveTest extends AbstractJcloud
     public void setUpClass() throws Exception {
         classManagementContext = newManagementContext();
         classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().resolve(SOFTLAYER_LOCATION_SPEC);
-        classVm = classEc2Loc.obtain(MutableMap.<String,Object>builder()
+        classVm = (JcloudsSshMachineLocation)classEc2Loc.obtain(MutableMap.<String,Object>builder()
                 .put("inboundPorts", ImmutableList.of(22))
                 .build());
         slVmUser = classVm.getUser();

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -524,7 +524,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
             
             // explicitly invoke this customizer, to comply with tests
             for (JcloudsLocationCustomizer customizer : getCustomizers(config().getBag())) {
-                customizer.customize(this, null, result);
+                customizer.customize(this, null, (JcloudsMachineLocation)result);
             }
 
             return result;
@@ -591,7 +591,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
             .configure(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS, ImmutableList.of(customizer))
             .configure(JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 1);
         FakeLocalhostWithParentJcloudsLocation ll = managementContext.getLocationManager().createLocation(LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class).configure(allConfig.getAllConfig()));
-        JcloudsSshMachineLocation l = (JcloudsSshMachineLocation)ll.obtain();
+        JcloudsMachineLocation l = (JcloudsMachineLocation)ll.obtain();
         Mockito.verify(customizer, Mockito.times(1)).customize(ll, null, l);
         Mockito.verify(customizer, Mockito.never()).preRelease(l);
         Mockito.verify(customizer, Mockito.never()).postRelease(l);

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -45,6 +45,7 @@ import brooklyn.config.ConfigKey;
 import brooklyn.entity.basic.ConfigKeys;
 import brooklyn.entity.basic.Entities;
 import brooklyn.location.LocationSpec;
+import brooklyn.location.MachineLocation;
 import brooklyn.location.NoMachinesAvailableException;
 import brooklyn.location.basic.LocationConfigKeys;
 import brooklyn.location.cloud.names.CustomMachineNamer;
@@ -547,7 +548,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
             .configure(LocationConfigKeys.LONGITUDE, -20d)
             .configure(JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 1);
         FakeLocalhostWithParentJcloudsLocation ll = managementContext.getLocationManager().createLocation(LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class).configure(allConfig.getAllConfig()));
-        JcloudsSshMachineLocation l = ll.obtain();
+        MachineLocation l = ll.obtain();
         log.info("loc:" +l);
         HostGeoInfo geo = HostGeoInfo.fromLocation(l);
         log.info("geo: "+geo);
@@ -571,7 +572,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
         FakeLocalhostWithParentJcloudsLocation ll = managementContext.getLocationManager().createLocation(LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class)
             .configure(new JcloudsPropertiesFromBrooklynProperties().getJcloudsProperties("softlayer", "wdc01", null, managementContext.getBrooklynProperties()))
             .configure(allConfig.getAllConfig()));
-        JcloudsSshMachineLocation l = ll.obtain();
+        MachineLocation l = ll.obtain();
         log.info("loc:" +l);
         HostGeoInfo geo = HostGeoInfo.fromLocation(l);
         log.info("geo: "+geo);
@@ -590,7 +591,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
             .configure(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS, ImmutableList.of(customizer))
             .configure(JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 1);
         FakeLocalhostWithParentJcloudsLocation ll = managementContext.getLocationManager().createLocation(LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class).configure(allConfig.getAllConfig()));
-        JcloudsSshMachineLocation l = ll.obtain();
+        JcloudsSshMachineLocation l = (JcloudsSshMachineLocation)ll.obtain();
         Mockito.verify(customizer, Mockito.times(1)).customize(ll, null, l);
         Mockito.verify(customizer, Mockito.never()).preRelease(l);
         Mockito.verify(customizer, Mockito.never()).postRelease(l);

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/LiveTestEntity.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/LiveTestEntity.java
@@ -58,7 +58,7 @@ public interface LiveTestEntity extends TestEntity {
             addLocations(locs);
             provisioningLocation = (JcloudsLocation) Iterables.find(locs, Predicates.instanceOf(JcloudsLocation.class));
             try {
-                obtainedLocation = provisioningLocation.obtain(((LocationInternal)provisioningLocation).config().getBag().getAllConfig());
+                obtainedLocation = (JcloudsSshMachineLocation)provisioningLocation.obtain(((LocationInternal)provisioningLocation).config().getBag().getAllConfig());
             } catch (NoMachinesAvailableException e) {
                 throw Throwables.propagate(e);
             }

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/provider/AbstractJcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/provider/AbstractJcloudsLocationTest.java
@@ -153,7 +153,7 @@ public abstract class AbstractJcloudsLocationTest {
     // Use this utility method to ensure machines are released on tearDown
     protected SshMachineLocation obtainMachine(Map flags) {
         try {
-            SshMachineLocation result = loc.obtain(flags);
+            SshMachineLocation result = (SshMachineLocation)loc.obtain(flags);
             machines.add(result);
             return result;
         } catch (NoMachinesAvailableException nmae) {

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/zone/AwsAvailabilityZoneExtensionTest.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/zone/AwsAvailabilityZoneExtensionTest.java
@@ -95,7 +95,7 @@ public class AwsAvailabilityZoneExtensionTest {
         JcloudsLocation subLocation = (JcloudsLocation) Iterables.getOnlyElement(subLocations);
         JcloudsSshMachineLocation machine = null;
         try {
-            machine = subLocation.obtain(ImmutableMap.builder()
+            machine = (JcloudsSshMachineLocation)subLocation.obtain(ImmutableMap.builder()
                     .put(JcloudsLocation.IMAGE_ID, US_EAST_IMAGE_ID)
                     .put(JcloudsLocation.HARDWARE_ID, SMALL_HARDWARE_ID)
                     .put(JcloudsLocation.INBOUND_PORTS, ImmutableList.of(22))

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <maxmind.version>0.8.1</maxmind.version>
         <jna.version>4.0.0</jna.version>
-        <winrm4j.version>0.1.0-SNAPSHOT</winrm4j.version>
+        <winrm4j.version>0.1.0</winrm4j.version>
         <coverage.target>${working.dir}</coverage.target>
 
         <!-- Release -->

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <maxmind.version>0.8.1</maxmind.version>
         <jna.version>4.0.0</jna.version>
+        <winrm4j.version>0.1.0-SNAPSHOT</winrm4j.version>
         <coverage.target>${working.dir}</coverage.target>
 
         <!-- Release -->

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
@@ -314,11 +314,7 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
      */
     public void copyRuntimeResources() {
         try {
-            // Ensure environment variables are not looked up here, otherwise sub-classes might
-            // lookup port numbers and fail with ugly error if port is not set. It could also
-            // cause us to block for attribute ready earlier than we need.
-            DynamicTasks.queue(SshEffectorTasks.ssh("mkdir -p " + getRunDir()).summary("create run directory")
-                    .requiringExitCodeZero()).get();
+            createDirectory(getRunDir(), "create run directory");
 
             Map<String, String> runtimeFiles = entity.getConfig(SoftwareProcess.RUNTIME_FILES);
             if (runtimeFiles != null && runtimeFiles.size() > 0) {

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessDriver.java
@@ -18,18 +18,26 @@
  */
 package brooklyn.entity.basic;
 
+import static brooklyn.util.JavaGroovyEquivalents.elvis;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import brooklyn.config.ConfigKey;
+import brooklyn.entity.software.SshEffectorTasks;
 import brooklyn.location.Location;
 import brooklyn.util.ResourceUtils;
+import brooklyn.util.collections.MutableMap;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.os.Os;
+import brooklyn.util.stream.ReaderInputStream;
 import brooklyn.util.task.DynamicTasks;
 import brooklyn.util.task.Tasks;
 import brooklyn.util.text.Strings;
@@ -131,7 +139,7 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 DynamicTasks.queue("post-install-command", new Runnable() { public void run() {
                     runPostInstallCommand(entity.getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND));
                 }});
-            };
+            }
 
             DynamicTasks.queue("customize", new Runnable() { public void run() {
                 waitForConfigKey(BrooklynConfigKeys.CUSTOMIZE_LATCH);
@@ -176,10 +184,8 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
 
     public abstract void runPreInstallCommand(String command);
     public abstract void setup();
-    public abstract void copyInstallResources();
     public abstract void install();
     public abstract void runPostInstallCommand(String command);
-    public abstract void copyRuntimeResources();
     public abstract void customize();
     public abstract void runPreLaunchCommand(String command);
     public abstract void launch();
@@ -197,25 +203,27 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
 
     @Override
     public void restart() {
-        DynamicTasks.queue("stop (best effort)", new Runnable() { public void run() {
-            DynamicTasks.markInessential();
-            boolean previouslyRunning = isRunning();
-            try {
-                ServiceStateLogic.setExpectedState(getEntity(), Lifecycle.STOPPING);
-                stop();
-            } catch (Exception e) {
-                // queue a failed task so that there is visual indication that this task had a failure,
-                // without interrupting the parent
-                if (previouslyRunning) {
-                    log.warn(getEntity() + " restart: stop failed, when was previously running (ignoring)", e);
-                    DynamicTasks.queue(Tasks.fail("Primary job failure (when previously running)", e));
-                } else {
-                    log.debug(getEntity() + " restart: stop failed (but was not previously running, so not a surprise)", e);
-                    DynamicTasks.queue(Tasks.fail("Primary job failure (when not previously running)", e));
+        DynamicTasks.queue("stop (best effort)", new Runnable() {
+            public void run() {
+                DynamicTasks.markInessential();
+                boolean previouslyRunning = isRunning();
+                try {
+                    ServiceStateLogic.setExpectedState(getEntity(), Lifecycle.STOPPING);
+                    stop();
+                } catch (Exception e) {
+                    // queue a failed task so that there is visual indication that this task had a failure,
+                    // without interrupting the parent
+                    if (previouslyRunning) {
+                        log.warn(getEntity() + " restart: stop failed, when was previously running (ignoring)", e);
+                        DynamicTasks.queue(Tasks.fail("Primary job failure (when previously running)", e));
+                    } else {
+                        log.debug(getEntity() + " restart: stop failed (but was not previously running, so not a surprise)", e);
+                        DynamicTasks.queue(Tasks.fail("Primary job failure (when not previously running)", e));
+                    }
+                    // the above queued tasks will cause this task to be indicated as failed, with an indication of severity
                 }
-                // the above queued tasks will cause this task to be indicated as failed, with an indication of severity
             }
-        }});
+        });
 
         if (doFullStartOnRestart()) {
             DynamicTasks.waitForLast();
@@ -249,6 +257,172 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
 
     public InputStream getResource(String url) {
         return resource.getResourceFromUrl(url);
+    }
+
+    /**
+     * Files and templates to be copied to the server <em>before</em> installation. This allows the {@link #install()}
+     * process to have access to all required resources.
+     * <p>
+     * Will be prefixed with the entity's {@link #getInstallDir() install directory} if relative.
+     *
+     * @see SoftwareProcess#INSTALL_FILES
+     * @see SoftwareProcess#INSTALL_TEMPLATES
+     * @see #copyRuntimeResources()
+     */
+    public void copyInstallResources() {
+
+        // Ensure environment variables are not looked up here, otherwise sub-classes might
+        // lookup port numbers and fail with ugly error if port is not set; better to wait
+        // until in Entity's code (e.g. customize) where such checks are done explicitly.
+        createDirectory(getInstallDir(), "create install directory");
+
+        // TODO see comment in copyResource, that should be queued as a task like the above
+        // (better reporting in activities console)
+
+        Map<String, String> installFiles = entity.getConfig(SoftwareProcess.INSTALL_FILES);
+        if (installFiles != null && installFiles.size() > 0) {
+            for (String source : installFiles.keySet()) {
+                String target = installFiles.get(source);
+                String destination = Os.isAbsolutish(target) ? target : Os.mergePathsUnix(getInstallDir(), target);
+                copyResource(source, destination, true);
+            }
+        }
+
+        Map<String, String> installTemplates = entity.getConfig(SoftwareProcess.INSTALL_TEMPLATES);
+        if (installTemplates != null && installTemplates.size() > 0) {
+            for (String source : installTemplates.keySet()) {
+                String target = installTemplates.get(source);
+                String destination = Os.isAbsolutish(target) ? target : Os.mergePathsUnix(getInstallDir(), target);
+                copyTemplate(source, destination, true, MutableMap.<String, Object>of());
+            }
+        }
+
+    }
+
+    protected abstract void createDirectory(String directoryName, String summaryForLogging);
+
+    /**
+     * Files and templates to be copied to the server <em>after</em> customisation. This allows overwriting of
+     * existing files such as entity configuration which may be copied from the installation directory
+     * during the {@link #customize()} process.
+     * <p>
+     * Will be prefixed with the entity's {@link #getRunDir() run directory} if relative.
+     *
+     * @see SoftwareProcess#RUNTIME_FILES
+     * @see SoftwareProcess#RUNTIME_TEMPLATES
+     * @see #copyInstallResources()
+     */
+    public void copyRuntimeResources() {
+        try {
+            // Ensure environment variables are not looked up here, otherwise sub-classes might
+            // lookup port numbers and fail with ugly error if port is not set. It could also
+            // cause us to block for attribute ready earlier than we need.
+            DynamicTasks.queue(SshEffectorTasks.ssh("mkdir -p " + getRunDir()).summary("create run directory")
+                    .requiringExitCodeZero()).get();
+
+            Map<String, String> runtimeFiles = entity.getConfig(SoftwareProcess.RUNTIME_FILES);
+            if (runtimeFiles != null && runtimeFiles.size() > 0) {
+                for (String source : runtimeFiles.keySet()) {
+                    String target = runtimeFiles.get(source);
+                    String destination = Os.isAbsolutish(target) ? target : Os.mergePathsUnix(getRunDir(), target);
+                    copyResource(source, destination, true);
+                }
+            }
+
+            Map<String, String> runtimeTemplates = entity.getConfig(SoftwareProcess.RUNTIME_TEMPLATES);
+            if (runtimeTemplates != null && runtimeTemplates.size() > 0) {
+                for (String source : runtimeTemplates.keySet()) {
+                    String target = runtimeTemplates.get(source);
+                    String destination = Os.isAbsolutish(target) ? target : Os.mergePathsUnix(getRunDir(), target);
+                    copyTemplate(source, destination, true, MutableMap.<String, Object>of());
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Error copying runtime resources", e);
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    /**
+     * @param template File to template and copy.
+     * @param target Destination on server.
+     * @return The exit code the SSH command run.
+     */
+    public int copyTemplate(File template, String target) {
+        return copyTemplate(template.toURI().toASCIIString(), target);
+    }
+
+    /**
+     * @param template URI of file to template and copy, e.g. file://.., http://.., classpath://..
+     * @param target Destination on server.
+     * @return The exit code of the SSH command run.
+     */
+    public int copyTemplate(String template, String target) {
+        return copyTemplate(template, target, false, ImmutableMap.<String, String>of());
+    }
+
+    /**
+     * @param template URI of file to template and copy, e.g. file://.., http://.., classpath://..
+     * @param target Destination on server.
+     * @param extraSubstitutions Extra substitutions for the templater to use, for example
+     *               "foo" -> "bar", and in a template ${foo}.
+     * @return The exit code of the SSH command run.
+     */
+    public int copyTemplate(String template, String target, boolean createParent, Map<String, ?> extraSubstitutions) {
+        String data = processTemplate(template, extraSubstitutions);
+        return copyResource(MutableMap.<Object,Object>of(), new StringReader(data), target, createParent);
+    }
+
+    public abstract int copyResource(Map<Object,Object> sshFlags, String source, String target, boolean createParentDir);
+
+    public abstract int copyResource(Map<Object,Object> sshFlags, InputStream source, String target, boolean createParentDir);
+
+    /**
+     * @param file File to copy.
+     * @param target Destination on server.
+     * @return The exit code the SSH command run.
+     */
+    public int copyResource(File file, String target) {
+        return copyResource(file.toURI().toASCIIString(), target);
+    }
+
+    /**
+     * @param resource URI of file to copy, e.g. file://.., http://.., classpath://..
+     * @param target Destination on server.
+     * @return The exit code of the SSH command run
+     */
+    public int copyResource(String resource, String target) {
+        return copyResource(MutableMap.of(), resource, target);
+    }
+
+    public int copyResource(String resource, String target, boolean createParentDir) {
+        return copyResource(MutableMap.of(), resource, target, createParentDir);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public int copyResource(Map sshFlags, String source, String target) {
+        return copyResource(sshFlags, source, target, false);
+    }
+
+    /**
+     * @see #copyResource(Map, InputStream, String, boolean)
+     */
+    public int copyResource(Reader source, String target) {
+        return copyResource(MutableMap.of(), source, target, false);
+    }
+
+    /**
+     * @see #copyResource(Map, InputStream, String, boolean)
+     */
+    public int copyResource(Map<Object,Object> sshFlags, Reader source, String target, boolean createParent) {
+        return copyResource(sshFlags, new ReaderInputStream(source), target, createParent);
+    }
+
+    /**
+     * @see #copyResource(Map, InputStream, String, boolean)
+     */
+    public int copyResource(InputStream source, String target) {
+        return copyResource(MutableMap.of(), source, target, false);
     }
 
     public String getResourceAsString(String url) {
@@ -289,4 +463,33 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
         Object val = entity.getConfig(configKey);
         if (val != null) log.debug("{} finished waiting for {} (value {}); continuing...", new Object[] {this, configKey, val});
     }
+
+    /**
+     * @deprecated since 0.5.0; instead rely on {@link brooklyn.entity.drivers.downloads.DownloadResolverManager} to include local-repo, such as:
+     *
+     * <pre>
+     * {@code
+     * DownloadResolver resolver = Entities.newDownloader(this);
+     * List<String> urls = resolver.getTargets();
+     * }
+     * </pre>
+     */
+    protected String getEntityVersionLabel() {
+        return getEntityVersionLabel("_");
+    }
+
+    /**
+     * @deprecated since 0.5.0; instead rely on {@link brooklyn.entity.drivers.downloads.DownloadResolverManager} to include local-repo
+     */
+    protected String getEntityVersionLabel(String separator) {
+        return elvis(entity.getEntityType().getSimpleName(),
+                entity.getClass().getName())+(getVersion() != null ? separator+getVersion() : "");
+    }
+
+    public String getVersion() {
+        return getEntity().getConfig(SoftwareProcess.SUGGESTED_VERSION);
+    }
+
+    public abstract String getRunDir();
+    public abstract String getInstallDir();
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessWinRmDriver.java
@@ -18,6 +18,8 @@
  */
 package brooklyn.entity.basic;
 
+import java.io.File;
+import java.io.InputStream;
 import java.util.List;
 
 import brooklyn.location.basic.WinRmMachineLocation;
@@ -38,6 +40,14 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
 
     public int executePowerShell(List<String> psScript) {
         return getMachine().executePsScript(psScript);
+    }
+
+    public int copyTo(File source, File destination) {
+        return getMachine().copyTo(source, destination);
+    }
+
+    public int copyTo(InputStream source, File destination) {
+        return getMachine().copyTo(source, destination);
     }
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessWinRmDriver.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.basic;
+
+import java.util.List;
+
+import brooklyn.location.basic.WinRmMachineLocation;
+
+public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwareProcessDriver {
+
+    public AbstractSoftwareProcessWinRmDriver(EntityLocal entity, WinRmMachineLocation location) {
+        super(entity, location);
+    }
+
+    public WinRmMachineLocation getMachine() {
+        return (WinRmMachineLocation) getLocation();
+    }
+
+    public int execute(List<String> script) {
+        return getMachine().executeScript(script);
+    }
+
+    public int executePowerShell(List<String> psScript) {
+        return getMachine().executePsScript(psScript);
+    }
+
+}

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessWinRmDriver.java
@@ -48,8 +48,8 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
 
     public AbstractSoftwareProcessWinRmDriver(EntityLocal entity, WinRmMachineLocation location) {
         super(entity, location);
-        entity.setAttribute(WINDOWS_USERNAME, location.config().get(WinRmMachineLocation.WINDOWS_USERNAME));
-        entity.setAttribute(WINDOWS_PASSWORD, location.config().get(WinRmMachineLocation.WINDOWS_PASSWORD));
+        entity.setAttribute(WINDOWS_USERNAME, location.config().get(WinRmMachineLocation.USER));
+        entity.setAttribute(WINDOWS_PASSWORD, location.config().get(WinRmMachineLocation.PASSWORD));
     }
 
     @Override
@@ -99,7 +99,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         if (createParentDir) {
             createDirectory(getDirectory(target), "Creating resource directory");
         }
-        return copyTo(new File(source), new File(target));
+        return copyTo(new File(source), target);
     }
 
     @Override
@@ -107,7 +107,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         if (createParentDir) {
             createDirectory(getDirectory(target), "Creating resource directory");
         }
-        return copyTo(source, new File(target));
+        return copyTo(source, target);
     }
 
     @Override
@@ -139,30 +139,30 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         return getLocation().executeScript(script).getStatusCode();
     }
 
-    public int executePowerShellNoRetry(List<String> psScript) {
+    public int executePsScriptNoRetry(List<String> psScript) {
         return getLocation().executePsScriptNoRetry(psScript).getStatusCode();
     }
 
-    public int executePowerShell(List<String> psScript) {
+    public int executePsScript(List<String> psScript) {
         return getLocation().executePsScript(psScript).getStatusCode();
     }
 
-    public int copyTo(File source, File destination) {
+    public int copyTo(File source, String destination) {
         return getLocation().copyTo(source, destination);
     }
 
-    public int copyTo(InputStream source, File destination) {
+    public int copyTo(InputStream source, String destination) {
         return getLocation().copyTo(source, destination);
     }
 
     public void rebootAndWait() {
         try {
-            executePowerShellNoRetry(ImmutableList.of("Restart-Computer -Force"));
+            executePsScriptNoRetry(ImmutableList.of("Restart-Computer -Force"));
         } catch (PyException e) {
             // Restarting the computer will cause the command to fail; ignore the exception and continue
         }
-        waitForWinRmStatus(false, entity.getConfig(VanillaWindowsProcess.REBOOT_UNAVAILABLE_TIMEOUT));
-        waitForWinRmStatus(true, entity.getConfig(VanillaWindowsProcess.REBOOT_AVAILABLE_TIMEOUT)).getWithError();
+        waitForWinRmStatus(false, entity.getConfig(VanillaWindowsProcess.REBOOT_BEGUN_TIMEOUT));
+        waitForWinRmStatus(true, entity.getConfig(VanillaWindowsProcess.REBOOT_COMPLETED_TIMEOUT)).getWithError();
     }
 
     private String getDirectory(String fileName) {

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaProcess.java
@@ -26,7 +26,7 @@ public interface AbstractVanillaProcess extends SoftwareProcess {
 
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.0.0");
 
-    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newStringConfigKey("launch.command", "command to run to launch the process", "./start.sh");
+    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newStringConfigKey("launch.command", "command to run to launch the process");
     ConfigKey<String> CHECK_RUNNING_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.command", "command to determine whether the process is running");
     ConfigKey<String> STOP_COMMAND = ConfigKeys.newStringConfigKey("stop.command", "command to run to stop the process");
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaProcess.java
@@ -18,5 +18,15 @@
  */
 package brooklyn.entity.basic;
 
-public interface AbstractVanillaSoftwareProcessDriver extends SoftwareProcessDriver {
+import brooklyn.config.ConfigKey;
+import brooklyn.event.basic.AttributeSensorAndConfigKey;
+
+public interface AbstractVanillaProcess extends SoftwareProcess {
+    AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = SoftwareProcess.DOWNLOAD_URL;
+
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.0.0");
+
+    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newStringConfigKey("launch.command", "command to run to launch the process", "./start.sh");
+    ConfigKey<String> CHECK_RUNNING_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.command", "command to determine whether the process is running");
+    ConfigKey<String> STOP_COMMAND = ConfigKeys.newStringConfigKey("stop.command", "command to run to stop the process");
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaProcessDriver.java
@@ -18,15 +18,5 @@
  */
 package brooklyn.entity.basic;
 
-import brooklyn.config.ConfigKey;
-import brooklyn.event.basic.AttributeSensorAndConfigKey;
-
-public interface AbstractVanillaSoftwareProcess extends SoftwareProcess {
-    AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = SoftwareProcess.DOWNLOAD_URL;
-
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.0.0");
-
-    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newStringConfigKey("launch.command", "command to run to launch the process", "./start.sh");
-    ConfigKey<String> CHECK_RUNNING_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.command", "command to determine whether the process is running");
-    ConfigKey<String> STOP_COMMAND = ConfigKeys.newStringConfigKey("stop.command", "command to run to stop the process");
+public interface AbstractVanillaProcessDriver extends SoftwareProcessDriver {
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaSoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaSoftwareProcess.java
@@ -18,6 +18,15 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+import brooklyn.config.ConfigKey;
+import brooklyn.event.basic.AttributeSensorAndConfigKey;
 
+public interface AbstractVanillaSoftwareProcess extends SoftwareProcess {
+    AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = SoftwareProcess.DOWNLOAD_URL;
+
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.0.0");
+
+    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newStringConfigKey("launch.command", "command to run to launch the process", "./start.sh");
+    ConfigKey<String> CHECK_RUNNING_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.command", "command to determine whether the process is running");
+    ConfigKey<String> STOP_COMMAND = ConfigKeys.newStringConfigKey("stop.command", "command to run to stop the process");
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractVanillaSoftwareProcessDriver.java
@@ -18,6 +18,5 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
-
+public interface AbstractVanillaSoftwareProcessDriver extends SoftwareProcessDriver {
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -114,6 +114,31 @@ public interface SoftwareProcess extends Entity, Startable {
     ConfigKey<String> SUGGESTED_RUN_DIR = BrooklynConfigKeys.SUGGESTED_RUN_DIR;
 
     /**
+     * Files to be copied to the server before pre-install.
+     * <p>
+     * Map of {@code classpath://foo/file.txt} (or other url) source to destination path,
+     * as {@code subdir/file} relative to installation directory or {@code /absolute/path/to/file}.
+     *
+     * @see #PRE_INSTALL_TEMPLATES
+     */
+    @Beta
+    @SuppressWarnings("serial")
+    @SetFromFlag("preInstallFiles")
+    ConfigKey<Map<String, String>> PRE_INSTALL_FILES = ConfigKeys.newConfigKey(new TypeToken<Map<String, String>>() { },
+            "files.preinstall", "Mapping of files, to be copied before install, to destination name relative to installDir");
+
+    /**
+     * Templates to be filled in and then copied to the server before install.
+     *
+     * @see #PRE_INSTALL_FILES
+     */
+    @Beta
+    @SuppressWarnings("serial")
+    @SetFromFlag("preInstallTemplates")
+    ConfigKey<Map<String, String>> PRE_INSTALL_TEMPLATES = ConfigKeys.newConfigKey(new TypeToken<Map<String, String>>() { },
+            "templates.preinstall", "Mapping of templates, to be filled in and copied before pre-install, to destination name relative to installDir");
+
+    /**
      * Files to be copied to the server before install.
      * <p>
      * Map of {@code classpath://foo/file.txt} (or other url) source to destination path,

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.entity.basic;
 
+import java.util.Collection;
 import java.util.Map;
 
 import brooklyn.config.ConfigKey;
@@ -34,6 +35,7 @@ import brooklyn.util.flags.SetFromFlag;
 import brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 
 public interface SoftwareProcess extends Entity, Startable {
@@ -42,6 +44,13 @@ public interface SoftwareProcess extends Entity, Startable {
     AttributeSensor<String> ADDRESS = Attributes.ADDRESS;
     AttributeSensor<String> SUBNET_HOSTNAME = Attributes.SUBNET_HOSTNAME;
     AttributeSensor<String> SUBNET_ADDRESS = Attributes.SUBNET_ADDRESS;
+
+    @SuppressWarnings("serial")
+    ConfigKey<Collection<Integer>> REQUIRED_OPEN_LOGIN_PORTS = ConfigKeys.newConfigKey(
+            new TypeToken<Collection<Integer>>() {},
+            "requiredOpenLoginPorts",
+            "The port(s) to be opened, to allow login",
+            ImmutableSet.of(22));
 
     @SetFromFlag("startTimeout")
     ConfigKey<Duration> START_TIMEOUT = BrooklynConfigKeys.START_TIMEOUT;

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -442,11 +442,12 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
      * plus any ports defined with a config keys ending in .port 
      */
     protected Collection<Integer> getRequiredOpenPorts() {
-        Set<Integer> ports = MutableSet.of(22);
+        // TODO: Should only open 22 *or* 5985. Perhaps a flag / ConfigKey on SoftwareProcessImpl?
+        Set<Integer> ports = MutableSet.of(22, 5985, 3389);
         Map<ConfigKey<?>, ?> allConfig = config().getBag().getAllConfigAsConfigKeyMap();
         Set<ConfigKey<?>> configKeys = Sets.newHashSet(allConfig.keySet());
         configKeys.addAll(getEntityType().getConfigKeys());
-        
+
         for (ConfigKey<?> k: configKeys) {
             if (PortRange.class.isAssignableFrom(k.getType())) {
                 PortRange p = (PortRange)getConfig(k);

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -438,12 +438,12 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     }
 
     /** returns the ports that this entity wants to use;
-     * default implementation returns 22 plus first value for each PortAttributeSensorAndConfigKey config key PortRange
-     * plus any ports defined with a config keys ending in .port 
+     * default implementation returns {@link SoftwareProcess#REQUIRED_OPEN_LOGIN_PORTS} plus first value 
+     * for each {@link PortAttributeSensorAndConfigKey} config key {@link PortRange}
+     * plus any ports defined with a config keys ending in {@code .port}.
      */
     protected Collection<Integer> getRequiredOpenPorts() {
-        // TODO: Should only open 22 *or* 5985. Perhaps a flag / ConfigKey on SoftwareProcessImpl?
-        Set<Integer> ports = MutableSet.of(22, 5985, 3389);
+        Set<Integer> ports = MutableSet.copyOf(getConfig(REQUIRED_OPEN_LOGIN_PORTS));
         Map<ConfigKey<?>, ?> allConfig = config().getBag().getAllConfigAsConfigKeyMap();
         Set<ConfigKey<?>> configKeys = Sets.newHashSet(allConfig.keySet());
         configKeys.addAll(getEntityType().getConfigKeys());

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcess.java
@@ -19,6 +19,7 @@
 package brooklyn.entity.basic;
 
 import brooklyn.catalog.Catalog;
+import brooklyn.config.ConfigKey;
 import brooklyn.entity.proxying.ImplementedBy;
 
 /** 
@@ -53,5 +54,5 @@ import brooklyn.entity.proxying.ImplementedBy;
 @Catalog(name="Vanilla Software Process", description="A software process configured with scripts, e.g. for launch, check-running and stop")
 @ImplementedBy(VanillaSoftwareProcessImpl.class)
 public interface VanillaSoftwareProcess extends AbstractVanillaProcess {
-
+    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newConfigKeyWithDefault(AbstractVanillaProcess.LAUNCH_COMMAND, "./start.sh");
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcess.java
@@ -19,9 +19,7 @@
 package brooklyn.entity.basic;
 
 import brooklyn.catalog.Catalog;
-import brooklyn.config.ConfigKey;
 import brooklyn.entity.proxying.ImplementedBy;
-import brooklyn.event.basic.AttributeSensorAndConfigKey;
 
 /** 
  * A {@link SoftwareProcess} entity that runs commands from an archive.
@@ -54,14 +52,6 @@ import brooklyn.event.basic.AttributeSensorAndConfigKey;
  */
 @Catalog(name="Vanilla Software Process", description="A software process configured with scripts, e.g. for launch, check-running and stop")
 @ImplementedBy(VanillaSoftwareProcessImpl.class)
-public interface VanillaSoftwareProcess extends SoftwareProcess {
-
-    AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = SoftwareProcess.DOWNLOAD_URL;
-
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.0.0");
-
-    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newStringConfigKey("launch.command", "command to run to launch the process", "./start.sh");
-    ConfigKey<String> CHECK_RUNNING_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.command", "command to determine whether the process is running");
-    ConfigKey<String> STOP_COMMAND = ConfigKeys.newStringConfigKey("stop.command", "command to run to stop the process");
+public interface VanillaSoftwareProcess extends AbstractVanillaSoftwareProcess {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcess.java
@@ -52,6 +52,6 @@ import brooklyn.entity.proxying.ImplementedBy;
  */
 @Catalog(name="Vanilla Software Process", description="A software process configured with scripts, e.g. for launch, check-running and stop")
 @ImplementedBy(VanillaSoftwareProcessImpl.class)
-public interface VanillaSoftwareProcess extends AbstractVanillaSoftwareProcess {
+public interface VanillaSoftwareProcess extends AbstractVanillaProcess {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcessDriver.java
@@ -18,6 +18,6 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaProcessDriver {
+public interface VanillaSoftwareProcessDriver extends SoftwareProcessDriver {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaSoftwareProcessDriver.java
@@ -18,6 +18,6 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+public interface VanillaSoftwareProcessDriver extends AbstractVanillaProcessDriver {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
@@ -18,6 +18,10 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+import brooklyn.config.ConfigKey;
 
+public interface VanillaWindowsProcess extends AbstractVanillaSoftwareProcess {
+    ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("launch.powershell.command", "command to run to launch the process", "./start.sh");
+    ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.powershell.command", "command to determine whether the process is running");
+    ConfigKey<String> STOP_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("stop.powershell.command", "command to run to stop the process");
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
@@ -19,9 +19,22 @@
 package brooklyn.entity.basic;
 
 import brooklyn.config.ConfigKey;
+import brooklyn.entity.proxying.ImplementedBy;
 
-public interface VanillaWindowsProcess extends AbstractVanillaSoftwareProcess {
-    ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("launch.powershell.command", "command to run to launch the process", "./start.sh");
-    ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.powershell.command", "command to determine whether the process is running");
-    ConfigKey<String> STOP_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("stop.powershell.command", "command to run to stop the process");
+@ImplementedBy(VanillaWindowsProcessImpl.class)
+public interface VanillaWindowsProcess extends AbstractVanillaProcess {
+    ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("launch.powershell.command",
+            "command to run to launch the process", "./start.sh");
+    ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.powershell.command",
+            "command to determine whether the process is running");
+    ConfigKey<String> STOP_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("stop.powershell.command",
+            "command to run to stop the process");
+    ConfigKey<String> CUSTOMIZE_COMMAND = ConfigKeys.newStringConfigKey("customize.command",
+            "command to run during the customization phase");
+    ConfigKey<String> CUSTOMIZE_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("customize.powershell.command",
+            "powershell command to run during the customization phase");
+    ConfigKey<String> INSTALL_COMMAND = ConfigKeys.newStringConfigKey("install.command",
+            "command to run during the install phase");
+    ConfigKey<String> INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("install.powershell.command",
+            "powershell command to run during the install phase");
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
@@ -18,12 +18,20 @@
  */
 package brooklyn.entity.basic;
 
+import java.util.Collection;
+
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.proxying.ImplementedBy;
 import brooklyn.util.time.Duration;
 
+import com.google.common.collect.ImmutableSet;
+
 @ImplementedBy(VanillaWindowsProcessImpl.class)
 public interface VanillaWindowsProcess extends AbstractVanillaProcess {
+    // 3389 is RDP; 5985 is WinRM (3389 isn't used by Brooklyn, but useful for the end-user subsequently)
+    ConfigKey<Collection<Integer>> REQUIRED_OPEN_LOGIN_PORTS = ConfigKeys.newConfigKeyWithDefault(
+            SoftwareProcess.REQUIRED_OPEN_LOGIN_PORTS,
+            ImmutableSet.of(5985, 3389));
     ConfigKey<String> PRE_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.powershell.command",
             "powershell command to run during the pre-install phase");
     ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",
@@ -46,9 +54,9 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
             "command to run during the install phase");
     ConfigKey<String> INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("install.powershell.command",
             "powershell command to run during the install phase");
-    ConfigKey<Duration> REBOOT_UNAVAILABLE_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.unavailable.timeout",
-            "duration to wait whilst waiting for a machine to become unavailable after a reboot", Duration.TWO_MINUTES);
-    // If automatic updates are enabled and there are updates waiting to be installed, thirty minutes may not be sufficient...
-    ConfigKey<Duration> REBOOT_AVAILABLE_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.unavailable.timeout",
-            "duration to wait whilst waiting for a machine to become unavailable after a reboot", Duration.minutes(30));
+    ConfigKey<Duration> REBOOT_BEGUN_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.begun.timeout",
+            "duration to wait whilst waiting for a machine to begin rebooting, and thus become unavailable", Duration.TWO_MINUTES);
+    // TODO If automatic updates are enabled and there are updates waiting to be installed, thirty minutes may not be sufficient...
+    ConfigKey<Duration> REBOOT_COMPLETED_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.completed.timeout",
+            "duration to wait whilst waiting for a machine to finish rebooting, and thus to become available again", Duration.minutes(30));
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
@@ -20,9 +20,18 @@ package brooklyn.entity.basic;
 
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.proxying.ImplementedBy;
+import brooklyn.util.time.Duration;
 
 @ImplementedBy(VanillaWindowsProcessImpl.class)
 public interface VanillaWindowsProcess extends AbstractVanillaProcess {
+    ConfigKey<String> PRE_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.powershell.command",
+            "powershell command to run during the pre-install phase");
+    ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",
+            "indicates that a reboot should be performed after the pre-install command is run", false);
+    ConfigKey<Boolean> INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("install.reboot.required",
+            "indicates that a reboot should be performed after the install command is run", false);
+    ConfigKey<Boolean> CUSTOMIZE_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("customize.reboot.required",
+            "indicates that a reboot should be performed after the customize command is run", false);
     ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("launch.powershell.command",
             "command to run to launch the process");
     ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.powershell.command",
@@ -37,4 +46,9 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
             "command to run during the install phase");
     ConfigKey<String> INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("install.powershell.command",
             "powershell command to run during the install phase");
+    ConfigKey<Duration> REBOOT_UNAVAILABLE_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.unavailable.timeout",
+            "duration to wait whilst waiting for a machine to become unavailable after a reboot", Duration.TWO_MINUTES);
+    // If automatic updates are enabled and there are updates waiting to be installed, thirty minutes may not be sufficient...
+    ConfigKey<Duration> REBOOT_AVAILABLE_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.unavailable.timeout",
+            "duration to wait whilst waiting for a machine to become unavailable after a reboot", Duration.minutes(30));
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcess.java
@@ -24,7 +24,7 @@ import brooklyn.entity.proxying.ImplementedBy;
 @ImplementedBy(VanillaWindowsProcessImpl.class)
 public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("launch.powershell.command",
-            "command to run to launch the process", "./start.sh");
+            "command to run to launch the process");
     ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.powershell.command",
             "command to determine whether the process is running");
     ConfigKey<String> STOP_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("stop.powershell.command",

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessDriver.java
@@ -18,6 +18,6 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaWindowsProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+public interface VanillaWindowsProcessDriver extends AbstractVanillaProcessDriver {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessDriver.java
@@ -18,6 +18,6 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+public interface VanillaWindowsProcessDriver extends AbstractVanillaSoftwareProcessDriver {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessDriver.java
@@ -18,6 +18,6 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaWindowsProcessDriver extends AbstractVanillaProcessDriver {
+public interface VanillaWindowsProcessDriver extends SoftwareProcessDriver {
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessImpl.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.entity.basic;
 
+
 public class VanillaWindowsProcessImpl extends SoftwareProcessImpl implements VanillaWindowsProcess {
     @Override
     public Class getDriverInterface() {

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessImpl.java
@@ -18,6 +18,21 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+public class VanillaWindowsProcessImpl extends SoftwareProcessImpl implements VanillaWindowsProcess {
+    @Override
+    public Class getDriverInterface() {
+        return VanillaWindowsProcessDriver.class;
+    }
 
+    @Override
+    protected void connectSensors() {
+        super.connectSensors();
+        connectServiceUpIsRunning();
+    }
+
+    @Override
+    protected void disconnectSensors() {
+        disconnectServiceUpIsRunning();
+        super.disconnectSensors();
+    }
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessImpl.java
@@ -35,4 +35,5 @@ public class VanillaWindowsProcessImpl extends SoftwareProcessImpl implements Va
         disconnectServiceUpIsRunning();
         super.disconnectSensors();
     }
+
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
@@ -28,27 +28,30 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
 
     @Override
     public void install() {
-
+        // TODO: Follow install path of VanillaSoftwareProcessSshDriver
+        executeCommand(VanillaWindowsProcess.INSTALL_COMMAND, VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND, true);
     }
 
     @Override
     public void customize() {
-
+        // TODO: Follow customize path of VanillaSoftwareProcessSshDriver
+        executeCommand(VanillaWindowsProcess.CUSTOMIZE_COMMAND, VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND, true);
     }
 
     @Override
     public void launch() {
-
+        executeCommand(VanillaWindowsProcess.LAUNCH_COMMAND, VanillaWindowsProcess.LAUNCH_POWERSHELL_COMMAND, true);
     }
 
     @Override
     public boolean isRunning() {
-        return executeCommand(VanillaWindowsProcess.CHECK_RUNNING_COMMAND, VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND);
+        return executeCommand(VanillaWindowsProcess.CHECK_RUNNING_COMMAND,
+                VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND, false);
     }
 
     @Override
     public void stop() {
-
+        executeCommand(VanillaWindowsProcess.STOP_POWERSHELL_COMMAND, VanillaWindowsProcess.STOP_COMMAND, true);
     }
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
@@ -19,6 +19,7 @@
 package brooklyn.entity.basic;
 
 import brooklyn.location.basic.WinRmMachineLocation;
+import brooklyn.util.time.Duration;
 
 public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWinRmDriver implements VanillaWindowsProcessDriver {
 

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
@@ -27,15 +27,30 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
     }
 
     @Override
+    public void preInstall() {
+        super.preInstall();
+        executeCommand(VanillaWindowsProcess.PRE_INSTALL_COMMAND, VanillaWindowsProcess.PRE_INSTALL_POWERSHELL_COMMAND, true);
+        if (entity.getConfig(VanillaWindowsProcess.PRE_INSTALL_REBOOT_REQUIRED)) {
+            rebootAndWait();
+        }
+    }
+
+    @Override
     public void install() {
         // TODO: Follow install path of VanillaSoftwareProcessSshDriver
         executeCommand(VanillaWindowsProcess.INSTALL_COMMAND, VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND, true);
+        if (entity.getConfig(VanillaWindowsProcess.INSTALL_REBOOT_REQUIRED)) {
+            rebootAndWait();
+        }
     }
 
     @Override
     public void customize() {
         // TODO: Follow customize path of VanillaSoftwareProcessSshDriver
         executeCommand(VanillaWindowsProcess.CUSTOMIZE_COMMAND, VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND, true);
+        if (entity.getConfig(VanillaWindowsProcess.CUSTOMIZE_REBOOT_REQUIRED)) {
+            rebootAndWait();
+        }
     }
 
     @Override
@@ -51,7 +66,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
 
     @Override
     public void stop() {
-        executeCommand(VanillaWindowsProcess.STOP_POWERSHELL_COMMAND, VanillaWindowsProcess.STOP_COMMAND, true);
+        executeCommand(VanillaWindowsProcess.STOP_COMMAND, VanillaWindowsProcess.STOP_POWERSHELL_COMMAND, true);
     }
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
@@ -18,6 +18,37 @@
  */
 package brooklyn.entity.basic;
 
-public interface VanillaSoftwareProcessDriver extends AbstractVanillaSoftwareProcessDriver {
+import brooklyn.location.basic.WinRmMachineLocation;
+
+public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWinRmDriver implements VanillaWindowsProcessDriver {
+
+    public VanillaWindowsProcessWinRmDriver(EntityLocal entity, WinRmMachineLocation location) {
+        super(entity, location);
+    }
+
+    @Override
+    public void install() {
+
+    }
+
+    @Override
+    public void customize() {
+
+    }
+
+    @Override
+    public void launch() {
+
+    }
+
+    @Override
+    public boolean isRunning() {
+        return executeCommand(VanillaWindowsProcess.CHECK_RUNNING_COMMAND, VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND);
+    }
+
+    @Override
+    public void stop() {
+
+    }
 
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/VanillaWindowsProcessWinRmDriver.java
@@ -19,7 +19,6 @@
 package brooklyn.entity.basic;
 
 import brooklyn.location.basic.WinRmMachineLocation;
-import brooklyn.util.time.Duration;
 
 public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWinRmDriver implements VanillaWindowsProcessDriver {
 
@@ -47,7 +46,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
     @Override
     public boolean isRunning() {
         return executeCommand(VanillaWindowsProcess.CHECK_RUNNING_COMMAND,
-                VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND, false);
+                VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND, false).getStatusCode() == 0;
     }
 
     @Override

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -567,7 +567,7 @@ public abstract class MachineLifecycleEffectorTasks {
             return null;
         }});
 
-        Maybe<SshMachineLocation> sshMachine = Machines.findUniqueSshMachineLocation(entity().getLocations());
+        Maybe<MachineLocation> machine = Machines.findUniqueMachineLocation(entity().getLocations());
         Task<String> stoppingProcess = null;
         if (canStop(stopProcessMode, entity())) {
             stoppingProcess = DynamicTasks.queue("stopping (process)", new Callable<String>() { public String call() {
@@ -579,7 +579,7 @@ public abstract class MachineLifecycleEffectorTasks {
         }
 
         Task<StopMachineDetails<Integer>> stoppingMachine = null;
-        if (canStop(stopMachineMode, sshMachine.isAbsent())) {
+        if (canStop(stopMachineMode, machine.isAbsent())) {
             // Release this machine (even if error trying to stop process - we rethrow that after)
             stoppingMachine = DynamicTasks.queue("stopping (machine)", new Callable<StopMachineDetails<Integer>>() {
                 public StopMachineDetails<Integer> call() {
@@ -615,7 +615,7 @@ public abstract class MachineLifecycleEffectorTasks {
             if (checkStopProcesses) {
                 // TODO we should test for destruction above, not merely successful "stop", as things like localhost and ssh won't be destroyed
                 DynamicTasks.waitForLast();
-                if (sshMachine.isPresent()) {
+                if (machine.isPresent()) {
                     // throw early errors *only if* there is a machine and we have not destroyed it
                     stoppingProcess.get();
                 }

--- a/software/base/src/main/java/brooklyn/entity/software/StaticSensor.java
+++ b/software/base/src/main/java/brooklyn/entity/software/StaticSensor.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package brooklyn.entity.software;
 
 import brooklyn.config.ConfigKey;

--- a/software/base/src/main/java/brooklyn/entity/software/StaticSensor.java
+++ b/software/base/src/main/java/brooklyn/entity/software/StaticSensor.java
@@ -22,14 +22,14 @@ import brooklyn.config.ConfigKey;
 import brooklyn.entity.basic.ConfigKeys;
 import brooklyn.entity.basic.EntityLocal;
 import brooklyn.entity.effector.AddSensor;
-import brooklyn.event.basic.Sensors;
 import brooklyn.util.config.ConfigBag;
+import brooklyn.util.flags.TypeCoercions;
 
-public class StaticSensor<T> extends AddSensor<Integer> {
+public class StaticSensor<T> extends AddSensor<T> {
 
-    public static final ConfigKey<Integer> STATIC_VALUE = ConfigKeys.newConfigKey(Integer.class, "static.value");
+    public static final ConfigKey<Object> STATIC_VALUE = ConfigKeys.newConfigKey(Object.class, "static.value");
 
-    private final Integer value;
+    private final Object value;
 
     public StaticSensor(ConfigBag params) {
         super(params);
@@ -39,6 +39,6 @@ public class StaticSensor<T> extends AddSensor<Integer> {
     @Override
     public void apply(EntityLocal entity) {
         super.apply(entity);
-        entity.setAttribute(Sensors.newIntegerSensor(name), value);
+        entity.setAttribute(sensor, (T) TypeCoercions.coerce(value, sensor.getType()));
     }
 }

--- a/software/base/src/main/java/brooklyn/entity/software/StaticSensor.java
+++ b/software/base/src/main/java/brooklyn/entity/software/StaticSensor.java
@@ -1,0 +1,26 @@
+package brooklyn.entity.software;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.EntityLocal;
+import brooklyn.entity.effector.AddSensor;
+import brooklyn.event.basic.Sensors;
+import brooklyn.util.config.ConfigBag;
+
+public class StaticSensor<T> extends AddSensor<Integer> {
+
+    public static final ConfigKey<Integer> STATIC_VALUE = ConfigKeys.newConfigKey(Integer.class, "static.value");
+
+    private final Integer value;
+
+    public StaticSensor(ConfigBag params) {
+        super(params);
+        value = params.get(STATIC_VALUE);
+    }
+
+    @Override
+    public void apply(EntityLocal entity) {
+        super.apply(entity);
+        entity.setAttribute(Sensors.newIntegerSensor(name), value);
+    }
+}

--- a/software/base/src/main/java/brooklyn/entity/software/winrm/WindowsPerformanceCounterSensors.java
+++ b/software/base/src/main/java/brooklyn/entity/software/winrm/WindowsPerformanceCounterSensors.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.software.winrm;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.EntityInternal;
+import brooklyn.entity.basic.EntityLocal;
+import brooklyn.entity.proxying.EntityInitializer;
+import brooklyn.event.basic.Sensors;
+import brooklyn.event.feed.windows.WindowsPerformanceCounterFeed;
+import brooklyn.util.config.ConfigBag;
+import brooklyn.util.text.Strings;
+
+import com.google.common.reflect.TypeToken;
+
+public class WindowsPerformanceCounterSensors implements EntityInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsPerformanceCounterSensors.class);
+
+    public final static ConfigKey<Set<Map<String, String>>> PERFORMANCE_COUNTERS = ConfigKeys.newConfigKey(new TypeToken<Set<Map<String, String>>>(){}, "performance.counters");
+
+    protected final Set<Map<String, String>> sensors;
+
+    public WindowsPerformanceCounterSensors(ConfigBag params) {
+        sensors = params.get(PERFORMANCE_COUNTERS);
+    }
+
+    public WindowsPerformanceCounterSensors(Map<String, String> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+    @Override
+    public void apply(EntityLocal entity) {
+        WindowsPerformanceCounterFeed.Builder builder = WindowsPerformanceCounterFeed.builder()
+                .entity(entity);
+        for (Map<String, String> sensorConfig : sensors) {
+            String sensorType = sensorConfig.get("sensorType");
+            Class<?> clazz;
+            try {
+                clazz = Strings.isNonEmpty(sensorType) ?
+                ((EntityInternal)entity).getManagementContext().getCatalog().getRootClassLoader().loadClass(sensorType) : String.class;
+            } catch (ClassNotFoundException e) {
+                LOG.warn("Could not load type {} for sensor {}", sensorType, sensorConfig.get("name"));
+                clazz = String.class;
+            }
+            builder.addSensor(sensorConfig.get("counter"), Sensors.newSensor(clazz, sensorConfig.get("name"), sensorConfig.get("description")));
+        }
+        builder.build();
+    }
+
+}

--- a/software/base/src/main/java/brooklyn/entity/software/winrm/WindowsPerformanceCounterSensors.java
+++ b/software/base/src/main/java/brooklyn/entity/software/winrm/WindowsPerformanceCounterSensors.java
@@ -57,18 +57,18 @@ public class WindowsPerformanceCounterSensors implements EntityInitializer {
         WindowsPerformanceCounterFeed.Builder builder = WindowsPerformanceCounterFeed.builder()
                 .entity(entity);
         for (Map<String, String> sensorConfig : sensors) {
+            String name = sensorConfig.get("name");
             String sensorType = sensorConfig.get("sensorType");
             Class<?> clazz;
             try {
-                clazz = Strings.isNonEmpty(sensorType) ?
-                ((EntityInternal)entity).getManagementContext().getCatalog().getRootClassLoader().loadClass(sensorType) : String.class;
+                clazz = Strings.isNonEmpty(sensorType)
+                        ? ((EntityInternal)entity).getManagementContext().getCatalog().getRootClassLoader().loadClass(sensorType) 
+                        : String.class;
             } catch (ClassNotFoundException e) {
-                LOG.warn("Could not load type {} for sensor {}", sensorType, sensorConfig.get("name"));
-                clazz = String.class;
+                throw new IllegalStateException("Could not load type "+sensorType+" for sensor "+name, e);
             }
-            builder.addSensor(sensorConfig.get("counter"), Sensors.newSensor(clazz, sensorConfig.get("name"), sensorConfig.get("description")));
+            builder.addSensor(sensorConfig.get("counter"), Sensors.newSensor(clazz, name, sensorConfig.get("description")));
         }
         builder.build();
     }
-
 }

--- a/software/base/src/test/java/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesMultiLocationTest.java
+++ b/software/base/src/test/java/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesMultiLocationTest.java
@@ -53,7 +53,7 @@ import com.google.common.collect.Lists;
  * 
  * Different from {@link DynamicClusterWithAvailabilityZonesTest} in the use of {@link MultiLocation}.
  * However, the difference is important: the {@link SoftwareProcess} entity has two locations
- * (the {@link MachineProvisioningLocation} and the {@link MachineLocation}, which was perviously
+ * (the {@link MachineProvisioningLocation} and the {@link MachineLocation}, which was previously
  * causing a failure - now fixed and tested here.
  */
 public class DynamicClusterWithAvailabilityZonesMultiLocationTest extends BrooklynAppUnitTestSupport {

--- a/software/base/src/test/java/brooklyn/entity/software/StaticSensorTest.java
+++ b/software/base/src/test/java/brooklyn/entity/software/StaticSensorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.software;
+
+import org.testng.annotations.Test;
+
+import brooklyn.entity.BrooklynAppUnitTestSupport;
+import brooklyn.entity.basic.BasicEntity;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.event.basic.Sensors;
+import brooklyn.test.EntityTestUtils;
+import brooklyn.util.config.ConfigBag;
+
+import com.google.common.collect.ImmutableMap;
+
+public class StaticSensorTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testAddsStaticSensorOfTypeString() {
+        BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new StaticSensor<String>(ConfigBag.newInstance(ImmutableMap.of(
+                        StaticSensor.SENSOR_NAME, "myname",
+                        StaticSensor.SENSOR_TYPE, String.class.getName(),
+                        StaticSensor.STATIC_VALUE, "myval")))));
+        
+        EntityTestUtils.assertAttributeEquals(entity, Sensors.newSensor(String.class, "myname"), "myval");
+    }
+    
+    @Test
+    public void testAddsStaticSensorOfTypeInteger() {
+        BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new StaticSensor<Integer>(ConfigBag.newInstance(ImmutableMap.of(
+                        StaticSensor.SENSOR_NAME, "myname",
+                        StaticSensor.SENSOR_TYPE, Integer.class.getName(),
+                        StaticSensor.STATIC_VALUE, "1")))));
+        
+        EntityTestUtils.assertAttributeEquals(entity, Sensors.newSensor(Integer.class, "myname"), 1);
+    }
+}

--- a/software/base/src/test/java/brooklyn/location/basic/WinRmMachineLocationLiveTest.java
+++ b/software/base/src/test/java/brooklyn/location/basic/WinRmMachineLocationLiveTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.basic;
+
+import static org.testng.Assert.assertEquals;
+import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import brooklyn.config.BrooklynProperties;
+import brooklyn.entity.BrooklynAppLiveTestSupport;
+import brooklyn.entity.basic.Entities;
+import brooklyn.location.jclouds.JcloudsLocation;
+import brooklyn.location.jclouds.JcloudsWinRmMachineLocation;
+import brooklyn.management.internal.ManagementContextInternal;
+import brooklyn.test.entity.LocalManagementContextForTests;
+import brooklyn.test.entity.TestApplication;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class WinRmMachineLocationLiveTest {
+    
+    // FIXME failing locally with:
+    //   Caused by: Traceback (most recent call last):
+    //     File "__pyclasspath__/winrm/__init__.py", line 40, in run_cmd
+    //     File "__pyclasspath__/winrm/protocol.py", line 118, in open_shell
+    //     File "__pyclasspath__/winrm/protocol.py", line 190, in send_message
+    //     File "__pyclasspath__/winrm/transport.py", line 112, in send_message
+    //     winrm.exceptions.WinRMTransportError: 500 WinRMTransport. [Errno 20001] getaddrinfo failed
+    //     at org.python.core.PyException.doRaise(PyException.java:226)
+
+    private static final Logger LOG = LoggerFactory.getLogger(BrooklynAppLiveTestSupport.class);
+
+    protected JcloudsLocation loc;
+    protected TestApplication app;
+    protected ManagementContextInternal mgmt;
+
+    private JcloudsWinRmMachineLocation machine;
+    
+    @BeforeClass(alwaysRun=true)
+    public void setUpClass() throws Exception {
+        mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-2", ImmutableMap.of(
+                "inboundPorts", ImmutableList.of(5985, 3389),
+                "displayName", "AWS Oregon (Windows)",
+                "imageId", "us-west-2/ami-8fd3f9bf",
+                "hardwareId", "m3.medium",
+                "useJcloudsSshInit", false));
+        machine = (JcloudsWinRmMachineLocation) loc.obtain();
+    }
+
+    @AfterClass(alwaysRun=true)
+    public void tearDownClass() throws Exception {
+        try {
+            if (machine != null) loc.release(machine);
+            if (mgmt != null) Entities.destroyAll(mgmt);
+        } catch (Throwable t) {
+            LOG.error("Caught exception in tearDown method", t);
+        } finally {
+            mgmt = null;
+        }
+    }
+
+    @Test(groups="Live")
+    public void testExecScript() throws Exception {
+        WinRmToolResponse response = machine.executeScript("echo true");
+        assertEquals(response.getStatusCode(), 0);
+        assertEquals(response.getStdErr(), "");
+    }
+}

--- a/software/database/pom.xml
+++ b/software/database/pom.xml
@@ -51,6 +51,8 @@
                             <exclude>src/main/resources/brooklyn/entity/database/mysql/mysql.conf</exclude>
                             <exclude>src/main/resources/brooklyn/entity/database/postgresql/postgresql.conf</exclude>
                             <exclude>src/main/resources/brooklyn/entity/database/rubyrep/rubyrep.conf</exclude>
+                            <exclude>src/main/resources/brooklyn/entity/database/mssql/ConfigurationFile.ini</exclude>
+                            <exclude>src/main/resources/brooklyn/entity/database/mssql/mssql.yaml</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/ConfigurationFile.ini
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/ConfigurationFile.ini
@@ -1,0 +1,390 @@
+;SQL Server 2012 Configuration File
+
+
+[OPTIONS]
+
+
+
+; Specifies a Setup work flow, like INSTALL, UNINSTALL, or UPGRADE. This is a required parameter. 
+
+
+
+ACTION="Install"
+
+; Detailed help for command line argument ROLE has not been defined yet.
+
+ROLE="AllFeatures_WithDefaults"
+
+
+; Detailed help for command line argument ENU has not been defined yet. 
+
+
+
+ENU="True"
+
+
+
+; Setup will not display any user interface. 
+
+
+
+QUIET="True"
+
+ 
+
+; Setup will display progress only, without any user interaction. 
+
+
+
+QUIETSIMPLE="False"
+
+
+
+; Specify whether SQL Server Setup should discover and include product updates. The valid values are True and False or 1 and 0. By default SQL Server Setup will include updates that are found. 
+
+
+
+UpdateEnabled="False"
+
+
+
+; Specifies features to install, uninstall, or upgrade. The list of top-level features include SQL, AS, RS, IS, MDS, and Tools. The SQL feature will install the Database Engine, Replication, Full-Text, and Data Quality Services (DQS) server. The Tools feature will install Management Tools, Books online components, SQL Server Data Tools, and other shared components. 
+
+
+
+FEATURES="${config['mssql.features']}"
+
+
+
+; Specify the location where SQL Server Setup will obtain product updates. The valid values are "MU" to search Microsoft Update, a valid folder path, a relative path such as .\MyUpdates or a UNC share. By default SQL Server Setup will search Microsoft Update or a Windows Update service through the Window Server Update Services. 
+
+
+
+UpdateSource="MU"
+
+
+
+; Displays the command line parameters usage 
+
+
+
+HELP="False"
+
+
+
+; Specifies that the detailed Setup log should be piped to the console. 
+
+
+
+INDICATEPROGRESS="True"
+
+
+
+; Specifies that Setup should install into WOW64. This command line argument is not supported on an IA64 or a 32-bit system. 
+
+
+
+X86="False"
+
+
+
+; Specify the root installation directory for shared components.  This directory remains unchanged after shared components are already installed. 
+
+
+
+INSTALLSHAREDDIR="C:\Program Files\Microsoft SQL Server"
+
+
+
+; Specify the root installation directory for the WOW64 shared components.  This directory remains unchanged after WOW64 shared components are already installed. 
+
+
+
+INSTALLSHAREDWOWDIR="C:\Program Files (x86)\Microsoft SQL Server"
+
+
+
+; Specify a default or named instance. MSSQLSERVER is the default instance for non-Express editions and SQLExpress for Express editions. This parameter is required when installing the SQL Server Database Engine (SQL), Analysis Services (AS), or Reporting Services (RS). 
+
+
+
+INSTANCENAME="MSSQLSERVER"
+
+
+
+; Specify the Instance ID for the SQL Server features you have specified. SQL Server directory structure, registry structure, and service names will incorporate the instance ID of the SQL Server instance. 
+
+
+
+INSTANCEID="MSSQLSERVER"
+
+
+
+; Specify that SQL Server feature usage data can be collected and sent to Microsoft. Specify 1 or True to enable and 0 or False to disable this feature. 
+
+
+
+SQMREPORTING="False"
+
+
+; The account used by the Distributed Replay Controller service.
+
+CTLRSVCACCOUNT="NT Service\SQL Server Distributed Replay Controller"
+
+; The startup type for the Distributed Replay Controller service.
+
+CTLRSTARTUPTYPE="Manual"
+
+; The account used by the Distributed Replay Client service.
+
+CLTSVCACCOUNT="NT Service\SQL Server Distributed Replay Client"
+
+; The startup type for the Distributed Replay Client service.
+
+CLTSTARTUPTYPE="Manual"
+
+; The result directory for the Distributed Replay Client service.
+
+CLTRESULTDIR="C:\Program Files (x86)\Microsoft SQL Server\DReplayClient\ResultDir"
+
+; The working directory for the Distributed Replay Client service.
+
+CLTWORKINGDIR="C:\Program Files (x86)\Microsoft SQL Server\DReplayClient\WorkingDir"
+
+; RSInputSettings_RSInstallMode_Description
+
+RSINSTALLMODE="DefaultNativeMode"
+
+; RSInputSettings_RSInstallMode_Description
+
+RSSHPINSTALLMODE="SharePointFilesOnlyMode"
+
+; Specify if errors can be reported to Microsoft to improve future SQL Server releases. Specify 1 or True to enable and 0 or False to disable this feature.
+
+
+
+; Specify if errors can be reported to Microsoft to improve future SQL Server releases. Specify 1 or True to enable and 0 or False to disable this feature. 
+
+
+
+ERRORREPORTING="False"
+
+
+
+; Specify the installation directory. 
+
+
+
+INSTANCEDIR="C:\Program Files\Microsoft SQL Server"
+
+
+
+; Agent account name 
+
+
+
+AGTSVCACCOUNT="NT Service\SQLSERVERAGENT"
+
+
+
+; Auto-start service after installation.  
+
+
+
+AGTSVCSTARTUPTYPE="Automatic"
+
+
+; Startup type for Integration Services.
+
+ISSVCSTARTUPTYPE="Automatic"
+
+; Account for Integration Services: Domain\User or system account.
+
+ISSVCACCOUNT="NT Service\MsDtsServer110"
+
+; The name of the account that the Analysis Services service runs under.
+
+ASSVCACCOUNT="NT Service\MSSQLServerOLAPService"
+
+; Controls the service startup type setting after the service has been created.
+
+ASSVCSTARTUPTYPE="Automatic"
+
+; The collation to be used by Analysis Services.
+
+ASCOLLATION="Latin1_General_CI_AS"
+
+; The location for the Analysis Services data files.
+
+ASDATADIR="C:\Program Files\Microsoft SQL Server\MSAS11.MSSQLSERVER\OLAP\Data"
+
+; The location for the Analysis Services log files.
+
+ASLOGDIR="C:\Program Files\Microsoft SQL Server\MSAS11.MSSQLSERVER\OLAP\Log"
+
+; The location for the Analysis Services backup files.
+
+ASBACKUPDIR="C:\Program Files\Microsoft SQL Server\MSAS11.MSSQLSERVER\OLAP\Backup"
+
+; The location for the Analysis Services temporary files.
+
+ASTEMPDIR="C:\Program Files\Microsoft SQL Server\MSAS11.MSSQLSERVER\OLAP\Temp"
+
+; The location for the Analysis Services configuration files.
+
+ASCONFIGDIR="C:\Program Files\Microsoft SQL Server\MSAS11.MSSQLSERVER\OLAP\Config"
+
+; Specifies whether or not the MSOLAP provider is allowed to run in process.
+
+ASPROVIDERMSOLAP="1"
+
+; Specifies the list of administrator accounts that need to be provisioned.
+
+ASSYSADMINACCOUNTS="BUILTIN\Administrators"
+
+; Specifies the server mode of the Analysis Services instance. Valid values are MULTIDIMENSIONAL and TABULAR. The default value is MULTIDIMENSIONAL.
+
+ASSERVERMODE="MULTIDIMENSIONAL"
+
+; CM brick TCP communication port 
+
+
+
+COMMFABRICPORT="0"
+
+
+
+; How matrix will use private networks 
+
+
+
+COMMFABRICNETWORKLEVEL="0"
+
+
+
+; How inter brick communication will be protected 
+
+
+
+COMMFABRICENCRYPTION="0"
+
+
+
+; TCP port used by the CM brick 
+
+
+
+MATRIXCMBRICKCOMMPORT="0"
+
+
+
+; Startup type for the SQL Server service. 
+
+
+
+SQLSVCSTARTUPTYPE="Automatic"
+
+
+
+; Level to enable FILESTREAM feature at (0, 1, 2 or 3). 
+
+
+
+FILESTREAMLEVEL="0"
+
+
+
+; Set to "1" to enable RANU for SQL Server Express. 
+
+
+
+ENABLERANU="False"
+
+
+
+; Specifies a Windows collation or an SQL collation to use for the Database Engine. 
+
+
+
+SQLCOLLATION="SQL_Latin1_General_CP1_CI_AS"
+
+
+
+; Account for SQL Server service: Domain\User or system account. 
+
+
+
+SQLSVCACCOUNT="NT Service\MSSQLSERVER"
+
+
+
+; Windows account(s) to provision as SQL Server system administrators. 
+
+
+
+SQLSYSADMINACCOUNTS="BUILTIN\Administrators"
+
+
+
+; The default is Windows Authentication. Use "SQL" for Mixed Mode Authentication. 
+
+
+
+SECURITYMODE="SQL"
+
+
+SAPWD="${config['mssql.sa.password']}"
+
+
+
+; Provision current user as a Database Engine system administrator for SQL Server 2012 Express. 
+
+
+
+ADDCURRENTUSERASSQLADMIN="False"
+
+
+
+; Specify 0 to disable or 1 to enable the TCP/IP protocol. 
+
+
+
+TCPENABLED="1"
+
+
+
+; Specify 0 to disable or 1 to enable the Named Pipes protocol. 
+
+
+
+NPENABLED="0"
+
+
+
+; Startup type for Browser Service. 
+
+
+
+BROWSERSVCSTARTUPTYPE="Disabled"
+
+
+; Specifies which account the report server NT service should execute under.  When omitted or when the value is empty string, the default built-in account for the current operating system.
+; The username part of RSSVCACCOUNT is a maximum of 20 characters long and
+; The domain part of RSSVCACCOUNT is a maximum of 254 characters long.
+
+RSSVCACCOUNT="NT Service\ReportServer"
+
+; Specifies how the startup mode of the report server NT service.  When
+; Manual - Service startup is manual mode (default).
+; Automatic - Service startup is automatic mode.
+; Disabled - Service is disabled
+
+RSSVCSTARTUPTYPE="Automatic"
+
+; Add description of input argument FTSVCACCOUNT
+
+FTSVCACCOUNT="NT Service\MSSQLFDLauncher"
+
+
+
+IAcceptSQLServerLicenseTerms="True"

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/checkrunningmssql.bat
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/checkrunningmssql.bat
@@ -1,0 +1,23 @@
+[#ftl]
+@echo off
+REM Licensed to the Apache Software Foundation (ASF) under one
+REM or more contributor license agreements.  See the NOTICE file
+REM distributed with this work for additional information
+REM regarding copyright ownership.  The ASF licenses this file
+REM to you under the Apache License, Version 2.0 (the
+REM "License"); you may not use this file except in compliance
+REM with the License.  You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing,
+REM software distributed under the License is distributed on an
+REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+REM KIND, either express or implied.  See the License for the
+REM specific language governing permissions and limitations
+REM under the License.
+
+set serviceName=MSSQL\$${config['mssql.instance.name']}
+
+[#noparse]
+sc query %serviceName% | find "RUNNING"

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/configuremssql.ps1
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/configuremssql.ps1
@@ -1,0 +1,22 @@
+[#ftl]
+#!ps1
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+netsh advfirewall firewall add rule name=SQLPort dir=in protocol=tcp action=allow localport=1433 remoteip=any profile=any
+( Get-WmiObject -Namespace "root\Microsoft\SqlServer\ComputerManagement11" -Query "Select * from ServerNetworkProtocolProperty where ProtocolName='Tcp' and IPAddressName='IPAll' and PropertyName='TcpPort'" ).SetStringValue("1433")

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/installmssql.ps1
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/installmssql.ps1
@@ -1,0 +1,49 @@
+[#ftl]
+#!ps1
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+$Url = "${config['mssql.download.url']}"
+$Path = "C:\sql2008.iso"
+$Username = "${config['mssql.download.user']}"
+$Password = '${config['mssql.download.password']}'
+
+
+$WebClient = New-Object System.Net.WebClient
+$WebClient.Credentials = New-Object System.Net.Networkcredential($Username, $Password)
+$WebClient.DownloadFile( $url, $path )
+
+$mountResult = Mount-DiskImage $Path -PassThru
+$driveLetter = (($mountResult | Get-Volume).DriveLetter) + ":\"
+
+New-Item -ItemType Directory -Force -Path "C:\Program Files (x86)\Microsoft SQL Server\DReplayClient\ResultDir"
+New-Item -ItemType Directory -Force -Path "C:\Program Files (x86)\Microsoft SQL Server\DReplayClient\WorkingDir"
+
+Install-WindowsFeature NET-Framework-Core
+
+$pass = '${attribute['windows.password']}'
+$secpasswd = ConvertTo-SecureString $pass -AsPlainText -Force
+$mycreds = New-Object System.Management.Automation.PSCredential ($($env:COMPUTERNAME + "\Administrator"), $secpasswd)
+
+Invoke-Command -ComputerName localhost -credential $mycreds -scriptblock {
+    param($driveLetter)
+    Start-Process ( $driveLetter + "setup.exe") -ArgumentList "/ConfigurationFile=C:\ConfigurationFile.ini" -RedirectStandardOutput "C:\sqlout.txt" -RedirectStandardError "C:\sqlerr.txt" -Wait
+} -Authentication CredSSP -argumentlist $driveLetter
+
+## Process complete

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/launchmssql.bat
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/launchmssql.bat
@@ -1,0 +1,25 @@
+[#ftl]
+@echo off
+REM Licensed to the Apache Software Foundation (ASF) under one
+REM or more contributor license agreements.  See the NOTICE file
+REM distributed with this work for additional information
+REM regarding copyright ownership.  The ASF licenses this file
+REM to you under the Apache License, Version 2.0 (the
+REM "License"); you may not use this file except in compliance
+REM with the License.  You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing,
+REM software distributed under the License is distributed on an
+REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+REM KIND, either express or implied.  See the License for the
+REM specific language governing permissions and limitations
+REM under the License.
+
+set serviceName=MSSQL\$${config['mssql.instance.name']}
+
+[#noparse]
+sc stop %serviceName%
+sc config %serviceName% start=auto
+sc start %serviceName%

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/mssql.yaml
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/mssql.yaml
@@ -1,0 +1,31 @@
+name: imageId us-west-2/ami-07390a37
+
+location: AWS Oregon Win
+
+services:
+- type: brooklyn.entity.basic.VanillaWindowsProcess
+  brooklyn.config:
+    templates.install:
+      classpath://brooklyn/entity/database/mssql/ConfigurationFile.ini: "C:\\ConfigurationFile.ini"
+      classpath://brooklyn/entity/database/mssql/installmssql.ps1: "C:\\installmssql.ps1"
+      classpath://brooklyn/entity/database/mssql/configuremssql.ps1: "C:\\configuremssql.ps1"
+      classpath://brooklyn/entity/database/mssql/launchmssql.bat: "C:\\launchmssql.bat"
+      classpath://brooklyn/entity/database/mssql/stopmssql.bat: "C:\\stopmssql.bat"
+    install.command: powershell -command "C:\\installmssql.ps1"
+    customize.command: powershell -command "C:\\configuremssql.ps1"
+    launch.command: "C:\\launchmssql.bat"
+    stop.command: "C:\\stopmssql.bat"
+    checkRunning.command: echo true
+
+    ## NOTE: Values must be supplied for the following
+    mssql.download.url:
+    mssql.download.user:
+    mssql.download.password:
+    mssql.sa.password:
+    mssql.instance.name:
+
+    ## The following is a list of *all* MSSQL features. Installation time and footprint can be greatly
+    ## reduced by removing unnecessary features
+    mssql.features: "SQLENGINE,REPLICATION,FULLTEXT,DQ,AS,RS,RS_SHP,DQC,BIDS,CONN,IS,BC,SDK,BOL,SSMS,ADV_SSMS,DREPLAY_CTLR,DREPLAY_CLT,SNAC_SDK"
+  provisioning.properties:
+    required.ports: 1433

--- a/software/database/src/main/resources/brooklyn/entity/database/mssql/stopmssql.bat
+++ b/software/database/src/main/resources/brooklyn/entity/database/mssql/stopmssql.bat
@@ -1,0 +1,24 @@
+[#ftl]
+@echo off
+REM Licensed to the Apache Software Foundation (ASF) under one
+REM or more contributor license agreements.  See the NOTICE file
+REM distributed with this work for additional information
+REM regarding copyright ownership.  The ASF licenses this file
+REM to you under the Apache License, Version 2.0 (the
+REM "License"); you may not use this file except in compliance
+REM with the License.  You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing,
+REM software distributed under the License is distributed on an
+REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+REM KIND, either express or implied.  See the License for the
+REM specific language governing permissions and limitations
+REM under the License.
+
+set serviceName=MSSQL\$${config['mssql.instance.name']}
+
+[#noparse]
+sc config %serviceName% start=demand
+sc stop %serviceName%

--- a/usage/launcher/src/test/java/brooklyn/entity/database/mssql/MssqlBlueprintLiveTest.java
+++ b/usage/launcher/src/test/java/brooklyn/entity/database/mssql/MssqlBlueprintLiveTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.entity.database.mssql;
+
+import java.io.StringReader;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import brooklyn.launcher.blueprints.AbstractBlueprintTest;
+import brooklyn.util.ResourceUtils;
+import brooklyn.util.text.TemplateProcessor;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Assumes that brooklyn.properties contains something like the following (but with real values!):
+ * 
+ * {@code
+ * test.mssql.download.url = http://myserver.com/sql2012.iso
+ * test.mssql.download.user = myname
+ * test.mssql.download.password = mypassword
+ * test.mssql.sa.password = mypassword
+ * test.mssql.instance.name = MYNAME
+ * }
+ */
+public class MssqlBlueprintLiveTest extends AbstractBlueprintTest {
+
+    // TODO Needs further testing
+    
+    @Test(groups={"Live"})
+    public void testMssql() throws Exception {
+        Map<String, String> substitutions = ImmutableMap.of(
+                "mssql.download.url", mgmt.getConfig().getFirst("test.mssql.download.url"),
+                "mssql.download.user", mgmt.getConfig().getFirst("test.mssql.download.user"),
+                "mssql.download.password", mgmt.getConfig().getFirst("test.mssql.download.password"),
+                "mssql.sa.password", mgmt.getConfig().getFirst("test.mssql.sa.password"),
+                "mssql.instance.name", mgmt.getConfig().getFirst("test.mssql.instance.name"));
+
+        String rawYaml = new ResourceUtils(this).getResourceAsString("mssql-test.yaml");
+        String yaml = TemplateProcessor.processTemplateContents(rawYaml, substitutions);
+        runTest(new StringReader(yaml));
+    }
+}

--- a/usage/launcher/src/test/resources/mssql-test.yaml
+++ b/usage/launcher/src/test/resources/mssql-test.yaml
@@ -1,14 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Duplicate of software/database/src/main/resources/brooklyn/entity/database/mssql/mssql.yaml,
+# but with template for download url, etc
+
 name: mssql
 
 location:
   jclouds:aws-ec2:us-west-2:
     displayName: AWS Oregon (Windows)
     imageId: us-west-2/ami-8fd3f9bf
-    hardwareId:  m3.medium
+    hardwareId: m3.medium
     useJcloudsSshInit: false
     templateOptions:
-      subnetId: subnet-a10e96c4
-      securityGroupIds: [['sg-a2d0c2c7']]
       mapNewVolumeToDeviceName: ["/dev/sda1", 100, true]
 
 services:
@@ -27,11 +47,11 @@ services:
     checkRunning.command: echo true
 
     ## NOTE: Values must be supplied for the following
-    mssql.download.url:
-    mssql.download.user:
-    mssql.download.password:
-    mssql.sa.password:
-    mssql.instance.name:
+    mssql.download.url: ${mssql.download.url}
+    mssql.download.user: ${mssql.download.user}
+    mssql.download.password: ${mssql.download.password}
+    mssql.sa.password: ${mssql.sa.password}
+    mssql.instance.name: ${mssql.instance.name}
 
     ## The following is a list of *all* MSSQL features. Installation time and footprint can be greatly
     ## reduced by removing unnecessary features


### PR DESCRIPTION
Builds on https://github.com/apache/incubator-brooklyn/pull/650, incorporating many of the pull request comments from there.

This also has @nakomis's commit(s) for https://github.com/apache/incubator-brooklyn/pull/639. Would be nice to address those before merge, but am happy if we merge then refactor so we can get the rest of this goodness.

The following have been deferred for this PR, but really must be addressed soon:

* Comments in PR #639 (@nakomis's PR on which this is built included those changes)

* More tests (!), including:

  * WinRmMachineLocation's script execution
    (there is one test, which needs attention!)
  
  * VanillaWindowsProcess
    (there is one test, which needs attention - MssqlBlueprintLiveTest)

  * JcloudsWinRmMachineLocation's public/private/subnet addresses

* Resolve naming differences in config between WinRM location/tool and SshTool/SshMachineLocation, such as SshTool#PROP_SSH_TRIES. Should these be merged int one well-named generic thing, deprecating the previous ssh config key?

* Resolve naming differences in JcloudsLocation, where it's ssh-specific. For example, should WAIT_FOR_WINRM_AVAILABLE and WAIT_FOR_SSHABLE. Would probably have to deprecate the old key, and generalise the name.

* JcloudsLocation:

  * Allow for user-specified credentials: want to support setting up a given user on the VM (or resetting the Administrator password), and to support vCloudDirector use-case where template contains username/password, so don't just use what is returned by jclouds.

  * Support for port-forwarding in JcloudsWinRmMachineLocation.

  * Resolve differences in "waitForReachable" between Windows and ssh code-paths.

  * Can we ensure the returned JcloudsMachineLocation will have the right node.getLoginPort for WinRM? How do we ensure that happens?

  * Generalise the sshHostAndPortOverride (e.g. rename to connectionHostAndPortOverride). Use it for the WinRM port in the windows case.

  * jcloudsLocation: need to release port-forwarding when it's a Windows VM

* WinRmMachineLocation: respect the configured `port` as the one to use when connecting (essential for port-forwarding scenarios).

* We should list (in docs / limitations) the main config options that are not supported (yet) on windows (rather than the user/customer discovering it by trying to configure it and eventually finding this log message, or just it being ignored silently (as would be the case for user/password configuration).


Some unaddressed minor comments:

* WinRmMachineLocation: worth a comment describing the file-copy approach used.

* WinRmMachineLocation.getDefaultUserMetadataString: worth some javadoc to say what this default user metadata will do.

* JcloudsLocation waitForReachable: would catch-block always be for a NumberFormatException? If so, can we be more specific?

* I wonder why we don't set the parent inside JcloudsLocation.registerJcloudsSshMachineLocation.

* AbstractSoftwareProcessWinRmDriver.WINDOWS_USERNAME: is inside the driver the best place to declare these sensors?

* Unaddressed questions from PR #650:

  * in jcloudsLocation, "This changes the execCommands description. I take it that's deliberate? Was the full script being logged multiple times before?"

  * in jcloudsLocation, "What exception are you expecting here? Can we just program more defensively when building the message?"

  * in JcloudsLocation, "Remove try-catch! @Nakomis: why catch exception when doing log message? What exception happened during logging?"

  * AbstractSoftwareProcessWinRmDriver.rebootAndWait: Can we be more specific - e.g. what exception do you expect. And log if not exactly right. There's a risk we'll pretend the VM is rebooting when actually we got back an error about permissions or something like that.


Other comments needing more thought (but less time critical):

* DynamicCluster.grow will not behave right for availability zones if the memberSpec defines a location. It will use that location in preference to the cluster's location.

* WinRmMachineLocation has a retry-loop when calling WinrmTool. This feels quite different from the SshMachineLocation implementation. I wonder if it's worth creating a wrapper of WinrmTool, such as for retries etc.

* Not sure about the name VanillaWindowsProcessDriver versus VanillaSoftwareProcessDriver. They are both software processes.

* Medium term, would be good to think more about how an entity author (working in yaml) can control the different phases. This is good enough for now, but we'll no doubt hit a use-case where one needs to reboot at a different phase, or where more phases would be useful (particularly for the equivalent of "sub-classing" within the yaml).
@alasdairhodge has some good thoughts on this, as has @ahgittin - worth a bigger discussion on that.
