### PR TITLE
Add link to GitHub blueprint library

### DIFF
--- a/docs/guide/yaml/index.md
+++ b/docs/guide/yaml/index.md
@@ -11,6 +11,7 @@ children:
 - custom-entities.md
 - chef/
 - { path: yaml-reference.md, title: YAML Blueprint Reference }
+- { link: 'https://github.com/brooklyncentral/blueprint-library', title: 'GitHub Blueprint Library' }
 ---
 
 


### PR DESCRIPTION
Adds link to https://github.com/brooklyncentral/blueprint-library from http://brooklyn.incubator.apache.org/v/latest/yaml/index.html