### PR TITLE
added type coercions for String to BigDecimal and BigInteger

### DIFF
--- a/core/src/main/java/brooklyn/util/flags/TypeCoercions.java
+++ b/core/src/main/java/brooklyn/util/flags/TypeCoercions.java
@@ -665,10 +665,22 @@ public class TypeCoercions {
                 return input.intValue();
             }
         });
+        registerAdapter(String.class, BigDecimal.class, new Function<String,BigDecimal>() {
+            @Override
+            public BigDecimal apply(String input) {
+                return new BigDecimal(input);
+            }
+        });
         registerAdapter(Double.class, BigDecimal.class, new Function<Double,BigDecimal>() {
             @Override
             public BigDecimal apply(Double input) {
                 return BigDecimal.valueOf(input);
+            }
+        });
+        registerAdapter(String.class, BigInteger.class, new Function<String,BigInteger>() {
+            @Override
+            public BigInteger apply(String input) {
+                return new BigInteger(input);
             }
         });
         registerAdapter(Long.class, BigInteger.class, new Function<Long,BigInteger>() {

--- a/core/src/test/java/brooklyn/util/internal/TypeCoercionsTest.java
+++ b/core/src/test/java/brooklyn/util/internal/TypeCoercionsTest.java
@@ -151,6 +151,12 @@ public class TypeCoercionsTest {
     }
 
     @Test
+    public void testCoerceStringToBigNumber() {
+    	assertEquals(TypeCoercions.coerce("0.5", BigDecimal.class), BigDecimal.valueOf(0.5));
+    	assertEquals(TypeCoercions.coerce("1", BigInteger.class), BigInteger.valueOf(1));
+    }
+
+    @Test
     public void testCoerceStringToEnum() {
         assertEquals(TypeCoercions.coerce("STARTING", Lifecycle.class), Lifecycle.STARTING);
         assertEquals(TypeCoercions.coerce("Starting", Lifecycle.class), Lifecycle.STARTING);


### PR DESCRIPTION
Added two type coercions to class brooklyn.util.flags.TypeCoercions in brooklyn-core:
  - String -> java.math.BigDecimal
  - String -> java.math.BigInteger
Also added a corresponding test case to TypeCoercionsTest.