### PR TITLE
[BROOKLYN-132] Add versions dropdown when creating applications from catalog template

### DIFF
--- a/usage/jsgui/pom.xml
+++ b/usage/jsgui/pom.xml
@@ -158,7 +158,7 @@
         </testResources>
         <plugins>
             <!--
-                 run js tests with: $ mvn clean process-resources jasmine:test
+                 run js tests with: $ mvn clean process-test-resources jasmine:test
                  run tests in the browser with: $ mvn jasmine:bdd
             -->
             <plugin>

--- a/usage/jsgui/src/main/webapp/assets/js/model/catalog-application.js
+++ b/usage/jsgui/src/main/webapp/assets/js/model/catalog-application.js
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+define(["underscore", "backbone"], function (_, Backbone) {
+    
+    var CatalogApplication = {}
+
+    CatalogApplication.Model = Backbone.Model.extend({
+        defaults: function () {
+            return {
+                id: "",
+                type: "",
+                name: "",
+                version: "",
+                description: "",
+                planYaml: "",
+                iconUrl: ""
+            }
+        }
+    })
+
+    CatalogApplication.Collection = Backbone.Collection.extend({
+        model: CatalogApplication.Model,
+        url: '/v1/catalog/applications',
+        getDistinctApplications: function() {
+            return this.groupBy('type');
+        },
+        getTypes: function(type) {
+            return _.uniq(this.chain().map(function(model) {return model.get('type')}).value());
+        },
+        hasType: function(type) {
+            return this.where({type: type}).length > 0;
+        },
+        getVersions: function(type) {
+            return this.chain().filter(function(model) {return model.get('type') === type}).map(function(model) {return model.get('version')}).value();
+        }
+    })
+
+    return CatalogApplication
+})

--- a/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/deploy-version-option.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/deploy-version-option.html
@@ -18,16 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<div class="template-lozenge frame" id="<%- id %>" data-type="<%- type %>" data-name="<%- name %>" data-yaml="<%- planYaml %>">
-    <% if (iconUrl) { %>
-    <div class="icon">
-        <img src="<%- iconUrl %>" alt="(icon)" />
-    </div>
-    <% } %>
-    <div class="blurb">
-        <div class="title"><%- name %></div>
-        <div class="description">
-            <%- description ? description : "" %>
-        </div>
-    </div>
-</div>
+<option value="<%- version %>">
+    <span class="provider"><%- version %></span>
+</option>

--- a/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/deploy.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/deploy.html
@@ -30,9 +30,14 @@ under the License.
         <div class="label-important">ERROR</div>  <span class="error-message-text">Failure performing specified action</span>
     </div>
 
+    <div id="app-versions" class="control-group">
+        <div class="deploy-label">Version</div>
+        <select class="select-version" style="margin:4px 0 4px 0; width:80%"></select>
+    </div>
+
     <div id="app-locations" class="control-group">
         <div class="deploy-label">Locations</div>
-        <div id="selector-container"></div>
+        <div id="selector-container-location"></div>
         <button id="add-selector-container" class="btn btn-info btn-mini">
             Add Additional Location</button>
     </div>

