### PR TITLE
clean up how locations are rendered in the js gui, and expand "delete"

### DIFF
--- a/core/src/main/java/brooklyn/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/brooklyn/catalog/internal/BasicBrooklynCatalog.java
@@ -355,6 +355,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 default: throw new RuntimeException("Only entity, policy & location catalog items are supported. Unsupported catalog item type " + item.getCatalogItemType());
             }
             ((AbstractBrooklynObjectSpec<?, ?>)spec).catalogItemId(item.getId());
+            
+            if (Strings.isBlank( ((AbstractBrooklynObjectSpec<?, ?>)spec).getDisplayName() ))
+                ((AbstractBrooklynObjectSpec<?, ?>)spec).displayName(item.getDisplayName());
+            
             return spec;
         }
 

--- a/usage/jsgui/src/main/webapp/assets/js/model/catalog-item-summary.js
+++ b/usage/jsgui/src/main/webapp/assets/js/model/catalog-item-summary.js
@@ -19,8 +19,9 @@
 define(["underscore", "backbone"], function (_, Backbone) {
 
     // NB: THIS IS NOT USED CURRENTLY
-    // the logic in application-add-wizard.js simply loads and manipulates json
-    // TODO change that so that it uses this backbone model + collection 
+    // the logic in application-add-wizard.js simply loads and manipulates json;
+    // logic in catalog.js (view) defines its own local model
+    // TODO change those so that they use this backbone model + collection,
     // allowing a way to specify on creation what we are looking up in the catalog -- apps or entities or policies
     
     var CatalogItem = {}
@@ -40,7 +41,7 @@ define(["underscore", "backbone"], function (_, Backbone) {
 
     CatalogItem.Collection = Backbone.Collection.extend({
         model:CatalogItem.Model,
-        url:'/v1/catalog'  // TODO is this application or entities or policies?
+        url:'/v1/catalog'  // TODO is this application or entities or policies? (but note THIS IS NOT USED)
     })
 
     return CatalogItem

--- a/usage/jsgui/src/main/webapp/assets/js/model/location.js
+++ b/usage/jsgui/src/main/webapp/assets/js/model/location.js
@@ -69,6 +69,12 @@ define(["underscore", "backbone"], function (_, Backbone) {
             name = this.get('name')
             if (name!=null && name.length>0) return name
             return this.get('spec')
+        },
+        getIdentifierName: function() {
+            var name = null;
+            name = this.get('name')
+            if (name!=null && name.length>0) return name
+            return this.get('spec')
         }
 
     })

--- a/usage/jsgui/src/main/webapp/assets/tpl/catalog/details-entity.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/catalog/details-entity.html
@@ -16,7 +16,12 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+
 <div class="catalog-details">
+
+    <div class="float-right">
+        <button data-name="<%= model.id %>" class="btn btn-danger delete">Delete</button>
+    </div>
 
     <% if (model.get("name") != model.get("symbolicName")) { %>
         <h2><%- model.get("name") %></h2>

--- a/usage/jsgui/src/main/webapp/assets/tpl/catalog/details-generic.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/catalog/details-generic.html
@@ -19,6 +19,10 @@ under the License.
 
 <div class="catalog-details">
 
+    <div class="float-right">
+        <button data-name="<%= model.id %>" class="btn btn-danger delete">Delete</button>
+    </div>
+
     <% if (model.get("name") !== undefined) { %>
         <h2><%= model.get("name") %></h2>
     <% } else if (model.get("type") !== undefined) { %>

--- a/usage/jsgui/src/main/webapp/assets/tpl/catalog/details-location.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/catalog/details-location.html
@@ -16,26 +16,30 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
+
 <div class="catalog-details">
 
-    <h3><%- model.getPrettyName() %></h3>
+    <h3><%- model.getIdentifierName() %></h3>
 
     <div class="float-right">
-        <button data-name="<%= model.getPrettyName() %>" class="btn btn-danger delete">Delete</button>
+        <button data-name="<%= model.getIdentifierName() %>" class="btn btn-danger delete">Delete</button>
     </div>
-
-<% if (!model.get("config") || _.isEmpty(model.get("config"))) { %>
-    <em>No special configuration</em>
-<% } else { %>
 
     <br/>
     <table>
-        <tr><td><strong>ID:</strong>&nbsp;&nbsp;</td><td><%- model.get("id") || "" %></td></tr>
-        <tr><td><strong>Name:</strong>&nbsp;&nbsp;</td><td><%- model.get("name") || "" %></td></tr>
-        <tr><td><strong>Spec:</strong>&nbsp;&nbsp;</td><td><%- model.get("spec") || "" %></td></tr>
+        <tr><td><strong>Display Name:</strong>&nbsp;&nbsp;</td><td><%- model.getPrettyName() || "" %></td></tr>
+        <tr><td><strong>Reference Name:</strong>&nbsp;&nbsp;</td><td><%- model.get("name") || "" %></td></tr>
+        <tr><td><strong>Internal ID:</strong>&nbsp;&nbsp;</td><td><%- model.get("id") || "" %></td></tr>
+        <tr><td><strong>Implementation Spec:</strong>&nbsp;&nbsp;</td><td><%- model.get("spec") || "" %></td></tr>
     </table>
     
     <br/>
+    
+<% if (!model.get("config") || _.isEmpty(model.get("config"))) { %>
+    <!-- either no config or it comes from a yaml plan and config not yet available;
+         TODO need to use the /v1/catalog/location API not the /v1/locations/ API -->
+<% } else { %>
+
     <table class="table table-striped table-condensed nonDatatables">
         <thead><tr>
             <th>Configuration Key</th>

--- a/usage/rest-api/src/main/java/brooklyn/rest/api/CatalogApi.java
+++ b/usage/rest-api/src/main/java/brooklyn/rest/api/CatalogApi.java
@@ -94,6 +94,19 @@ public interface CatalogApi {
         @PathParam("entityId") String entityId) throws Exception;
 
     @DELETE
+    @Path("/applications/{applicationId}/{version}")
+    @ApiOperation(value = "Deletes a specific version of an application's definition from the catalog")
+    @ApiErrors(value = {
+        @ApiError(code = 404, reason = "Entity not found")
+    })
+    public void deleteApplication(
+        @ApiParam(name = "applicationId", value = "The ID of the application or template to delete", required = true)
+        @PathParam("applicationId") String entityId,
+
+        @ApiParam(name = "version", value = "The version identifier of the application or template to delete", required = true)
+        @PathParam("version") String version) throws Exception;
+
+    @DELETE
     @Path("/entities/{entityId}/{version}")
     @ApiOperation(value = "Deletes a specific version of an entity's definition from the catalog")
     @ApiErrors(value = {

--- a/usage/rest-server/src/main/java/brooklyn/rest/resources/CatalogResource.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/resources/CatalogResource.java
@@ -160,6 +160,11 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
     }
 
     @Override
+    public void deleteApplication(String applicationId, String version) throws Exception {
+        deleteEntity(applicationId, version);
+    }
+
+    @Override
     public void deleteEntity(String entityId, String version) throws Exception {
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.MODIFY_CATALOG_ITEM, StringAndArgument.of(entityId+(Strings.isBlank(version) ? "" : ":"+version), "delete"))) {
             throw WebResourceUtils.unauthorized("User '%s' is not authorized to modify catalog",

--- a/usage/rest-server/src/test/java/brooklyn/rest/resources/ApiDocResourceTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/resources/ApiDocResourceTest.java
@@ -98,7 +98,7 @@ public class ApiDocResourceTest extends BrooklynRestResourceTest {
     @Test
     public void testCatalogDetails() throws Exception {
         ApidocRoot response = client().resource("/v1/apidoc/brooklyn.rest.resources.CatalogResource").get(ApidocRoot.class);
-        assertEquals(countOperations(response), 21, "ops="+getOperations(response));
+        assertEquals(countOperations(response), 22, "ops="+getOperations(response));
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
there was (is) confusion between catalog name and location displayName and a named location.
it deserves a major sort-out, i think treating location defs as catalog items and location instances as entities;
and only using the catalog api, not a dedicated locations api (or if there is, it delegates to catalog),
also removing all the LocationManager blah.

but until then we needed something which avoided confusion where catalog item names for locations
aren't rendered, and magic display names from location-metadata were being showed so it looked
like nothing was being added, though the location worked.

for locations, a catalog item name now does nothing, but the location's name (i.e. human-readable ID aka catalog item ID, not the display name)
is shown in the catalog accordion list (the "IdentifierName"), better info (but not the full yaml yet) is shown in the detail,
and versions are at least handled without bugs, even if only one version for location is really supported in the gui.

also adds delete for entity and apps and policies, and fixes delete for locations.

@nakomis this should help prevent the user-confusion which you experienced