### PR TITLE
BROOKLYN-137 stopIptables and openIptables don't work on CentOS7

### DIFF
--- a/utils/common/src/main/java/brooklyn/util/ssh/IptablesCommands.java
+++ b/utils/common/src/main/java/brooklyn/util/ssh/IptablesCommands.java
@@ -89,6 +89,33 @@ public class IptablesCommands {
         return iptablesService("status");
     }
 
+    @Beta // implementation not portable across distros
+    public static String firewalldService(String cmd) {
+        return sudo(alternatives(
+                BashCommands.ifExecutableElse1("systemctl", "systemctl " + cmd + " firewalld"),
+                "/usr/bin/systemctl " + cmd + " firewalld"));
+    }
+
+    @Beta // implementation not portable across distros
+    public static String firewalldServiceStop() {
+        return firewalldService("stop");
+    }
+
+    @Beta // implementation not portable across distros
+    public static String firewalldServiceStart() {
+        return firewalldService("start");
+    }
+
+    @Beta // implementation not portable across distros
+    public static String firewalldServiceRestart() {
+        return firewalldService("restart");
+    }
+
+    @Beta // implementation not portable across distros
+    public static String firewalldServiceStatus() {
+        return firewalldService("status");
+    }
+    
     /**
      * Returns the command that saves iptables rules on file.
      *
@@ -201,4 +228,29 @@ public class IptablesCommands {
         return addIptablesRule(direction, chain, networkInterface, protocol.convert(), port, policy);
     }
 
+    /**
+     * Returns the command that adds firewalld direct rule.
+     *
+     * @return Returns the command that adds firewalld direct rule.
+     */
+    public static String addFirewalldRule(Chain chain, brooklyn.util.net.Protocol protocol, int port, Policy policy) {
+        return addFirewalldRule(chain, Optional.<String>absent(), protocol, port, policy);
+    }
+    
+    /**
+     * Returns the command that adds firewalld direct rule.
+     *
+     * @return Returns the command that adds firewalld direct rule.
+     */
+    public static String addFirewalldRule(Chain chain, Optional<String> networkInterface, brooklyn.util.net.Protocol protocol, int port, Policy policy) {
+        String command = new String("/usr/bin/firewall-cmd");
+        String commandPermanent = new String("/usr/bin/firewall-cmd --permanent");
+        
+        String interfaceParameter = String.format("%s", networkInterface.isPresent() ? " -i " + networkInterface.get() : "");
+        
+        String commandParameters = String.format(" --direct --add-rule ipv4 filter %s 0 %s -p %s --dport %d -j %s", 
+                                                                chain, interfaceParameter,  protocol, port, policy);
+        
+        return sudo(chain(command + commandParameters, commandPermanent + commandParameters));
+    }
 }