--- a/usage/jsgui/src/test/javascript/specs/model/catalog-application-spec.js
+++ b/usage/jsgui/src/test/javascript/specs/model/catalog-application-spec.js
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+define([
+    'underscore', 'model/catalog-application'
+], function (_, CatalogApplication) {
+    var catalogApplication = new CatalogApplication.Model
+    catalogApplication.url = 'fixtures/catalog-application.json'
+    catalogApplication.fetch({async:false})
+
+    describe('model/catalog-application', function() {
+        it('loads data from fixture file', function () {
+            expect(catalogApplication.get('id')).toEqual('com.example.app:1.1')
+            expect(catalogApplication.get('type')).toEqual('com.example.app')
+            expect(catalogApplication.get('name')).toEqual('My example application')
+            expect(catalogApplication.get('version')).toEqual('1.1')
+            expect(catalogApplication.get('description')).toEqual('My awesome example application, as a catalog item')
+            expect(catalogApplication.get('planYaml')).toEqual('services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch application\"\n  checkRunning.command: echo \"Check running application\"')
+            expect(catalogApplication.get('iconUrl')).toEqual('http://my.example.com/icon.png')
+        })
+    })
+    describe("model/catalog-application", function () {
+        it('fetches from /v1/locations', function () {
+            var catalogApplicationCollection = new CatalogApplication.Collection()
+            expect(catalogApplicationCollection.url).toEqual('/v1/catalog/applications')
+        })
+
+        // keep these in describe so jasmine-maven will load them from the file pointed by URL
+        var catalogApplicationFixture = new CatalogApplication.Collection
+        catalogApplicationFixture.url = 'fixtures/catalog-application-list.json'
+        catalogApplicationFixture.fetch()
+
+        it('loads all model properties defined in fixtures/catalog-application.json', function () {
+            expect(catalogApplicationFixture.length).toEqual(3)
+
+            var catalogApplication1 = catalogApplicationFixture.at(0)
+            expect(catalogApplication1.get('id')).toEqual('com.example.app:1.1')
+            expect(catalogApplication1.get('type')).toEqual('com.example.app')
+            expect(catalogApplication1.get('name')).toEqual('My example application')
+            expect(catalogApplication1.get('version')).toEqual('1.1')
+            expect(catalogApplication1.get('description')).toEqual('My awesome example application, as a catalog item')
+            expect(catalogApplication1.get('planYaml')).toEqual('services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch application\"\n  checkRunning.command: echo \"Check running application\"')
+            expect(catalogApplication1.get('iconUrl')).toEqual('http://my.example.com/icon.png')
+
+            var catalogApplication2 = catalogApplicationFixture.at(1)
+            expect(catalogApplication2.get('id')).toEqual('com.example.app:2.0')
+            expect(catalogApplication2.get('type')).toEqual('com.example.app')
+            expect(catalogApplication2.get('name')).toEqual('My example application')
+            expect(catalogApplication2.get('version')).toEqual('2.0')
+            expect(catalogApplication2.get('description')).toEqual('My awesome example application, as a catalog item')
+            expect(catalogApplication2.get('planYaml')).toEqual('services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch application\"\n  checkRunning.command: echo \"Check running application\"')
+            expect(catalogApplication2.get('iconUrl')).toEqual('http://my.example.com/icon.png')
+
+            var catalogApplication3 = catalogApplicationFixture.at(2)
+            expect(catalogApplication3.get('id')).toEqual('com.example.other.app:1.0')
+            expect(catalogApplication3.get('type')).toEqual('com.example.other.app')
+            expect(catalogApplication3.get('name')).toEqual('Another example application')
+            expect(catalogApplication3.get('version')).toEqual('1.0')
+            expect(catalogApplication3.get('description')).toEqual('Another awesome example application, as a catalog item')
+            expect(catalogApplication3.get('planYaml')).toEqual('services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch other application\"\n  checkRunning.command: echo \"Check running other application\"')
+            expect(catalogApplication3.get('iconUrl')).toEqual('http://my.other.example.com/icon.png')
+        })
+
+        it ('Collection#getDistinctApplications returns all available applications, group by type', function() {
+            var groupBy = catalogApplicationFixture.getDistinctApplications()
+
+            expect(Object.keys(groupBy).length).toBe(2)
+            expect(groupBy.hasOwnProperty('com.example.app')).toBeTruthy()
+            expect(groupBy['com.example.app'].length).toBe(2)
+            expect(groupBy['com.example.app'][0].get('version')).toEqual('1.1')
+            expect(groupBy['com.example.app'][1].get('version')).toEqual('2.0')
+            expect(groupBy.hasOwnProperty('com.example.other.app')).toBeTruthy()
+            expect(groupBy['com.example.other.app'].length).toBe(1)
+            expect(groupBy['com.example.other.app'][0].get('version')).toEqual('1.0')
+        })
+
+        it('Collection#getTypes() returns only distinct types', function() {
+            var types = catalogApplicationFixture.getTypes()
+
+            expect(types.length).toBe(2)
+            expect(types[0]).toEqual('com.example.app')
+            expect(types[1]).toEqual('com.example.other.app')
+        })
+
+        describe('Collection#hasType()', function() {
+            it('Returns true if the given type exists within the applications list', function() {
+                var ret = catalogApplicationFixture.hasType('com.example.other.app')
+
+                expect(ret).toBeTruthy()
+            })
+
+            it('Returns false if the given type exists within the applications list', function() {
+                var ret = catalogApplicationFixture.hasType('com.example.other.app.that.does.not.exist')
+
+                expect(ret).toBeFalsy()
+            })
+        })
+
+        describe('Collection#getVersions()', function() {
+            it('Returns an empty array if no applications exist with the given type', function() {
+                var versions = catalogApplicationFixture.getVersions('com.example.other.app.that.does.not.exist')
+
+                expect(versions.length).toBe(0)
+            })
+
+            it('Returns the expected array of versions if applications exist with the given type', function() {
+                var versions = catalogApplicationFixture.getVersions('com.example.app')
+
+                expect(versions.length).toBe(2)
+                expect(versions[0]).toEqual('1.1')
+                expect(versions[1]).toEqual('2.0')
+            })
+        })
+    })
+})

