### PR TITLE
Don't create install dir in copy-pre-install-resources unless needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <jetty.version>8.1.17.v20150415</jetty.version>
         <airline.version>0.6</airline.version>
         <mockwebserver.version>20121111</mockwebserver.version>
-        <freemarker.version>2.3.19</freemarker.version>
+        <freemarker.version>2.3.22</freemarker.version>
         <commons-io.version>2.4</commons-io.version>
         <hazelcast.version>3.0</hazelcast.version>
         <jsonPath.version>0.9.1</jsonPath.version>


### PR DESCRIPTION
Lots of unit tests assume that no ssh connection will be established when testing localhost entities. The addition of `copy-pre-install-resources` breaks the tests if local ssh is not configured properly. Create install dir only if there are resources to copy (and therefore the test expects it will try to ssh).