### PR TITLE
Upgrade freemarker, latest version fixes Jython loading errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <jetty.version>8.1.17.v20150415</jetty.version>
         <airline.version>0.6</airline.version>
         <mockwebserver.version>20121111</mockwebserver.version>
-        <freemarker.version>2.3.19</freemarker.version>
+        <freemarker.version>2.3.22</freemarker.version>
         <commons-io.version>2.4</commons-io.version>
         <hazelcast.version>3.0</hazelcast.version>
         <jsonPath.version>0.9.1</jsonPath.version>


### PR DESCRIPTION
Fixes test errors when building with Java 6
```
java.lang.NoClassDefFoundError: Could not initialize class freemarker.template.Configuration
```

See http://sourceforge.net/p/freemarker/bugs/394/, https://github.com/freemarker/freemarker/commit/1bc3291c98f8fe80fa211b880366f2bba90f7187
