### PR TITLE
Remove shared statics causing issues in Clocker

### DIFF
--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -37,7 +37,6 @@ import org.jclouds.sshj.config.SshjSshClientModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import brooklyn.entity.basic.Entities;
 import brooklyn.entity.basic.Sanitizer;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.config.ConfigBag;

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -204,7 +205,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     private static final Pattern LIST_PATTERN = Pattern.compile("^\\[(.*)\\]$");
     private static final Pattern INTEGER_PATTERN = Pattern.compile("^\\d*$");
 
-    private static boolean loggedSshKeysHint = false;
+    private final AtomicBoolean loggedSshKeysHint = new AtomicBoolean(false);
+    private final AtomicBoolean listedAvailableTemplatesOnNoSuchTemplate = new AtomicBoolean(false);
 
     private final Map<String,Map<String, ? extends Object>> tagMapping = Maps.newLinkedHashMap();
 
@@ -1145,8 +1147,6 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             // TODO put user metadata and tags into notes, when jclouds exposes notes, because metadata not exposed via web portal 
         }
     }
-    
-    private static boolean listedAvailableTemplatesOnNoSuchTemplate = false;
 
     /** returns the jclouds Template which describes the image to be built, for the given config and compute service */
     public Template buildTemplate(ComputeService computeService, ConfigBag config) {
@@ -1213,13 +1213,15 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             throw new IllegalStateException("Not authorized to access cloud "+this+" to resolve "+templateBuilder, e);
         } catch (Exception e) {
             try {
-                synchronized (this) {
+                IOException ioe = Exceptions.getFirstThrowableOfType(e, IOException.class);
+                if (ioe != null) {
+                    LOG.warn("IOException found...", ioe);
+                    throw ioe;
+                }
+                if (listedAvailableTemplatesOnNoSuchTemplate.compareAndSet(false, true)) {
                     // delay subsequent log.warns (put in synch block) so the "Loading..." message is obvious
                     LOG.warn("Unable to match required VM template constraints "+templateBuilder+" when trying to provision VM in "+this+" (rethrowing): "+e);
-                    if (!listedAvailableTemplatesOnNoSuchTemplate) {
-                        listedAvailableTemplatesOnNoSuchTemplate = true;
-                        logAvailableTemplates(config);
-                    }
+                    logAvailableTemplates(config);
                 }
             } catch (Exception e2) {
                 LOG.warn("Error loading available images to report (following original error matching template which will be rethrown): "+e2, e2);
@@ -1502,8 +1504,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                  * if this config key is not set, use a key `brooklyn_id_rsa` and `.pub` in `MGMT_BASE_DIR`,
                  * with permission 0600, creating it if necessary, and logging the fact that this was created.
                  */
-                if (!loggedSshKeysHint && !config.containsKey(PRIVATE_KEY_FILE)) {
-                    loggedSshKeysHint = true;
+                if (!config.containsKey(PRIVATE_KEY_FILE) && loggedSshKeysHint.compareAndSet(false, true)) {
                     LOG.info("Default SSH keys not found or not usable; will create new keys for each machine. "
                         + "Create ~/.ssh/id_rsa or "
                         + "set "+PRIVATE_KEY_FILE.getName()+" / "+PRIVATE_KEY_PASSPHRASE.getName()+" / "+PASSWORD.getName()+" "


### PR DESCRIPTION
Clocker has more than one `JcloudsLocation` so the check for exceptions is skipped sometimes, becasue the guard is a static variable shared by all instances. This gives unhelpful error messages occasionally, particularly in the presence of network failures raising `IOException`s.