### PR TITLE
Set explicit versions for conflicting transitive dependencies

### DIFF
--- a/examples/webapps/hello-world-sql/pom.xml
+++ b/examples/webapps/hello-world-sql/pom.xml
@@ -46,11 +46,25 @@
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
         <version>${fasterxml.jackson.version}</version>
+        <exclusions>
+            <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda</artifactId>
         <version>${fasterxml.jackson.version}</version>
+        <exclusions>
+            <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
         <dependency>
             <groupId>mysql</groupId>
@@ -66,6 +80,21 @@
             <groupId>com.basho.riak</groupId>
             <artifactId>riak-client</artifactId>
             <version>${riak.version}</version>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-joda</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,15 @@
         <winrm4j.version>0.1.0</winrm4j.version>
         <coverage.target>${working.dir}</coverage.target>
 
+        <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
+        <clojure.version>1.4.0</clojure.version>
+        <zookeeper.version>3.3.4</zookeeper.version>
+        <ring-core.version>1.1.5</ring-core.version>
+        <clj-time.version>0.4.1</clj-time.version>
+        <commons-codec.version>1.9</commons-codec.version>
+        <log4j.version>1.2.17</log4j.version>
+        <commons-logging.version>1.2</commons-logging.version>
+
         <!-- Release -->
         <!-- no passphrase by default, so we can do automated deploy builds;
              you can still supply your own passphrase with -Dgpg.passphrase=XXX -->
@@ -1107,6 +1116,7 @@
                                 <requireMavenVersion>
                                     <version>[3.0.0,)</version>
                                 </requireMavenVersion>
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </execution>

--- a/software/messaging/pom.xml
+++ b/software/messaging/pom.xml
@@ -174,6 +174,17 @@
             <artifactId>kafka</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <!-- for storm -->
@@ -184,18 +195,117 @@
 			<!-- keep storm out of the jar-with-dependencies -->
             <scope>test</scope>
             <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.clojure</groupId>
+                    <artifactId>clojure</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ring</groupId>
+                    <artifactId>ring-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>clj-time</groupId>
+                    <artifactId>clj-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- Transitive dependencies, declared explicitly due to version mismatch -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>clojure</artifactId>
+            <version>${clojure.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>ring</groupId>
+            <artifactId>ring-core</artifactId>
+            <version>${ring-core.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>org.clojure</groupId>
+                    <artifactId>clojure</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>clj-time</groupId>
+                    <artifactId>clj-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>clj-time</groupId>
+            <artifactId>clj-time</artifactId>
+            <version>${clj-time.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>org.clojure</groupId>
+                    <artifactId>clojure</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <!-- End of transitive dependencies -->
     </dependencies>
 
 </project>

--- a/software/nosql/pom.xml
+++ b/software/nosql/pom.xml
@@ -38,6 +38,17 @@
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-software-base</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
@@ -118,6 +129,7 @@
             <version>${astyanax.version}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
@@ -125,6 +137,10 @@
                 <exclusion>
                     <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -142,6 +158,15 @@
             <version>${jcouchdb.version}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
@@ -203,6 +228,18 @@
             <artifactId>brooklyn-locations-jclouds</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Transitive dependencies, declared explicitly due to version mismatch -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons-logging.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/usage/camp/pom.xml
+++ b/usage/camp/pom.xml
@@ -78,6 +78,13 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.1</version>
+            <exclusions>
+                <!-- Dependency versions mismatch between transitive dependencies, declare explicitly -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- TODO not enamoured of including software-base here, but it allows us to reference chef and vanilla for short names;
@@ -132,6 +139,13 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Transitive dependencies, declared explicitly due to version mismatch -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons-logging.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Also check if transitive dependencies' versions match during build - `dependencyConvergence` rule in the enforcer plugin.