### PR TITLE
Determine type of entity in rest response from api annotation

### DIFF
--- a/usage/rest-api/src/main/java/brooklyn/rest/api/EntityConfigApi.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/api/EntityConfigApi.java
@@ -18,6 +18,19 @@
  */
 package brooklyn.rest.api;
 
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
 import brooklyn.rest.apidoc.Apidoc;
 import brooklyn.rest.domain.EntityConfigSummary;
 
@@ -25,12 +38,6 @@ import com.wordnik.swagger.core.ApiError;
 import com.wordnik.swagger.core.ApiErrors;
 import com.wordnik.swagger.core.ApiOperation;
 import com.wordnik.swagger.core.ApiParam;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-
-import java.util.List;
-import java.util.Map;
 
 @Path("/v1/applications/{application}/entities/{entity}/config")
 @Apidoc("Entity Config")
@@ -64,6 +71,7 @@ public interface EntityConfigApi {
             @ApiParam(value = "Return raw config data instead of display values", required = false)
             @QueryParam("raw") @DefaultValue("false") final Boolean raw);
 
+    //To call this endpoint set the Accept request field e.g curl -H "Accept: application/json" ...
     @GET
     @Path("/{config}")
     @ApiOperation(value = "Fetch config value (json)", responseClass = "Object")

--- a/usage/rest-client/pom.xml
+++ b/usage/rest-client/pom.xml
@@ -114,14 +114,14 @@
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-core</artifactId>
             <version>${project.version}</version>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-core</artifactId>
             <version>${project.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>

--- a/usage/rest-client/pom.xml
+++ b/usage/rest-client/pom.xml
@@ -119,12 +119,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
-            <artifactId>brooklyn-core</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-rest-server</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/usage/rest-client/src/main/java/brooklyn/rest/client/BrooklynApi.java
+++ b/usage/rest-client/src/main/java/brooklyn/rest/client/BrooklynApi.java
@@ -34,7 +34,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.eclipse.jetty.util.log.Log;
 import org.jboss.resteasy.client.ClientExecutor;
 import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
@@ -62,7 +61,6 @@ import brooklyn.rest.api.UsageApi;
 import brooklyn.rest.api.VersionApi;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.http.BuiltResponsePreservingError;
-import brooklyn.util.http.HttpTool;
 
 import com.wordnik.swagger.core.ApiOperation;
 
@@ -130,7 +128,7 @@ public class BrooklynApi {
                     Class<?> type = String.class;
                     if (result1 instanceof Response) {
                         Response resp = (Response)result1;
-                        if(HttpTool.isStatusCodeHealthy(resp.getStatus()) && method.isAnnotationPresent(ApiOperation.class)) {
+                        if(isStatusCodeHealthy(resp.getStatus()) && method.isAnnotationPresent(ApiOperation.class)) {
                            type = getClassFromMethodAnnotationOrDefault(method, type);
                         }
                         // wrap the original response so it self-closes
@@ -146,6 +144,8 @@ public class BrooklynApi {
                 }  
             }
             
+            private boolean isStatusCodeHealthy(int code) { return (code>=200 && code<=299); }
+            
             private Class<?> getClassFromMethodAnnotationOrDefault(Method method, Class<?> def){
                 Class<?> type;
                 try{
@@ -153,7 +153,7 @@ public class BrooklynApi {
                     type = Class.forName(responseClass);
                 } catch (Exception e) {
                     type = def;
-                    LOG.info("Unable to get class from annotation: {}.  Defaulting to {}", e.getMessage(), def.getName());
+                    LOG.debug("Unable to get class from annotation: {}.  Defaulting to {}", e.getMessage(), def.getName());
                     Exceptions.propagateIfFatal(e);
                 }
                 return type;

--- a/usage/rest-client/src/main/java/brooklyn/rest/client/BrooklynApi.java
+++ b/usage/rest-client/src/main/java/brooklyn/rest/client/BrooklynApi.java
@@ -122,9 +122,12 @@ public class BrooklynApi {
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {                 
                 try {
                     Object result1 = method.invoke(result0, args);
+                    Class<?> type = String.class;
                     if (result1 instanceof Response) {
-                        String responseClass = method.getAnnotation(ApiOperation.class).responseClass();
-                        Class<?> type = Class.forName(responseClass);
+                        if(((Response)result1).getStatus()/100 == 2) {
+                           String responseClass = method.getAnnotation(ApiOperation.class).responseClass();
+                           type = Class.forName(responseClass);
+                        }
                         // wrap the original response so it self-closes
                         result1 = BuiltResponsePreservingError.copyResponseAndClose((Response) result1, type);
                     }

--- a/usage/rest-client/src/main/java/brooklyn/util/http/BuiltResponsePreservingError.java
+++ b/usage/rest-client/src/main/java/brooklyn/util/http/BuiltResponsePreservingError.java
@@ -45,7 +45,7 @@ public class BuiltResponsePreservingError extends BuiltResponse {
     }
     
     @SuppressWarnings("deprecation")
-    public static Response copyResponseAndClose(Response source) {
+    public static <T> Response copyResponseAndClose(Response source, Class<T> type) {
         int status = -1;
         Headers<Object> headers = new Headers<Object>();
         Object entity = null;
@@ -54,7 +54,7 @@ public class BuiltResponsePreservingError extends BuiltResponse {
             headers.putAll(source.getHeaders());
             if (source instanceof org.jboss.resteasy.client.ClientResponse) {
                 // ClientResponse requires strong type info, which we don't yet have
-                entity = ((org.jboss.resteasy.client.ClientResponse<?>)source).getEntity(String.class);
+                entity = ((org.jboss.resteasy.client.ClientResponse<?>)source).getEntity(type);
             } else {
                 entity = source.getEntity();
             }

--- a/usage/rest-client/src/main/java/brooklyn/util/http/BuiltResponsePreservingError.java
+++ b/usage/rest-client/src/main/java/brooklyn/util/http/BuiltResponsePreservingError.java
@@ -53,7 +53,6 @@ public class BuiltResponsePreservingError extends BuiltResponse {
             status = source.getStatus();
             headers.putAll(source.getHeaders());
             if (source instanceof org.jboss.resteasy.client.ClientResponse) {
-                // ClientResponse requires strong type info, which we don't yet have
                 entity = ((org.jboss.resteasy.client.ClientResponse<?>)source).getEntity(type);
             } else {
                 entity = source.getEntity();


### PR DESCRIPTION
Previously the Response was read into a String, which makes it difficult
to convert back into the domain object.