### PR TITLE
Riak uses ulimit configuration recommended in Basho's docs

### DIFF
--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNode.java
@@ -72,7 +72,12 @@ public interface RiakNode extends SoftwareProcess {
 
     ConfigKey<String> RIAK_CONF_ADDITIONAL_CONTENT = ConfigKeys.newStringConfigKey(
             "riak.riakConf.additionalContent", "Template file (in freemarker format) for setting up additional settings in the riak.conf file", "");
-
+    
+    // maxOpenFiles' default value (65536) is based on the Basho's recommendation - http://docs.basho.com/riak/latest/ops/tuning/open-files-limit/ 
+    @SetFromFlag("maxOpenFiles")
+    ConfigKey<Integer> RIAK_MAX_OPEN_FILES = ConfigKeys.newIntegerConfigKey(
+            "riak.max.open.files", "Number of the open files required by Riak", 65536);
+    
     @SetFromFlag("downloadUrlRhelCentos")
     AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL_RHEL_CENTOS = ConfigKeys.newTemplateSensorAndConfigKey("download.url.rhelcentos",
             "URL pattern for downloading the linux RPM installer (will substitute things like ${version} automatically)",

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -43,6 +43,7 @@ import brooklyn.util.config.ConfigBag;
 import brooklyn.util.guava.Functionals;
 import brooklyn.util.time.Duration;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.ContiguousSet;
@@ -70,6 +71,11 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
         // fail fast if config files not avail
         Entities.getRequiredUrlConfig(this, RIAK_VM_ARGS_TEMPLATE_URL);
         Entities.getRequiredUrlConfig(this, RIAK_APP_CONFIG_TEMPLATE_URL);
+        
+        Integer defaultMaxOpenFiles = RIAK_MAX_OPEN_FILES.getDefaultValue();
+        Integer maxOpenFiles = getConfig(RiakNode.RIAK_MAX_OPEN_FILES);
+        Preconditions.checkArgument(maxOpenFiles >= defaultMaxOpenFiles , "Specified number of open files : %s : is less than the required minimum",
+                maxOpenFiles, defaultMaxOpenFiles);
     }
 
     public boolean isPackageDownloadUrlProvided() {

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -314,7 +314,7 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
 
         if (isPackageInstall()) {
             commands.add(addSbinPathCommand());
-            commands.add(sudo("service riak start"));
+            commands.add(sudo(format("sh -c \"ulimit -n %s && service riak start\"", maxOpenFiles())));
         } else {
             // NOTE: See instructions at http://superuser.com/questions/433746/is-there-a-fix-for-the-too-many-open-files-in-system-error-on-os-x-10-7-1
             // for increasing the system limit for number of open files
@@ -593,5 +593,9 @@ public class RiakNodeSshDriver extends AbstractSoftwareProcessSshDriver implemen
         Map<String, String> newPathVariable = ImmutableMap.of("PATH", sbinPath);
 //        log.warn("riak command not found on PATH. Altering future commands' environment variables from {} to {}", getShellEnvironment(), newPathVariable);
         scriptHelper.environmentVariablesReset(newPathVariable);
+    }
+
+    public Integer maxOpenFiles() {
+        return entity.getConfig(RiakNode.RIAK_MAX_OPEN_FILES);
     }
 }


### PR DESCRIPTION
Riak has a specific requirement for the number of the allowed open files. It is described at http://docs.basho.com/riak/latest/ops/tuning/open-files-limit/.

Riak generates a warning message if the limit is bellow 65536.
```
# /etc/init.d/riak start
Starting riak: !!!!
!!!! WARNING: ulimit -n is 1024; 65536 is the recommended minimum.
!!!!

```
This PR provides configuration parameter for the number of the open files. The number of open files will default to the recommended value (65536) in case provided value is less than it. 