### PR TITLE
More integration test fixes

### DIFF
--- a/core/src/test/java/brooklyn/test/TestHttpRequestHandler.java
+++ b/core/src/test/java/brooklyn/test/TestHttpRequestHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+
+import brooklyn.util.exceptions.Exceptions;
+
+public class TestHttpRequestHandler implements HttpRequestHandler {
+    private HttpEntity entity;
+    private int responseCode = HttpStatus.SC_OK;
+    private Collection<Header> headers = new ArrayList<Header>();
+
+    public TestHttpRequestHandler response(String response) {
+        try {
+            this.entity = new StringEntity(response);
+        } catch (UnsupportedEncodingException e) {
+            throw Exceptions.propagate(e);
+        }
+        return this;
+    }
+
+    public TestHttpRequestHandler code(int responseCode) {
+        this.responseCode = responseCode;
+        return this;
+    }
+
+    public TestHttpRequestHandler header(String name, String value) {
+        headers.add(new BasicHeader(name, value));
+        return this;
+    }
+
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        for (Header h : headers) {
+            response.setHeader(h);
+        }
+
+        response.setStatusCode(responseCode);
+        response.setEntity(entity);
+    }
+
+}

--- a/core/src/test/java/brooklyn/test/TestHttpServer.java
+++ b/core/src/test/java/brooklyn/test/TestHttpServer.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.apache.http.protocol.ImmutableHttpProcessor;
+import org.apache.http.protocol.ResponseConnControl;
+import org.apache.http.protocol.ResponseContent;
+
+import brooklyn.util.collections.MutableList;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.net.Networking;
+
+public class TestHttpServer {
+    private static class HandlerTuple {
+        String path;
+        HttpRequestHandler handler;
+        public HandlerTuple(String path, HttpRequestHandler handler) {
+            this.path = path;
+            this.handler = handler;
+        }
+    }
+    private HttpServer server;
+    private List<HttpRequestInterceptor> requestInterceptors = MutableList.of();
+    private List<HttpResponseInterceptor> responseInterceptors = MutableList.of(new ResponseContent(), new ResponseConnControl());
+    private int basePort = 50505;
+    private Collection<HandlerTuple> handlers = MutableList.of();
+
+    public TestHttpServer interceptor(HttpResponseInterceptor interceptor) {
+        checkNotStarted();
+        responseInterceptors.add(interceptor);
+        return this;
+    }
+
+    public TestHttpServer requestInterceptors(List<HttpResponseInterceptor> interceptors) {
+        checkNotStarted();
+        this.responseInterceptors = interceptors;
+        return this;
+    }
+
+    public TestHttpServer interceptor(HttpRequestInterceptor interceptor) {
+        checkNotStarted();
+        requestInterceptors.add(interceptor);
+        return this;
+    }
+
+    public TestHttpServer responseInterceptors(List<HttpRequestInterceptor> interceptors) {
+        checkNotStarted();
+        this.requestInterceptors = interceptors;
+        return this;
+    }
+
+    public TestHttpServer basePort(int basePort) {
+        checkNotStarted();
+        this.basePort = basePort;
+        return this;
+    }
+
+    public TestHttpServer handler(String path, HttpRequestHandler handler) {
+        checkNotStarted();
+        handlers.add(new HandlerTuple(path, handler));
+        return this;
+    }
+
+    public TestHttpServer start() {
+        checkNotStarted();
+
+        HttpProcessor httpProcessor = new ImmutableHttpProcessor(requestInterceptors, responseInterceptors);
+        int port = Networking.nextAvailablePort(basePort);
+        ServerBootstrap bootstrap = ServerBootstrap.bootstrap()
+            .setListenerPort(port)
+            .setLocalAddress(getLocalAddress())
+            .setHttpProcessor(httpProcessor);
+
+        for (HandlerTuple tuple : handlers) {
+            bootstrap.registerHandler(tuple.path, tuple.handler);
+        }
+        server = bootstrap.create();
+
+        try {
+            server.start();
+        } catch (IOException e) {
+            throw Exceptions.propagate(e);
+        }
+
+        return this;
+    }
+
+    public void stop() {
+        server.stop();
+    }
+
+    private void checkNotStarted() {
+        if (server != null) {
+            throw new IllegalStateException("Server already started");
+        }
+    }
+
+    private InetAddress getLocalAddress() {
+        try {
+            return InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    public String getUrl() {
+        try {
+            return new URL("http", server.getInetAddress().getHostAddress(), server.getLocalPort(), "").toExternalForm();
+        } catch (MalformedURLException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+}

--- a/policy/src/test/java/brooklyn/policy/autoscaling/AutoScalerPolicyMetricTest.java
+++ b/policy/src/test/java/brooklyn/policy/autoscaling/AutoScalerPolicyMetricTest.java
@@ -125,7 +125,7 @@ public class AutoScalerPolicyMetricTest {
         Asserts.succeedsEventually(ImmutableMap.of("timeout", TIMEOUT_MS), currentSizeAsserter(tc, 2));
         
         tc.setAttribute(MY_ATTRIBUTE, 0);
-        Asserts.succeedsEventually(ImmutableMap.of("timeout", TIMEOUT_MS), currentSizeAsserter(tc, 0));
+        Asserts.succeedsEventually(ImmutableMap.of("timeout", TIMEOUT_MS), currentSizeAsserter(tc, 1));
     }
     
     @Test(groups="Integration")

--- a/usage/rest-server/src/test/java/brooklyn/rest/resources/CatalogResetTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/resources/CatalogResetTest.java
@@ -20,46 +20,24 @@ package brooklyn.rest.resources;
 
 import static org.testng.Assert.assertNotNull;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.InetAddress;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-
 import javax.ws.rs.core.MediaType;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpException;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.bootstrap.HttpServer;
-import org.apache.http.impl.bootstrap.ServerBootstrap;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.HttpProcessor;
-import org.apache.http.protocol.HttpRequestHandler;
-import org.apache.http.protocol.ImmutableHttpProcessor;
-import org.apache.http.protocol.ResponseConnControl;
-import org.apache.http.protocol.ResponseContent;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import brooklyn.catalog.BrooklynCatalog;
 import brooklyn.rest.testing.BrooklynRestResourceTest;
+import brooklyn.test.TestHttpRequestHandler;
+import brooklyn.test.TestHttpServer;
 import brooklyn.util.ResourceUtils;
-import brooklyn.util.exceptions.Exceptions;
-import brooklyn.util.net.Networking;
 
 import com.sun.jersey.api.client.UniformInterfaceException;
 
 public class CatalogResetTest extends BrooklynRestResourceTest {
 
-    private HttpServer server;
+    private TestHttpServer server;
     private String serverUrl;
 
     @BeforeClass(alwaysRun=true)
@@ -67,20 +45,11 @@ public class CatalogResetTest extends BrooklynRestResourceTest {
     public void setUp() throws Exception {
         useLocalScannedCatalog();
         super.setUp();
-        HttpProcessor httpProcessor = new ImmutableHttpProcessor(
-                new ResponseContent(),
-                new ResponseConnControl());
-
-        int port = Networking.nextAvailablePort(50505);
-        server = ServerBootstrap.bootstrap()
-            .setListenerPort(port)
-            .setLocalAddress(InetAddress.getLocalHost())
-            .setHttpProcessor(httpProcessor)
-            .registerHandler("/404", new ResponseHandler().code(HttpStatus.SC_NOT_FOUND).response("Not Found"))
-            .registerHandler("/200", new ResponseHandler().response("OK"))
-            .create();
-        server.start();
-        serverUrl = new URL("http", server.getInetAddress().getHostAddress(), server.getLocalPort(), "").toExternalForm();
+        server = new TestHttpServer()
+            .handler("/404", new TestHttpRequestHandler().code(HttpStatus.SC_NOT_FOUND).response("Not Found"))
+            .handler("/200", new TestHttpRequestHandler().response("OK"))
+            .start();
+        serverUrl = server.getUrl();
     }
 
     @Override
@@ -141,40 +110,4 @@ public class CatalogResetTest extends BrooklynRestResourceTest {
         assertNotNull(catalog.getCatalogItem("brooklyn.osgi.tests.SimpleApplication", BrooklynCatalog.DEFAULT_VERSION));
     }
 
-    private static class ResponseHandler implements HttpRequestHandler {
-        private HttpEntity entity;
-        private int responseCode = HttpStatus.SC_OK;
-        private Collection<Header> headers = new ArrayList<Header>();
-
-        public ResponseHandler response(String response) {
-            try {
-                this.entity = new StringEntity(response);
-            } catch (UnsupportedEncodingException e) {
-                throw Exceptions.propagate(e);
-            }
-            return this;
-        }
-
-        public ResponseHandler code(int responseCode) {
-            this.responseCode = responseCode;
-            return this;
-        }
-
-        @SuppressWarnings("unused")
-        public ResponseHandler header(String name, String value) {
-            headers.add(new BasicHeader(name, value));
-            return this;
-        }
-
-        @Override
-        public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
-            for (Header h : headers) {
-                response.setHeader(h);
-            }
-
-            response.setStatusCode(responseCode);
-            response.setEntity(entity);
-        }
-
-    }
 }


### PR DESCRIPTION
* Don't unmanage `BrooklynNode` until the STOP effector and all parent entity tasks complete. Prevents `CancellationException: null` error when the STOP effector is called from another effector (i.e. `STOP_NODE_AND_KILL_APPS`)
* AutoScaler now has a default min of 1 member
* Wait for all apps to be running before continuing tests in `BrooklynNodeIntegrationTest` (not just managed)
* Don't use remote services when a local one will do, avoids quota exceeded failures