### PR TITLE
Fixes issue where port was not being opened if port range was overridden

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/SameServerDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SameServerDriverLifecycleEffectorTasks.java
@@ -29,6 +29,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.Entity;
@@ -40,6 +41,8 @@ import brooklyn.location.PortRange;
 import brooklyn.location.basic.LocationConfigKeys;
 import brooklyn.management.TaskAdaptable;
 import brooklyn.util.collections.MutableSet;
+import brooklyn.util.flags.TypeCoercions;
+import brooklyn.util.guava.Maybe;
 import brooklyn.util.task.DynamicTasks;
 
 public class SameServerDriverLifecycleEffectorTasks extends MachineLifecycleEffectorTasks {
@@ -64,9 +67,27 @@ public class SameServerDriverLifecycleEffectorTasks extends MachineLifecycleEffe
     /** @return the ports required for a specific child entity */
     protected Collection<Integer> getRequiredOpenPorts(Entity entity) {
         Set<Integer> ports = MutableSet.of(22);
+        /* TODO: This won't work if there's a port collision, which will cause the corresponding port attribute
+           to be incremented until a free port is found. In that case the entity will use the free port, but the
+           firewall will open the initial port instead. Mostly a problem for SameServerEntity, localhost location.
+        */
+        // TODO: Remove duplication between this and SoftwareProcessImpl.getRequiredOpenPorts
         for (ConfigKey<?> k: entity.getEntityType().getConfigKeys()) {
-            if (PortRange.class.isAssignableFrom(k.getType())) {
-                PortRange p = (PortRange) entity.getConfig(k);
+            Object value;
+            if (PortRange.class.isAssignableFrom(k.getType()) || k.getName().matches(".*\\.port")) {
+                value = entity.config().get(k);
+            } else {
+                // config().get() will cause this to block until all config has been resolved
+                // using config().getRaw(k) means that we won't be able to use e.g. 'http.port: $brooklyn:component("x").attributeWhenReady("foo")'
+                // but that's unlikely to be used
+                Maybe<Object> maybeValue = ((AbstractEntity.BasicConfigurationSupport)entity.config()).getRaw(k);
+                value = maybeValue.isPresent() ? maybeValue.get() : null;
+            }
+
+            Maybe<PortRange> maybePortRange = TypeCoercions.tryCoerce(value, new TypeToken<PortRange>() {});
+
+            if (maybePortRange.isPresentAndNonNull()) {
+                PortRange p = maybePortRange.get();
                 if (p != null && !p.isEmpty()) ports.add(p.iterator().next());
             }
         }

--- a/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
@@ -30,6 +30,7 @@ import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.entity.proxying.ImplementedBy;
 import brooklyn.entity.software.MachineLifecycleEffectorTasksTest;
 import brooklyn.entity.trait.Startable;
+import brooklyn.event.basic.PortAttributeSensorAndConfigKey;
 import brooklyn.location.Location;
 import brooklyn.location.LocationSpec;
 import brooklyn.location.basic.FixedListMachineProvisioningLocation;
@@ -59,6 +60,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -410,9 +412,18 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         doTestReleaseEvenIfErrorDuringStop(SimulatedFailInChildOnStopDriver.class);
     }
 
+    @Test
+    public void testOpenPortsWithPortRangeConfig() throws Exception {
+        MyService entity = app.createAndManageChild(EntitySpec.create(MyService.class)
+            .configure("http.port", "9999+"));
+        Assert.assertTrue(entity.getRequiredOpenPorts().contains(9999));
+    }
+
     @ImplementedBy(MyServiceImpl.class)
     public interface MyService extends SoftwareProcess {
+        PortAttributeSensorAndConfigKey HTTP_PORT = Attributes.HTTP_PORT;
         public SoftwareProcessDriver getDriver();
+        public Collection<Integer> getRequiredOpenPorts();
     }
 
     public static class MyServiceImpl extends SoftwareProcessImpl implements MyService {
@@ -425,7 +436,14 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         }
 
         @Override
-        public Class<?> getDriverInterface() { return SimulatedDriver.class; }
+        public Class<?> getDriverInterface() {
+            return SimulatedDriver.class;
+        }
+
+        @Override
+        public Collection<Integer> getRequiredOpenPorts() {
+            return super.getRequiredOpenPorts();
+        }
     }
 
     @ImplementedBy(MyServiceWithVersionImpl.class)


### PR DESCRIPTION
The following YAML was failing to open the port (8080 or 9090) in the AWS security group

```
location: aws-ec2:eu-west-1
services:
- type: brooklyn.entity.webapp.jboss.JBoss7Server
  brooklyn.config:
    http.port: 9090+
```