--- a/usage/rest-api/src/test/resources/fixtures/catalog-application-list.json
+++ b/usage/rest-api/src/test/resources/fixtures/catalog-application-list.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": "com.example.app:1.1",
+        "type": "com.example.app",
+        "name": "My example application",
+        "version": "1.1",
+        "description": "My awesome example application, as a catalog item",
+        "planYaml": "services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch application\"\n  checkRunning.command: echo \"Check running application\"",
+        "iconUrl": "http://my.example.com/icon.png"
+    },
+    {
+        "id": "com.example.app:2.0",
+        "type": "com.example.app",
+        "name": "My example application",
+        "version": "2.0",
+        "description": "My awesome example application, as a catalog item",
+        "planYaml": "services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch application\"\n  checkRunning.command: echo \"Check running application\"",
+        "iconUrl": "http://my.example.com/icon.png"
+    },
+    {
+        "id": "com.example.other.app:1.0",
+        "type": "com.example.other.app",
+        "name": "Another example application",
+        "version": "1.0",
+        "description": "Another awesome example application, as a catalog item",
+        "planYaml": "services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch other application\"\n  checkRunning.command: echo \"Check running other application\"",
+        "iconUrl": "http://my.other.example.com/icon.png"
+    }
+]

--- a/usage/rest-api/src/test/resources/fixtures/catalog-application.json
+++ b/usage/rest-api/src/test/resources/fixtures/catalog-application.json
@@ -1,0 +1,9 @@
+{
+    "id": "com.example.app:1.1",
+    "type": "com.example.app",
+    "name": "My example application",
+    "version": "1.1",
+    "description": "My awesome example application, as a catalog item",
+    "planYaml": "services:\n- type: brooklyn.entity.basic.VanillaSoftwareProcess\n  launch.command: echo \"Launch application\"\n  checkRunning.command: echo \"Check running application\"",
+    "iconUrl": "http://my.example.com/icon.png"
+}


### PR DESCRIPTION
This PR adds a versions dropdown on the second step modal, when an application is created from a template. This dropdown is always visible for consistency, even if there is only one version available.

Please note that as I was not sure that the `catalog-item` model could apply to any object returned by the `/v1/catalog/*` endpoints so I created a specific one for the applications only: `catalog-application`. It also makes sense as one backbone model should have only one endpoint.