### PR TITLE
BrooklynApi.getEntity handles instances of BuiltResponsePreservingError

### DIFF
--- a/usage/rest-client/pom.xml
+++ b/usage/rest-client/pom.xml
@@ -104,6 +104,10 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>

--- a/usage/rest-server/src/main/java/brooklyn/rest/filter/LoggingFilter.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/filter/LoggingFilter.java
@@ -146,9 +146,9 @@ public class LoggingFilter implements Filter {
                         message.append("******");
                     } else {
                         message.append(httpRequest.getHeader(headerName));
-                        if (headerNames.hasMoreElements()) {
-                            message.append(", ");
-                        }
+                    }
+                    if (headerNames.hasMoreElements()) {
+                        message.append(", ");
                     }
                 }
             }


### PR DESCRIPTION
`BuiltResponsePreservingError` can turn response entities into strings, breaking callers of `BrooklynApi.getEntity`.