### PR TITLE
Remove redundant (and failing) test

### DIFF
--- a/core/src/test/java/brooklyn/event/feed/http/HttpFeedTest.java
+++ b/core/src/test/java/brooklyn/event/feed/http/HttpFeedTest.java
@@ -51,6 +51,7 @@ import brooklyn.util.collections.MutableMap;
 import brooklyn.util.guava.Functionals;
 import brooklyn.util.http.BetterMockWebServer;
 import brooklyn.util.http.HttpToolResponse;
+import brooklyn.util.net.Networking;
 import brooklyn.util.time.Duration;
 
 import com.google.common.base.Function;
@@ -301,28 +302,14 @@ public class HttpFeedTest extends BrooklynAppUnitTestSupport {
 
 
     @Test
-    public void testPollsAndParsesHttpErrorResponseWild() throws Exception {
-        feed = HttpFeed.builder()
-                .entity(entity)
-                .baseUri("http://0.0.0.0")
-                .poll(HttpPollConfig.forSensor(SENSOR_STRING)
-                        .onSuccess(Functions.constant("success"))
-                        .onFailure(Functions.constant("failure"))
-                        .onException(Functions.constant("error")))
-                .build();
-        
-        assertSensorEventually(SENSOR_STRING, "error", TIMEOUT_MS);
-    }
-    
-    @Test
     public void testPollsAndParsesHttpErrorResponseLocal() throws Exception {
+        int unboundPort = Networking.nextAvailablePort(10000);
         feed = HttpFeed.builder()
                 .entity(entity)
-                // combo of port 46069 and unknown path will hopefully give an error
-                // (without the port, in jenkins it returns some bogus success page)
-                .baseUri("http://localhost:46069/path/should/not/exist")
+                .baseUri("http://localhost:" + unboundPort + "/path/should/not/exist")
                 .poll(new HttpPollConfig<String>(SENSOR_STRING)
                         .onSuccess(Functions.constant("success"))
+                        .onFailure(Functions.constant("failure"))
                         .onException(Functions.constant("error")))
                 .build();
         

--- a/software/base/src/test/java/brooklyn/entity/basic/lifecycle/StartStopSshDriverTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/lifecycle/StartStopSshDriverTest.java
@@ -26,9 +26,9 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -116,7 +116,7 @@ public class StartStopSshDriverTest {
             @Override
             public void run() {
               List<ThreadInfo> currentThreads = getThreadsCalling(StreamGobbler.class);
-              Collection<Long> currentThreadIds = MutableSet.copyOf(getThreadId(currentThreads));
+              Set<Long> currentThreadIds = MutableSet.copyOf(getThreadId(currentThreads));
 
               currentThreadIds.removeAll(existingThreadIds);
               assertEquals(currentThreadIds, ImmutableSet.<Long>of());


### PR DESCRIPTION
Functionality covered with next test (without it being integration). Turns out IP 0.0.0.0 points to localhost ports. Ad blockers should reconsider using it :).
Also use port which is known to not be bound, instead of hard coding.