### PR TITLE
Fix Jenkins build error - "Unable to access URL brooklyn.webconsole.security.keystore.url"

### DIFF
--- a/usage/launcher/src/test/java/brooklyn/launcher/BrooklynWebServerTest.java
+++ b/usage/launcher/src/test/java/brooklyn/launcher/BrooklynWebServerTest.java
@@ -24,6 +24,8 @@ import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.util.List;
@@ -183,9 +185,24 @@ public class BrooklynWebServerTest {
         keystore.load(instream, password.toCharArray());
         return keystore;
     }
+    
+    @Test
+    public void testGetFileFromUrl() throws Exception {
+        String url = "file:///tmp/special%40file%20with%20spaces";
+        String file = "/tmp/special@file with spaces";
+        assertEquals(getFile(new URL(url)), file);
+    }
 
-    private String getFile(String file) {
+    private String getFile(String classpathResource) {
         // this works because both IDE and Maven run tests with classes/resources on the file system
-        return new File(getClass().getResource("/" + file).getFile()).getAbsolutePath();
+        return getFile(getClass().getResource("/" + classpathResource));
+    }
+
+    private String getFile(URL url) {
+        try {
+            return new File(url.toURI()).getAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw Exceptions.propagate(e);
+        }
     }
 }


### PR DESCRIPTION
Fix transformation of URL to file path - a good example why one shouldn't use string operations when converting between file path and URL.
Sample failure - https://builds.apache.org/job/incubator-brooklyn-pull-requests/1267/console

```
erifyHttps(brooklyn.launcher.BrooklynWebServerTest)  Time elapsed: 0.018 sec  <<< FAILURE!
java.lang.IllegalArgumentException: Unable to access URL brooklyn.webconsole.security.keystore.url: /home/jenkins/jenkins-slave/workspace/incubator-brooklyn-pull-requests%402/usage/launcher/target/test-classes/server.ks
	at brooklyn.util.ResourceUtils.getResourceFromUrl(ResourceUtils.java:287)
	at brooklyn.util.ResourceUtils.checkUrlExists(ResourceUtils.java:484)
	at brooklyn.launcher.BrooklynWebServer.getLocalKeyStorePath(BrooklynWebServer.java:515)
	at brooklyn.launcher.BrooklynWebServer.createContextFactory(BrooklynWebServer.java:443)
	at brooklyn.launcher.BrooklynWebServer.start(BrooklynWebServer.java:373)
	at brooklyn.launcher.BrooklynWebServerTest.verifyHttps(BrooklynWebServerTest.java:115)
```