### PR TITLE
Feature: byon customization

### DIFF
--- a/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/SshMachineLocation.java
@@ -21,6 +21,7 @@ package brooklyn.location.basic;
 import static brooklyn.util.GroovyJavaMethods.truth;
 
 import com.google.common.annotations.Beta;
+
 import groovy.lang.Closure;
 
 import java.io.Closeable;
@@ -114,6 +115,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
+import com.google.common.reflect.TypeToken;
 
 /**
  * Operations on a machine that is accessible via ssh.
@@ -144,6 +146,12 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
 
     public static final ConfigKey<Boolean> DETECT_MACHINE_DETAILS = ConfigKeys.newBooleanConfigKey("detectMachineDetails",
             "Attempt to detect machine details automatically. Works with SSH-accessible Linux instances.", true);
+
+    public static final ConfigKey<Iterable<String>> PRIVATE_ADDRESSES = ConfigKeys.newConfigKey(
+            new TypeToken<Iterable<String>>() {},
+            "privateAddresses",
+            "Private addresses of this machine, e.g. those within the private network", 
+            null);
 
     @SetFromFlag
     protected String user;
@@ -460,7 +468,8 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
     
     @Override
     public Set<String> getPrivateAddresses() {
-        return ImmutableSet.of();
+        Iterable<String> result = getConfig(PRIVATE_ADDRESSES);
+        return (result == null) ? ImmutableSet.<String>of() : ImmutableSet.copyOf(result);
     }
 
     public HostAndPort getSshHostAndPort() {

--- a/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/WinRmMachineLocation.java
@@ -53,7 +53,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.net.HostAndPort;
+import com.google.common.reflect.TypeToken;
 
 public class WinRmMachineLocation extends AbstractLocation implements MachineLocation {
 
@@ -92,6 +92,12 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
             "Max number of times to attempt WinRM operations", 
             10);
 
+    public static final ConfigKey<Iterable<String>> PRIVATE_ADDRESSES = ConfigKeys.newConfigKey(
+            new TypeToken<Iterable<String>>() {},
+            "privateAddresses",
+            "Private addresses of this machine, e.g. those within the private network", 
+            null);
+
     @Override
     public InetAddress getAddress() {
         return getConfig(ADDRESS);
@@ -128,7 +134,8 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
     
     @Override
     public Set<String> getPrivateAddresses() {
-        return ImmutableSet.of();
+        Iterable<String> result = getConfig(PRIVATE_ADDRESSES);
+        return (result == null) ? ImmutableSet.<String>of() : ImmutableSet.copyOf(result);
     }
 
     public WinRmToolResponse executeScript(String script) {

--- a/core/src/test/java/brooklyn/location/basic/SshMachineLocationTest.java
+++ b/core/src/test/java/brooklyn/location/basic/SshMachineLocationTest.java
@@ -122,6 +122,16 @@ public class SshMachineLocationTest {
         assertSame(host2.getMachineDetails(), machineDetails);
     }
     
+    @Test
+    public void testConfigurePrivateAddresses() throws Exception {
+        SshMachineLocation host2 = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+                .configure("address", Networking.getLocalHost())
+                .configure(SshMachineLocation.PRIVATE_ADDRESSES, ImmutableList.of("1.2.3.4"))
+                .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true));
+
+        assertEquals(host2.getPrivateAddresses(), ImmutableSet.of("1.2.3.4"));
+    }
+    
     // Wow, this is hard to test (until I accepted creating the entity + effector)! Code smell?
     // Need to call getMachineDetails in a DynamicSequentialTask so that the "innessential" takes effect,
     // to not fail its caller. But to get one of those outside of an effector is non-obvious.

--- a/docs/guide/ops/locations/index.md
+++ b/docs/guide/ops/locations/index.md
@@ -401,6 +401,31 @@ brooklyn.location.named.On-Prem\ Iron\ Example.privateKeyFile=~/.ssh/produser_id
 brooklyn.location.named.On-Prem\ Iron\ Example.privateKeyPassphrase=s3cr3tpassphrase
 {% endhighlight %}
 
+For more complex host configuration, one can define custom config values per machine. In the example 
+below, there will be two machines. The first will be a machine reachable on
+`ssh -i ~/.ssh/brooklyn.pem -p 8022 myuser@50.51.52.53`. The second is a windows machine, reachable 
+over WinRM. Each machine has also has a private address (e.g. for within a private network).
+
+{% highlight yaml %}
+location:
+  byon:
+    hosts:
+    - ssh: 50.51.52.53:8022
+      privateAddresses: [10.0.0.1]
+      privateKeyFile: ~/.ssh/brooklyn.pem
+      user: myuser
+    - winrm: 50.51.52.54:8985
+      privateAddresses: [10.0.0.2]
+      password: mypassword
+      user: myuser
+      osfamily: windows
+{% endhighlight %}
+
+The BYON location also supports a machine chooser, using the config key `byon.machineChooser`. 
+This allows one to plugin logic to choose from the set of available machines in the pool. For
+example, additional config could be supplied for each machine. This could be used (during the call
+to `location.obtain()`) to find the config that matches the requirements of the entity being
+provisioned. See `brooklyn.location.basic.FixedListMachineProvisioningLocation.MACHINE_CHOOSER`.
 
 
 ### Other Location Topics

--- a/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/SoftwareProcessEntityTest.java
@@ -507,6 +507,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
             events.add("stop");
             launched = false;
             entity.setAttribute(Startable.SERVICE_UP, false);
+            entity.setAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
         }
     
         @Override
@@ -519,6 +520,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         @Override
         public void install() {
             events.add("install");
+            entity.setAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.STARTING);
         }
     
         @Override
@@ -531,6 +533,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
             events.add("launch");
             launched = true;
             entity.setAttribute(Startable.SERVICE_UP, true);
+            entity.setAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         }
 
         @Override

--- a/software/base/src/test/java/brooklyn/location/basic/WinRmMachineLocationTest.java
+++ b/software/base/src/test/java/brooklyn/location/basic/WinRmMachineLocationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.location.basic;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import brooklyn.entity.BrooklynAppUnitTestSupport;
+import brooklyn.entity.basic.BrooklynConfigKeys;
+import brooklyn.location.LocationSpec;
+import brooklyn.util.net.Networking;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+public class WinRmMachineLocationTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testConfigurePrivateAddresses() throws Exception {
+        WinRmMachineLocation host = mgmt.getLocationManager().createLocation(LocationSpec.create(WinRmMachineLocation.class)
+                .configure("address", Networking.getLocalHost())
+                .configure(WinRmMachineLocation.PRIVATE_ADDRESSES, ImmutableList.of("1.2.3.4"))
+                .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true));
+
+        assertEquals(host.getPrivateAddresses(), ImmutableSet.of("1.2.3.4"));
+    }
+}

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlLocationResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlLocationResolver.java
@@ -134,7 +134,9 @@ public class BrooklynYamlLocationResolver {
         
         Maybe<Location> l = mgmt.getLocationRegistry().resolve(spec, null, flags);
         if (l.isPresent()) return l.get();
+        
+        RuntimeException exception = ((Absent<?>)l).getException();
         throw new IllegalStateException("Illegal parameter for 'location' ("+spec+"); not resolvable: "+
-            Exceptions.collapseText( ((Absent<?>)l).getException() ));
+            Exceptions.collapseText( exception ), exception);
     }
 }

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.location.MachineLocation;
+import brooklyn.location.basic.FixedListMachineProvisioningLocation;
+import brooklyn.location.basic.LocationPredicates;
+import brooklyn.location.basic.SshMachineLocation;
+import brooklyn.location.basic.WinRmMachineLocation;
+import brooklyn.util.net.UserAndHostAndPort;
+
+import com.google.api.client.repackaged.com.google.common.base.Joiner;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+public class ByonLocationsYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(ByonLocationsYamlTest.class);
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testByonSpec() throws Exception {
+        String yaml = Joiner.on("\n").join(
+                "location: byon(user=myuser,mykey=myval,hosts=\"1.1.1.1\")",
+                "services:",
+                "- serviceType: brooklyn.entity.basic.BasicApplication");
+        
+        Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
+        FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) Iterables.get(app.getLocations(), 0);
+        
+        Set<SshMachineLocation> machines = loc.getAvailable();
+        SshMachineLocation machine = Iterables.getOnlyElement(machines);
+        assertMachine(machine, UserAndHostAndPort.fromParts("myuser", "1.1.1.1",  22), ImmutableMap.of("mykey", "myval"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testByonMachine() throws Exception {
+        String yaml = Joiner.on("\n").join(
+                "location:",
+                "  byon:",
+                "    hosts:",
+                "    - ssh: 1.1.1.1:8022",
+                "      privateAddresses: [10.0.0.1]",
+                "      password: mypassword",
+                "      user: myuser",
+                "      mykey: myval",
+                "services:",
+                "- serviceType: brooklyn.entity.basic.BasicApplication");
+        
+        Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
+        FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) Iterables.get(app.getLocations(), 0);
+        
+        Set<SshMachineLocation> machines = loc.getAvailable();
+        SshMachineLocation machine = Iterables.getOnlyElement(machines);
+        assertMachine(machine, UserAndHostAndPort.fromParts("myuser", "1.1.1.1",  8022), ImmutableMap.of(
+                SshMachineLocation.PASSWORD.getName(), "mypassword",
+                "mykey", "myval"));
+        assertEquals(machine.getPrivateAddresses(), ImmutableSet.of("10.0.0.1"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testByonWindowsMachine() throws Exception {
+        String yaml = Joiner.on("\n").join(
+                "location:",
+                "  byon:",
+                "    hosts:",
+                "    - winrm: 1.1.1.1:8985",
+                "      privateAddresses: [10.0.0.1]",
+                "      password: mypassword",
+                "      user: myuser",
+                "      mykey: myval",
+                "      osfamily: windows",
+                "services:",
+                "- serviceType: brooklyn.entity.basic.BasicApplication");
+        
+        Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
+        FixedListMachineProvisioningLocation<WinRmMachineLocation> loc = (FixedListMachineProvisioningLocation<WinRmMachineLocation>) Iterables.get(app.getLocations(), 0);
+        
+        Set<WinRmMachineLocation> machines = loc.getAvailable();
+        WinRmMachineLocation machine = Iterables.getOnlyElement(machines);
+        assertMachine(machine, UserAndHostAndPort.fromParts("myuser", "1.1.1.1",  8985), ImmutableMap.of(
+                SshMachineLocation.PASSWORD.getName(), "mypassword",
+                "mykey", "myval"));
+        assertEquals(machine.getPrivateAddresses(), ImmutableSet.of("10.0.0.1"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testByonMultiMachine() throws Exception {
+        String yaml = Joiner.on("\n").join(
+                "location:",
+                "  byon:",
+                "    hosts:",
+                "    - ssh: 1.1.1.1:8022",
+                "      privateAddresses: [10.0.0.1]",
+                "      password: mypassword",
+                "      user: myuser",
+                "      mykey: myval1",
+                "    - ssh: 1.1.1.2:8022",
+                "      privateAddresses: [10.0.0.2]",
+                "      password: mypassword",
+                "      user: myuser",
+                "      mykey: myval2",
+                "    - winrm: 1.1.1.3:8985",
+                "      privateAddresses: [10.0.0.3]",
+                "      password: mypassword",
+                "      user: myuser",
+                "      mykey: myval3",
+                "      osfamily: windows",
+                "services:",
+                "- serviceType: brooklyn.entity.basic.BasicApplication");
+        
+        Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
+        FixedListMachineProvisioningLocation<MachineLocation> loc = (FixedListMachineProvisioningLocation<MachineLocation>) Iterables.get(app.getLocations(), 0);
+        
+        Set<MachineLocation> machines = loc.getAvailable();
+        assertEquals(machines.size(), 3, "machines="+machines);
+        SshMachineLocation machine1 = (SshMachineLocation) Iterables.find(machines, LocationPredicates.configEqualTo(ConfigKeys.newStringConfigKey("mykey"), "myval1"));
+        SshMachineLocation machine2 = (SshMachineLocation) Iterables.find(machines, LocationPredicates.configEqualTo(ConfigKeys.newStringConfigKey("mykey"), "myval2"));
+        WinRmMachineLocation machine3 = (WinRmMachineLocation) Iterables.find(machines, Predicates.instanceOf(WinRmMachineLocation.class));
+
+        assertMachine(machine1, UserAndHostAndPort.fromParts("myuser", "1.1.1.1",  8022), ImmutableMap.of(
+                SshMachineLocation.PASSWORD.getName(), "mypassword",
+                "mykey", "myval1"));
+        assertEquals(machine1.getPrivateAddresses(), ImmutableSet.of("10.0.0.1"));
+
+        assertMachine(machine2, UserAndHostAndPort.fromParts("myuser", "1.1.1.2",  8022), ImmutableMap.of(
+                SshMachineLocation.PASSWORD.getName(), "mypassword",
+                "mykey", "myval2"));
+        assertEquals(machine2.getPrivateAddresses(), ImmutableSet.of("10.0.0.2"));
+
+        assertMachine(machine3, UserAndHostAndPort.fromParts("myuser", "1.1.1.3",  8985), ImmutableMap.of(
+                SshMachineLocation.PASSWORD.getName(), "mypassword",
+                "mykey", "myval3"));
+        assertEquals(machine3.getPrivateAddresses(), ImmutableSet.of("10.0.0.3"));
+    }
+    
+    private void assertMachine(SshMachineLocation machine, UserAndHostAndPort conn, Map<String, ?> config) {
+        assertEquals(machine.getAddress().getHostAddress(), conn.getHostAndPort().getHostText());
+        assertEquals(machine.getPort(), conn.getHostAndPort().getPort());
+        assertEquals(machine.getUser(), conn.getUser());
+        for (Map.Entry<String, ?> entry : config.entrySet()) {
+            Object actualVal = machine.getConfig(ConfigKeys.newConfigKey(Object.class, entry.getKey()));
+            assertEquals(actualVal, entry.getValue());
+        }
+    }
+    
+    private void assertMachine(WinRmMachineLocation machine, UserAndHostAndPort conn, Map<String, ?> config) {
+        assertEquals(machine.getAddress().getHostAddress(), conn.getHostAndPort().getHostText());
+        assertEquals(machine.getConfig(WinRmMachineLocation.WINRM_PORT), (Integer) conn.getHostAndPort().getPort());
+        assertEquals(machine.getUser(), conn.getUser());
+        for (Map.Entry<String, ?> entry : config.entrySet()) {
+            Object actualVal = machine.getConfig(ConfigKeys.newConfigKey(Object.class, entry.getKey()));
+            assertEquals(actualVal, entry.getValue());
+        }
+    }
+    
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/utils/common/src/main/java/brooklyn/util/collections/CollectionFunctionals.java
+++ b/utils/common/src/main/java/brooklyn/util/collections/CollectionFunctionals.java
@@ -106,6 +106,23 @@ public class CollectionFunctionals {
         return new SizeFunction(valueIfInputNull);
     }
 
+    public static final class FirstElementFunction<T> implements Function<Iterable<? extends T>, T> {
+        private FirstElementFunction() {
+        }
+
+        @Override
+        public T apply(Iterable<? extends T> input) {
+            if (input==null) return null;
+            return Iterables.get(input, 0);
+        }
+
+        @Override public String toString() { return "firstElementFunction"; }
+    }
+
+    public static <T> Function<Iterable<? extends T>, T> firstElement() {
+        return new FirstElementFunction<T>();
+    }
+    
     public static <K> Function<Map<K,?>,Set<K>> keys() {
         return new KeysOfMapFunction<K>();
     }

--- a/utils/common/src/main/java/brooklyn/util/net/UserAndHostAndPort.java
+++ b/utils/common/src/main/java/brooklyn/util/net/UserAndHostAndPort.java
@@ -31,6 +31,10 @@ public class UserAndHostAndPort implements Serializable {
         return new UserAndHostAndPort(user, HostAndPort.fromParts(host, port));
     }
 
+    public static UserAndHostAndPort fromParts(String user, HostAndPort hostAndPort) {
+        return new UserAndHostAndPort(user, hostAndPort);
+    }
+
     /**
      * Split a string of the form myuser@myhost:1234 into a user, host and port.
      *  

--- a/utils/common/src/test/java/brooklyn/util/collections/CollectionFunctionalsTest.java
+++ b/utils/common/src/test/java/brooklyn/util/collections/CollectionFunctionalsTest.java
@@ -48,4 +48,10 @@ public class CollectionFunctionalsTest {
         Assert.assertEquals(CollectionFunctionals.mapSize(-1).apply(null), (Integer)(-1));
     }
 
+    @Test
+    public void testFirstElement() {
+        Assert.assertEquals(CollectionFunctionals.firstElement().apply(null), null);
+        Assert.assertEquals(CollectionFunctionals.firstElement().apply(ImmutableList.of("a")), "a");
+        Assert.assertEquals(CollectionFunctionals.firstElement().apply(ImmutableList.of("a", "b", "c")), "a");
+    }
 }


### PR DESCRIPTION
Allows a BYON location to have more complex configuration (e.g. each machine having its own separate map of config), including in YAML.

Also supports a MACHINE_CHOOSER config. This can be used to customize the choice of which available machine should be returned, when obtain() is called.

The motivation is to make BYON more useful for multi-VM deployments, where you want to pick particular machines for particular software components.