### PR TITLE
Count the null values for the average enrichers

### DIFF
--- a/software/webapp/src/main/java/brooklyn/entity/webapp/DynamicWebAppClusterImpl.java
+++ b/software/webapp/src/main/java/brooklyn/entity/webapp/DynamicWebAppClusterImpl.java
@@ -117,6 +117,7 @@ public class DynamicWebAppClusterImpl extends DynamicClusterImpl implements Dyna
                     .publishing(average)
                     .fromMembers()
                     .computingAverage()
+                    .defaultValueForUnreportedSensors(0)
                     .build());
         }
     }


### PR DESCRIPTION
This fixes TomcatAutoScalerPolicyTest

Basically the problem is that after making a request to Tomcat, update event for REQUEST_COUNT_PER_NODE is triggered immediately.
This causes Enrichers.average() to have a null value for the requests of the newly created Tomcat Entity.
This leads to average of 2 requests per node which exceeds the allowed metric of 0 to 1 which triggers scaling.

It is discuss-able whether we should apply the fix here, but I think in the general case it is good to include count the null when calculating average enrichers.