### PR TITLE
Provision latch

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
+++ b/core/src/main/java/brooklyn/entity/basic/BrooklynConfigKeys.java
@@ -143,6 +143,7 @@ public class BrooklynConfigKeys {
      * component is up, but this entity does not care about the dependent component's actual config values.
      */
 
+    public static final ConfigKey<Boolean> PROVISION_LATCH = newBooleanConfigKey("provision.latch", "Latch for blocking location provision until ready");
     public static final ConfigKey<Boolean> START_LATCH = newBooleanConfigKey("start.latch", "Latch for blocking start until ready");
     public static final ConfigKey<Boolean> SETUP_LATCH = newBooleanConfigKey("setup.latch", "Latch for blocking setup until ready");
     public static final ConfigKey<Boolean> PRE_INSTALL_RESOURCES_LATCH = newBooleanConfigKey("resources.preInstall.latch", "Latch for blocking pre-install resources until ready");

--- a/locations/jclouds/src/test/java/brooklyn/location/jclouds/BailOutJcloudsLocation.java
+++ b/locations/jclouds/src/test/java/brooklyn/location/jclouds/BailOutJcloudsLocation.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package brooklyn.location.jclouds;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.domain.Template;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.reflect.TypeToken;
+
+import brooklyn.config.BrooklynProperties;
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.location.LocationSpec;
+import brooklyn.management.ManagementContext;
+import brooklyn.management.internal.LocalManagementContext;
+import brooklyn.util.collections.MutableMap;
+import brooklyn.util.config.ConfigBag;
+import brooklyn.util.exceptions.CompoundRuntimeException;
+import brooklyn.util.exceptions.Exceptions;
+
+public class BailOutJcloudsLocation extends JcloudsLocation {
+
+    // Don't care which image; not actually provisioning
+    private static final String US_EAST_IMAGE_ID = "us-east-1/ami-7d7bfc14";
+    public static final RuntimeException BAIL_OUT_FOR_TESTING = new RuntimeException("early termination for test");
+
+    public static final ConfigKey<Function<ConfigBag, Void>> BUILD_TEMPLATE_INTERCEPTOR = ConfigKeys.newConfigKey(
+            new TypeToken<Function<ConfigBag, Void>>() {},
+            "buildtemplateinterceptor");
+
+    public static final ConfigKey<Boolean> BUILD_TEMPLATE = ConfigKeys.newBooleanConfigKey(
+            "buildtemplate");
+
+    private static final long serialVersionUID = -3373789512935057842L;
+
+    ConfigBag lastConfigBag;
+    Template template;
+
+    public BailOutJcloudsLocation() {
+        super();
+    }
+
+    public BailOutJcloudsLocation(Map<?, ?> conf) {
+        super(conf);
+    }
+
+    @Override
+    public Template buildTemplate(ComputeService computeService, ConfigBag config) {
+        lastConfigBag = config;
+        if (getConfig(BUILD_TEMPLATE_INTERCEPTOR) != null) {
+            getConfig(BUILD_TEMPLATE_INTERCEPTOR).apply(config);
+        }
+        if (Boolean.TRUE.equals(getConfig(BUILD_TEMPLATE))) {
+            template = super.buildTemplate(computeService, config);
+        }
+        throw BAIL_OUT_FOR_TESTING;
+    }
+
+    public Template getTemplate() {
+        return template;
+    }
+
+    public void tryObtain() {
+        tryObtain(Collections.emptyMap());
+    }
+
+    public void tryObtain(Map<?, ?> flags) {
+        tryObtainAndCheck(flags, Predicates.alwaysTrue());
+    }
+
+    public void tryObtainAndCheck(Map<?, ?> flags, Predicate<? super ConfigBag> test) {
+        try {
+            obtain(flags);
+        } catch (Exception e) {
+            if (e == BAIL_OUT_FOR_TESTING || e.getCause() == BAIL_OUT_FOR_TESTING
+                    || (e instanceof CompoundRuntimeException && ((CompoundRuntimeException) e).getAllCauses().contains(BAIL_OUT_FOR_TESTING))) {
+                test.apply(lastConfigBag);
+            } else {
+                throw Exceptions.propagate(e);
+            }
+        }
+    }
+
+    @Override
+    @VisibleForTesting
+    public UserCreation createUserStatements(@Nullable Image image, ConfigBag config) {
+        return super.createUserStatements(image, config);
+    }
+
+
+    public static BailOutJcloudsLocation newBailOutJcloudsLocation(ManagementContext mgmt) {
+        return newBailOutJcloudsLocation(mgmt, Collections.<ConfigKey<?>, Object>emptyMap());
+    }
+
+    public static BailOutJcloudsLocation newBailOutJcloudsLocation(ManagementContext mgmt, Map<ConfigKey<?>, ?> config) {
+        Map<ConfigKey<?>, ?> allConfig = MutableMap.<ConfigKey<?>, Object>builder()
+                .put(IMAGE_ID, "bogus")
+                .put(CLOUD_PROVIDER, "aws-ec2")
+                .put(ACCESS_IDENTITY, "bogus")
+                .put(CLOUD_REGION_ID, "bogus")
+                .put(ACCESS_CREDENTIAL, "bogus")
+                .put(USER, "fred")
+                .put(MIN_RAM, 16)
+                .put(JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 1)
+                .putAll(config)
+                .build();
+        return mgmt.getLocationManager().createLocation(
+                LocationSpec.create(BailOutJcloudsLocation.class).configure(allConfig));
+    }
+
+
+    // todo better name
+
+    /** As {@link BailOutJcloudsLocation}, counting the number of {@link #buildTemplate} calls. */
+    public static class CountingBailOutJcloudsLocation extends BailOutJcloudsLocation {
+        private static final long serialVersionUID = 2433684033045735773L;
+        int buildTemplateCount = 0;
+        @Override
+        public Template buildTemplate(ComputeService computeService, ConfigBag config) {
+            buildTemplateCount++;
+            return super.buildTemplate(computeService, config);
+        }
+    }
+
+    public static CountingBailOutJcloudsLocation newCountingBailOutJcloudsLocation(ManagementContext mgmt, Map flags) {
+        LocationSpec<CountingBailOutJcloudsLocation> spec = LocationSpec.create(CountingBailOutJcloudsLocation.class)
+                .configure(flags);
+        return mgmt.getLocationManager().createLocation(spec);
+    }
+
+    /** @see #newBailOutJcloudsLocationForLiveTest(LocalManagementContext, Map)} */
+    public static BailOutJcloudsLocation newBailOutJcloudsLocationForLiveTest(LocalManagementContext mgmt) {
+        return newBailOutJcloudsLocationForLiveTest(mgmt, Collections.<ConfigKey<?>, Object>emptyMap());
+    }
+
+    /**
+     * Takes identity and access credential from management context's Brooklyn properties and sets
+     * inbound ports to [22, 80, 9999].
+     */
+    public static BailOutJcloudsLocation newBailOutJcloudsLocationForLiveTest(LocalManagementContext mgmt, Map<ConfigKey<?>, ?> config) {
+        BrooklynProperties brooklynProperties = mgmt.getBrooklynProperties();
+        String identity = (String) brooklynProperties.get("brooklyn.location.jclouds.aws-ec2.identity");
+        if (identity == null) identity = (String) brooklynProperties.get("brooklyn.jclouds.aws-ec2.identity");
+        String credential = (String) brooklynProperties.get("brooklyn.location.jclouds.aws-ec2.credential");
+        if (credential == null) credential = (String) brooklynProperties.get("brooklyn.jclouds.aws-ec2.credential");
+
+        Map<ConfigKey<?>, ?> allConfig = MutableMap.<ConfigKey<?>, Object>builder()
+                .put(CLOUD_PROVIDER, AbstractJcloudsLiveTest.AWS_EC2_PROVIDER)
+                .put(CLOUD_REGION_ID, AbstractJcloudsLiveTest.AWS_EC2_USEAST_REGION_NAME)
+                .put(IMAGE_ID, US_EAST_IMAGE_ID) // so Brooklyn does not attempt to load all EC2 images
+                .put(ACCESS_IDENTITY, identity)
+                .put(ACCESS_CREDENTIAL, credential)
+                .put(INBOUND_PORTS, "[22, 80, 9999]")
+                .put(BUILD_TEMPLATE, true)
+                .putAll(config)
+                .build();
+
+        return newBailOutJcloudsLocation(mgmt, allConfig);
+    }
+
+}

--- a/software/base/pom.xml
+++ b/software/base/pom.xml
@@ -141,6 +141,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-locations-jclouds</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>mx4j</groupId>
             <artifactId>mx4j-tools</artifactId>
             <scope>test</scope>

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-
 import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
@@ -275,6 +274,8 @@ public abstract class MachineLifecycleEffectorTasks {
         return DynamicTasks.queue(Tasks.<MachineLocation>builder().name("provisioning ("+location.getDisplayName()+")").body(
                 new Callable<MachineLocation>() {
                     public MachineLocation call() throws Exception {
+                        // Blocks if a latch was configured.
+                        entity().getConfig(BrooklynConfigKeys.PROVISION_LATCH);
                         final Map<String,Object> flags = obtainProvisioningFlags(location);
                         if (!(location instanceof LocalhostMachineProvisioningLocation))
                             log.info("Starting {}, obtaining a new location instance in {} with ports {}", new Object[] {entity(), location, flags.get("inboundPorts")});

--- a/software/base/src/test/java/brooklyn/entity/software/MachineLifecycleEffectorTasksTest.java
+++ b/software/base/src/test/java/brooklyn/entity/software/MachineLifecycleEffectorTasksTest.java
@@ -19,14 +19,41 @@
 package brooklyn.entity.software;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.BasicEntity;
 import brooklyn.entity.basic.BasicEntityImpl;
+import brooklyn.entity.basic.BrooklynConfigKeys;
+import brooklyn.entity.basic.BrooklynTaskTags;
+import brooklyn.entity.basic.EmptySoftwareProcess;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.basic.EntityLocal;
 import brooklyn.entity.basic.Lifecycle;
 import brooklyn.entity.basic.SoftwareProcess;
 import brooklyn.entity.basic.SoftwareProcess.StopSoftwareParameters.StopMode;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.entity.trait.Startable;
+import brooklyn.event.AttributeSensor;
+import brooklyn.event.basic.DependentConfiguration;
+import brooklyn.event.basic.Sensors;
+import brooklyn.location.jclouds.BailOutJcloudsLocation;
+import brooklyn.management.Task;
+import brooklyn.test.Asserts;
+import brooklyn.test.entity.TestApplication;
+import brooklyn.util.task.TaskInternal;
+import brooklyn.util.time.Duration;
 
 public class MachineLifecycleEffectorTasksTest {
     public static boolean canStop(StopMode stopMode, boolean isEntityStopped) {
@@ -52,6 +79,61 @@ public class MachineLifecycleEffectorTasksTest {
     public void testBasicSonftwareProcessCanStop(StopMode mode, boolean isEntityStopped, boolean expected) {
         boolean canStop = canStop(mode, isEntityStopped);
         assertEquals(canStop, expected);
+    }
+
+    @Test
+    public void testProvisionLatchObeyed() throws Exception {
+
+        AttributeSensor<Boolean> ready = Sensors.newBooleanSensor("readiness");
+
+        TestApplication app = TestApplication.Factory.newManagedInstanceForTests();
+        BasicEntity triggerEntity = app.createAndManageChild(EntitySpec.create(BasicEntity.class));
+
+        EmptySoftwareProcess entity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class)
+                .configure(BrooklynConfigKeys.PROVISION_LATCH, DependentConfiguration.attributeWhenReady(triggerEntity, ready)));
+
+        final Task<Void> task = Entities.invokeEffector(app, app, Startable.START, ImmutableMap.of(
+                "locations", ImmutableList.of(BailOutJcloudsLocation.newBailOutJcloudsLocation(app.getManagementContext()))));
+
+        assertEffectorBlockingDetailsEventually(entity, "Waiting for config " + BrooklynConfigKeys.PROVISION_LATCH.getName());
+
+        Asserts.succeedsContinually(new Runnable() {
+            @Override
+            public void run() {
+                assertFalse(task.isDone());
+            }
+        });
+        try {
+            ((EntityLocal) triggerEntity).setAttribute(ready, true);
+            task.get(Duration.THIRTY_SECONDS);
+        } catch (Throwable t) {
+            // BailOut location throws but we don't care.
+        } finally {
+            Entities.destroyAll(app.getManagementContext());
+        }
+    }
+
+    private void assertEffectorBlockingDetailsEventually(final Entity entity, final String blockingDetailsSnippet) {
+        Asserts.succeedsEventually(new Runnable() {
+            @Override public void run() {
+                Task<?> entityTask = Iterables.getOnlyElement(entity.getApplication().getManagementContext().getExecutionManager().getTasksWithAllTags(
+                        ImmutableList.of(BrooklynTaskTags.EFFECTOR_TAG, BrooklynTaskTags.tagForContextEntity(entity))));
+                String blockingDetails = getBlockingDetails(entityTask);
+                assertTrue(blockingDetails.contains(blockingDetailsSnippet));
+            }});
+    }
+
+    private String getBlockingDetails(Task<?> task) {
+        List<TaskInternal<?>> taskChain = Lists.newArrayList();
+        TaskInternal<?> taskI = (TaskInternal<?>) task;
+        while (taskI != null) {
+            taskChain.add(taskI);
+            if (taskI.getBlockingDetails() != null) {
+                return taskI.getBlockingDetails();
+            }
+            taskI = (TaskInternal<?>) taskI.getBlockingTask();
+        }
+        throw new IllegalStateException("No blocking details for "+task+" (walked task chain "+taskChain+")");
     }
 
 }


### PR DESCRIPTION
First commit is boring - it just simplifies `JcloudsLocationTest`.

Second commit adds `BrooklynConfigKeys.PROVISION_LATCH`, to block provisioning of locations until some criteria is met.