### PR TITLE
Jsgui tweaks

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/css/base.css
+++ b/usage/jsgui/src/main/webapp/assets/css/base.css
@@ -1114,6 +1114,11 @@ tr.app-add-wizard-config-entry {
     margin-bottom: 6px;
     background-color: #F0F0F0;
     border-radius: 5px;
+    overflow-y: scroll;
+}
+.catalog-accordion-wrapper .accordion-nav-row {
+    white-space: pre;
+    word-wrap: normal;
 }
 .accordion-item {
     -webkit-border-radius: 5px;

--- a/usage/jsgui/src/main/webapp/assets/js/util/brooklyn-utils.js
+++ b/usage/jsgui/src/main/webapp/assets/js/util/brooklyn-utils.js
@@ -188,6 +188,32 @@ define([
         });
     }
 
+    Util.setSelectionRange = function (input, selectionStart, selectionEnd) {
+      if (input.setSelectionRange) {
+        input.focus();
+        input.setSelectionRange(selectionStart, selectionEnd);
+      }
+      else if (input.createTextRange) {
+        var range = input.createTextRange();
+        range.collapse(true);
+        range.moveEnd('character', selectionEnd);
+        range.moveStart('character', selectionStart);
+        range.select();
+      }
+    };
+            
+    Util.setCaretToPos = function (input, pos) {
+      Util.setSelectionRange(input, pos, pos);
+    };
+
+    $.fn.setCaretToStart = function() {
+      this.each(function(index, elem) {
+        Util.setCaretToPos(elem, 0);
+        $(elem).scrollTop(0);
+      });
+      return this;
+    };
+
     $("#logout-link").on("click", function (e) {
         e.preventDefault();
         Util.logout()

--- a/usage/jsgui/src/main/webapp/assets/js/view/application-add-wizard.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/application-add-wizard.js
@@ -280,7 +280,7 @@ define([
                     if (yaml) {
                         // it's a yaml catalog template which includes a location, show the yaml tab
            	            $("ul#app-add-wizard-create-tab").find("a[href='#yamlTab']").tab('show');
-                        $("#yaml_code").focus();
+                        $("#yaml_code").setCaretToStart();
                     } else {
                         // it's a java catalog template or yaml template without a location, go to wizard
                         this.currentStep += 1;
@@ -302,7 +302,7 @@ define([
                     that.model.spec.pruneLocations();
                     $("textarea#yaml_code").val(JsYaml.safeDump(oldSpecToCamp(that.model.spec.toJSON())));
                     $("ul#app-add-wizard-create-tab").find("a[href='#yamlTab']").tab('show');
-                    $("#yaml_code").focus();
+                    $("#yaml_code").setCaretToStart();
                 });
             } else {
                 // call to validate should showFailure

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-config.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-config.js
@@ -176,30 +176,24 @@ define([
             
             this.zeroClipboard = new ZeroClipboard();
             this.zeroClipboard.on( "dataRequested" , function(client) {
-                var text = $(this).attr('copy-value');
-                if (!text) text = $(this).closest('.floatGroup').find('.value').html();
                 try {
-//                    log("Copying text '"+text+"' to clipboard");
+                    // the zeroClipboard instance is a singleton so check our scope first
+                    if (!$(this).closest("#config-table").length) return;
+                    var text = $(this).attr('copy-value');
+                    if (!text) text = $(this).closest('.floatGroup').find('.value').html();
+                    
+//                    log("Copying config text '"+text+"' to clipboard");
                     client.setText(text);
                     
-                    var $widget = $(this);
-                    var oldHtml = $widget.html();
-                    var fnRestore = _.once(function() { $widget.html(oldHtml); });
-                    // show the word copied for feedback;
+                    // show the word "copied" for feedback;
                     // NB this occurs on mousedown, due to how flash plugin works
                     // (same style of feedback and interaction as github)
                     // the other "clicks" are now triggered by *mouseup*
+                    var $widget = $(this);
+                    var oldHtml = $widget.html();
                     $widget.html('<b>Copied!</b>');
-                    setTimeout(fnRestore, 3000);
-                    
-                    // these listeners stay registered until page is reloaded
-                    // but they do nothing after first run, due to use of _.once
-                    // however the timeout is good enough, and actually desired
-                    // because on corner case of mousedown-moveaway-mouseup,
-                    // we want to keep the feedback; so they work, but are disabled for now.
-                    // (remove once we are happy with this behaviour, since Feb 2014)
-//                    that.zeroClipboard.on( "mouseout", fnRestore);
-//                    that.zeroClipboard.on( "mouseup", fnRestore);
+                    // use a timeout to restore because mouseouts can leave corner cases (see history)
+                    setTimeout(function() { $widget.html(oldHtml); }, 600);
                 } catch (e) {
                     log("Zeroclipboard failure; falling back to prompt mechanism");
                     log(e);
@@ -229,7 +223,10 @@ define([
         floatMenuActive: false,
         lastFloatMenuRowId: null,
         lastFloatFocusInTextForEventUnmangling: null,
-        updateFloatMenus: function() { this.zeroClipboard.clip( $('.valueCopy') ); },
+        updateFloatMenus: function() {
+            $('#config-table *[rel="tooltip"]').tooltip();
+            this.zeroClipboard.clip( $('.valueCopy') );
+        },
         showFloatLeft: function(event) {
             this.noteFloatMenuFocusChange(true, event, "show-left");
             this.showFloatLeftOf($(event.currentTarget));

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
@@ -184,30 +184,24 @@ define([
             
             this.zeroClipboard = new ZeroClipboard();
             this.zeroClipboard.on( "dataRequested" , function(client) {
-                var text = $(this).attr('copy-value');
-                if (!text) text = $(this).closest('.floatGroup').find('.value').html();
                 try {
-//                    log("Copying text '"+text+"' to clipboard");
+                    // the zeroClipboard instance is a singleton so check our scope first
+                    if (!$(this).closest("#sensors-table").length) return;
+                    var text = $(this).attr('copy-value');
+                    if (!text) text = $(this).closest('.floatGroup').find('.value').html();
+                    
+//                    log("Copying sensors text '"+text+"' to clipboard");
                     client.setText(text);
                     
-                    var $widget = $(this);
-                    var oldHtml = $widget.html();
-                    var fnRestore = _.once(function() { $widget.html(oldHtml); });
-                    // show the word copied for feedback;
+                    // show the word "copied" for feedback;
                     // NB this occurs on mousedown, due to how flash plugin works
                     // (same style of feedback and interaction as github)
                     // the other "clicks" are now triggered by *mouseup*
+                    var $widget = $(this);
+                    var oldHtml = $widget.html();
                     $widget.html('<b>Copied!</b>');
-                    setTimeout(fnRestore, 3000);
-                    
-                    // these listeners stay registered until page is reloaded
-                    // but they do nothing after first run, due to use of _.once
-                    // however the timeout is good enough, and actually desired
-                    // because on corner case of mousedown-moveaway-mouseup,
-                    // we want to keep the feedback; so they work, but are disabled for now.
-                    // (remove once we are happy with this behaviour, since Feb 2014)
-//                    that.zeroClipboard.on( "mouseout", fnRestore);
-//                    that.zeroClipboard.on( "mouseup", fnRestore);
+                    // use a timeout to restore because mouseouts can leave corner cases (see history)
+                    setTimeout(function() { $widget.html(oldHtml); }, 600);
                 } catch (e) {
                     log("Zeroclipboard failure; falling back to prompt mechanism");
                     log(e);
@@ -248,7 +242,10 @@ define([
         floatMenuActive: false,
         lastFloatMenuRowId: null,
         lastFloatFocusInTextForEventUnmangling: null,
-        updateFloatMenus: function() { this.zeroClipboard.clip( $('.valueCopy') ); },
+        updateFloatMenus: function() {
+            $('#sensors-table *[rel="tooltip"]').tooltip();
+            this.zeroClipboard.clip( $('.valueCopy') );
+        },
         showFloatLeft: function(event) {
             this.noteFloatMenuFocusChange(true, event, "show-left");
             this.showFloatLeftOf($(event.currentTarget));

--- a/usage/jsgui/src/main/webapp/assets/tpl/apps/config-name.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/apps/config-name.html
@@ -23,7 +23,7 @@ under the License.
     title="<% 
          if (description) { %><b><%- description %></b><br/><% } 
          if (type) { %>(<% 
-           if (type.startsWith("java.lang.") || type.startsWith("util.")) type = type.substring(10);
+           if (type.startsWith("java.lang.") || type.startsWith("java.util.")) type = type.substring(10);
          %><%- type %>)<% } %>">
     <%- name %>
 </span>

--- a/usage/jsgui/src/main/webapp/assets/tpl/apps/config-name.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/apps/config-name.html
@@ -18,7 +18,17 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<% if (description || type) { %>
 <span class="config-name" rel="tooltip" data-placement="left"
-    title="<% if (description) { %><b><%- description %></b><br/><% } %>(<%- type %>)">
+    title="<% 
+         if (description) { %><b><%- description %></b><br/><% } 
+         if (type) { %>(<% 
+           if (type.startsWith("java.lang.") || type.startsWith("util.")) type = type.substring(10);
+         %><%- type %>)<% } %>">
     <%- name %>
 </span>
+<% } else { %>
+<span class="config-name">
+    <%- name %>
+</span>
+<% } %>

--- a/usage/jsgui/src/main/webapp/assets/tpl/apps/sensor-name.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/apps/sensor-name.html
@@ -18,7 +18,17 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<% if (description || type) { %>
 <span class="sensor-name" rel="tooltip" data-placement="left"
-    title="<% if (description) { %><b><%- description %></b><br/><% } %>(<%- type %>)">
+    title="<% 
+         if (description) { %><b><%- description %></b><br/><% } 
+         if (type) { %>(<% 
+           if (type.startsWith("java.lang.") || type.startsWith("util.")) type = type.substring(10);
+         %><%- type %>)<% } %>">
     <%- name %>
 </span>
+<% } else { %>
+<span class="sensor-name">
+    <%- name %>
+</span>
+<% } %>

--- a/usage/jsgui/src/main/webapp/assets/tpl/apps/sensor-name.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/apps/sensor-name.html
@@ -23,7 +23,7 @@ under the License.
     title="<% 
          if (description) { %><b><%- description %></b><br/><% } 
          if (type) { %>(<% 
-           if (type.startsWith("java.lang.") || type.startsWith("util.")) type = type.substring(10);
+           if (type.startsWith("java.lang.") || type.startsWith("java.util.")) type = type.substring(10);
          %><%- type %>)<% } %>">
     <%- name %>
 </span>


### PR DESCRIPTION
* config+sensors tooltip renders nicely
* catalog items listed in accordion view don't wrap
* yaml preview window focuses at the top not the bottom (for long blueprints)

The second one needs tested on windows to ensure scrollbars don't clutter.

You can test 2 and 3 with:

```
brooklyn.catalog:
  items:
  - id: foo-bar-baz-foo-bar-baz-foo-bar-baz-foo-bar-baz-foo-bar-baz-foo-bar-baz-foo-bar-baz_boo
    itemType: template
    item:
      location: localhost
      services:
      - type:  brooklyn.entity.basic.BasicEntity
        brooklyn.config:
         x:
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
          blah
```