### PR TITLE
Tweak PasswordHasher to avoid potentially misleading use of ByteBuffer.array()

### DIFF
--- a/usage/rest-server/src/main/java/brooklyn/rest/security/PasswordHasher.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/security/PasswordHasher.java
@@ -24,8 +24,9 @@ import com.google.common.hash.Hashing;
 
 public class PasswordHasher {
     public static String sha256(String salt, String password) {
-        byte[] salted = Charsets.UTF_8.encode((salt == null ? "" : salt) + password).array();
-        HashCode hash = Hashing.sha256().hashBytes(salted);
+        if (salt == null) salt = "";
+        byte[] bytes = (salt + password).getBytes(Charsets.UTF_8);
+        HashCode hash = Hashing.sha256().hashBytes(bytes);
         return hash.toString();
     }
 }

--- a/usage/rest-server/src/test/java/brooklyn/rest/security/PasswordHasherTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/security/PasswordHasherTest.java
@@ -26,6 +26,6 @@ public class PasswordHasherTest {
 
     @Test
     public void testHashSha256() throws Exception {
-        assertEquals(PasswordHasher.sha256("mysalt", "mypassword"), "e1c2390613b1beff83420c15d6ceca3b2e77e66e3f4be4e45186032120a30f22");
+        assertEquals(PasswordHasher.sha256("mysalt", "mypassword"), "d02878b06efa88579cd84d9e50b211c0a7caa92cf243bad1622c66081f7e2692");
     }
 }

--- a/usage/rest-server/src/test/java/brooklyn/rest/security/PasswordHasherTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/security/PasswordHasherTest.java
@@ -26,6 +26,12 @@ public class PasswordHasherTest {
 
     @Test
     public void testHashSha256() throws Exception {
+        // Note: expected hash values generated externally:
+        // echo -n mysaltmypassword | openssl dgst -sha256
+
         assertEquals(PasswordHasher.sha256("mysalt", "mypassword"), "d02878b06efa88579cd84d9e50b211c0a7caa92cf243bad1622c66081f7e2692");
+        assertEquals(PasswordHasher.sha256("", "mypassword"), "89e01536ac207279409d4de1e5253e01f4a1769e696db0d6062ca9b8f56767c8");
+        assertEquals(PasswordHasher.sha256(null, "mypassword"), "89e01536ac207279409d4de1e5253e01f4a1769e696db0d6062ca9b8f56767c8");
     }
+
 }


### PR DESCRIPTION
Using `ByteBuffer.array()` to convert a salted password to its constituent bytes frequently results in an indeterminate number of spurious bytes to be included, due to the fact that the buffer's raw backing array is usually larger than the space consumed just by the values written to it. This causes Brooklyn-generated hashes to deviate from the expected `sha256(salt + password)` values.

Even though Brooklyn itself can generate internally-consistent hashes, it is desirable for the algorithm to be sufficiently predictable to permit generation by simple external mechanisms, for example:
````
echo -n "saltpassword" | openssl dgst -sha256
echo -n "saltpassword" | sha256sum
echo -n "saltpassword" | shasum -a 256
````