### PR TITLE
Change to install or run dir before executing configured pre and post commands

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/AbstractSoftwareProcessSshDriver.java
@@ -291,22 +291,22 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
 
     @Override
     public void runPreInstallCommand(String command) {
-        execute(ImmutableList.of(command), "running pre-install commands");
+        execute(ImmutableList.of("cd " + getInstallDir(), command), "running pre-install commands");
     }
 
     @Override
     public void runPostInstallCommand(String command) {
-        execute(ImmutableList.of(command), "running post-install commands");
+        execute(ImmutableList.of("cd " + getInstallDir(), command), "running post-install commands");
     }
 
     @Override
     public void runPreLaunchCommand(String command) {
-        execute(ImmutableList.of(command), "running pre-launch commands");
+        execute(ImmutableList.of("cd " + getRunDir(), command), "running pre-launch commands");
     }
 
     @Override
     public void runPostLaunchCommand(String command) {
-        execute(ImmutableList.of(command), "running post-launch commands");
+        execute(ImmutableList.of("cd " + getRunDir(), command), "running post-launch commands");
     }
 
     /**


### PR DESCRIPTION
This means that pre-install and post-install commands run in `$INSTALL_DIR` and pre-launch and post-launch run in `$RUN_DIR`