### PR TITLE
MongoDB fixes

### DIFF
--- a/core/src/main/java/brooklyn/location/basic/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/brooklyn/location/basic/LocalhostMachineProvisioningLocation.java
@@ -238,7 +238,7 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
             releasePort(null, p);
     }
     
-    public static class LocalhostMachine extends SshMachineLocation {
+    public static class LocalhostMachine extends SshMachineLocation implements HasSubnetHostname {
         // declaring this here (as well as on LocalhostMachineProvisioningLocation) because:
         //  1. machine.getConfig(key) will not inherit default value of machine.getParent()'s key
         //  2. things might instantiate a `LocalhostMachine` without going through LocalhostMachineProvisioningLocation
@@ -299,6 +299,14 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
                 address = Networking.getLocalHost();
             super.configure(properties);
             return this;
+        }
+        @Override
+        public String getSubnetHostname() {
+           return Networking.getLocalHost().getHostName();
+        }
+        @Override
+        public String getSubnetIp() {
+            return Networking.getLocalHost().getHostAddress();
         }
     }
 

--- a/software/nosql/src/main/java/brooklyn/entity/nosql/mongodb/sharding/MongoDBShardClusterImpl.java
+++ b/software/nosql/src/main/java/brooklyn/entity/nosql/mongodb/sharding/MongoDBShardClusterImpl.java
@@ -146,7 +146,7 @@ public class MongoDBShardClusterImpl extends DynamicClusterImpl implements Mongo
                     
                     MongoDBServer primary = replicaSet.getAttribute(MongoDBReplicaSet.PRIMARY_ENTITY);
                     if (primary != null) {
-                        String addr = Strings.removeFromStart(primary.getAttribute(MongoDBServer.MONGO_SERVER_ENDPOINT), "http://");
+                        String addr = String.format("%s:%d", primary.getAttribute(MongoDBServer.SUBNET_HOSTNAME), primary.getAttribute(MongoDBServer.PORT));
                         String replicaSetURL = ((MongoDBReplicaSet) replicaSet).getName() + "/" + addr;
                         boolean added = client.addShardToRouter(replicaSetURL);
                         if (added) {


### PR DESCRIPTION
Probably resolves problems in local and/or cloud environments.

It seems that ```BrooklynAccessUtils``` is the preferred way to determine Brooklyn's accessible address. Now it uses hostname when used with locations in local or cloud environments. On some occasions it should use subnet_hostname instead of the hostname.
```MongoDBShardedDeploymentIntegrationTest``` demonstrates the scenario.