--- a/utils/common/src/main/java/brooklyn/util/ssh/IptablesCommands.java
+++ b/utils/common/src/main/java/brooklyn/util/ssh/IptablesCommands.java
@@ -115,7 +115,12 @@ public class IptablesCommands {
     public static String firewalldServiceStatus() {
         return firewalldService("status");
     }
-    
+
+    @Beta // implementation not portable across distros
+    public static String firewalldServiceIsActive() {
+        return firewalldService("is-active");
+    }
+
     /**
      * Returns the command that saves iptables rules on file.
      *

--- a/utils/common/src/test/java/brooklyn/util/ssh/IptablesCommandsFirewalldTest.java
+++ b/utils/common/src/test/java/brooklyn/util/ssh/IptablesCommandsFirewalldTest.java
@@ -61,6 +61,11 @@ public class IptablesCommandsFirewalldTest {
             + "else echo \"( { which systemctl && systemctl stop firewalld ; } || "
             + "/usr/bin/systemctl stop firewalld )\" | sudo -E -n -S -s -- bash ; fi )";
 
+    private static final String firewalldServiceIsActive = "( if test \"$UID\" -eq 0; then ( ( { "
+            + "which systemctl && systemctl is-active firewalld ; } || /usr/bin/systemctl is-active firewalld ) ); "
+            + "else echo \"( { which systemctl && systemctl is-active firewalld ; } || /usr/bin/systemctl is-active firewalld )\" | "
+            + "sudo -E -n -S -s -- bash ; fi )";
+
     @Test
     public void testAddFirewalldRule() {
         Assert.assertEquals(IptablesCommands.addFirewalldRule(Chain.INPUT,
@@ -90,5 +95,10 @@ public class IptablesCommandsFirewalldTest {
     @Test
     public void testFirewalldServiceStop() {
         Assert.assertEquals(IptablesCommands.firewalldServiceStop(), firewalldServiceStop);
+    }
+
+    @Test
+    public void testFirewalldServiceIsActive() {
+        Assert.assertEquals(IptablesCommands.firewalldServiceIsActive(), firewalldServiceIsActive);
     }
 }

--- a/utils/common/src/test/java/brooklyn/util/ssh/IptablesCommandsFirewalldTest.java
+++ b/utils/common/src/test/java/brooklyn/util/ssh/IptablesCommandsFirewalldTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.util.ssh;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import brooklyn.util.net.Protocol;
+import brooklyn.util.ssh.IptablesCommands.Chain;
+import brooklyn.util.ssh.IptablesCommands.Policy;
+
+public class IptablesCommandsFirewalldTest {
+    private static final String addFirewalldRule = "( if test \"$UID\" -eq 0; then "
+            + "( ( /usr/bin/firewall-cmd --direct --add-rule ipv4 filter INPUT 0  -p tcp --dport 3306 -j ACCEPT "
+            + "&& /usr/bin/firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 0  -p tcp --dport 3306 -j ACCEPT ) ); "
+            + "else echo \"( /usr/bin/firewall-cmd --direct --add-rule ipv4 filter INPUT 0  -p tcp --dport 3306 -j ACCEPT "
+            + "&& /usr/bin/firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT 0  -p tcp --dport 3306 -j ACCEPT )\" "
+            + "| sudo -E -n -S -s -- bash ; fi )";
+
+    private static final String firewalldService = "( if test \"$UID\" -eq 0; then ( ( { "
+            + "which systemctl && systemctl status firewalld ; } || /usr/bin/systemctl status firewalld ) ); "
+            + "else echo \"( { which systemctl && systemctl status firewalld ; } || "
+            + "/usr/bin/systemctl status firewalld )\" | sudo -E -n -S -s -- bash ; fi )";
+
+    private static final String firewalldServiceRestart = "( if test \"$UID\" -eq 0; then ( ( { "
+            + "which systemctl && systemctl restart firewalld ; } || "
+            + "/usr/bin/systemctl restart firewalld ) ); else echo \"( { "
+            + "which systemctl && systemctl restart firewalld ; } || /usr/bin/systemctl restart firewalld )\" | "
+            + "sudo -E -n -S -s -- bash ; fi )";
+
+    private static final String firewalldServiceStart = "( if test \"$UID\" -eq 0; then ( ( { "
+            + "which systemctl && systemctl start firewalld ; } "
+            + "|| /usr/bin/systemctl start firewalld ) ); "
+            + "else echo \"( { which systemctl && systemctl start firewalld ; } || "
+            + "/usr/bin/systemctl start firewalld )\" | sudo -E -n -S -s -- bash ; fi )";
+
+    private static final String firewalldServiceStatus = "( if test \"$UID\" -eq 0; then ( ( { "
+            + "which systemctl && systemctl status firewalld ; "
+            + "} || /usr/bin/systemctl status firewalld ) ); else echo \"( { "
+            + "which systemctl && systemctl status firewalld ; } || "
+            + "/usr/bin/systemctl status firewalld )\" | sudo -E -n -S -s -- bash ; fi )";
+
+    private static final String firewalldServiceStop = "( if test \"$UID\" -eq 0; then ( ( { "
+            + "which systemctl && systemctl stop firewalld ; } || /usr/bin/systemctl stop firewalld ) ); "
+            + "else echo \"( { which systemctl && systemctl stop firewalld ; } || "
+            + "/usr/bin/systemctl stop firewalld )\" | sudo -E -n -S -s -- bash ; fi )";
+
+    @Test
+    public void testAddFirewalldRule() {
+        Assert.assertEquals(IptablesCommands.addFirewalldRule(Chain.INPUT,
+                Protocol.TCP, 3306, Policy.ACCEPT), addFirewalldRule);
+    }
+
+    @Test
+    public void testFirewalldService() {
+        Assert.assertEquals(IptablesCommands.firewalldService("status"), firewalldService);
+    }
+
+    @Test
+    public void testFirewalldServiceRestart() {
+        Assert.assertEquals(IptablesCommands.firewalldServiceRestart(), firewalldServiceRestart);
+    }
+
+    @Test
+    public void testFirewalldServiceStart() {
+        Assert.assertEquals(IptablesCommands.firewalldServiceStart(), firewalldServiceStart);
+    }
+
+    @Test
+    public void testFirewalldServiceStatus() {
+        Assert.assertEquals(IptablesCommands.firewalldServiceStatus(), firewalldServiceStatus);
+    }
+
+    @Test
+    public void testFirewalldServiceStop() {
+        Assert.assertEquals(IptablesCommands.firewalldServiceStop(), firewalldServiceStop);
+    }
+}


### PR DESCRIPTION
 Implemented to retain full backwards compatibility before the release

- Adding preliminary support for firewalld
- Starting/stopping/restrting of firewalld service
- Adding rules via firewalld's direct interface
- Tests