### PR TITLE
SoftwareProcess exposes LifecycleEffectorTasks implementation as config

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcess.java
@@ -214,7 +214,16 @@ public interface SoftwareProcess extends Entity, Startable {
                     "several others. Set to null or to 0 to disable any delay.",
             Duration.TEN_SECONDS);
 
-    /** controls the behavior when starting (stop, restart) {@link Startable} children as part of the start (stop, restart) effector on this entity
+    /**
+     * Sets the object that manages the sequence of calls of the entity's driver.
+     */
+    @Beta
+    @SetFromFlag("lifecycleEffectorTasks")
+    ConfigKey<SoftwareProcessDriverLifecycleEffectorTasks> LIFECYCLE_EFFECTOR_TASKS = ConfigKeys.newConfigKey(SoftwareProcessDriverLifecycleEffectorTasks.class,
+            "softwareProcess.lifecycleTasks", "An object that handles lifecycle of an entity's associated machine.",
+            new SoftwareProcessDriverLifecycleEffectorTasks());
+
+    /** Controls the behavior when starting (stop, restart) {@link Startable} children as part of the start (stop, restart) effector on this entity
      * <p>
      * (NB: restarts are currently not propagated to children in the default {@link SoftwareProcess}
      * due to the various semantics which may be desired; this may change, but if entities have specific requirements for restart,
@@ -258,7 +267,9 @@ public interface SoftwareProcess extends Entity, Startable {
     }
 
     @SetFromFlag("childStartMode")
-    ConfigKey<ChildStartableMode> CHILDREN_STARTABLE_MODE = ConfigKeys.newConfigKey(ChildStartableMode.class, "children.startable.mode");
+    ConfigKey<ChildStartableMode> CHILDREN_STARTABLE_MODE = ConfigKeys.newConfigKey(ChildStartableMode.class,
+            "children.startable.mode", "Controls behaviour when starting Startable children as part of this entity's lifecycle.",
+            ChildStartableMode.NONE);
 
     @SuppressWarnings("rawtypes")
     AttributeSensor<MachineProvisioningLocation> PROVISIONING_LOCATION = Sensors.newSensor(
@@ -301,7 +312,7 @@ public interface SoftwareProcess extends Entity, Startable {
 
         @Beta /** @since 0.7.0 semantics of parameters to restart being explored */
         public static final ConfigKey<StopMode> STOP_PROCESS_MODE = ConfigKeys.newConfigKey(StopMode.class, "stopProcessMode",
-                "When to stop the process with regard to the entity state" +
+                "When to stop the process with regard to the entity state. " +
                 "ALWAYS will try to stop the process even if the entity is marked as stopped, " +
                 "IF_NOT_STOPPED stops the process only if the entity is not marked as stopped, " +
                 "NEVER doesn't stop the process.", StopMode.IF_NOT_STOPPED);

--- a/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SoftwareProcessImpl.java
@@ -85,9 +85,6 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     /** @see #connectServiceUpIsRunning() */
     private volatile FunctionFeed serviceProcessIsRunning;
 
-    private static final SoftwareProcessDriverLifecycleEffectorTasks LIFECYCLE_TASKS =
-            new SoftwareProcessDriverLifecycleEffectorTasks();
-
     protected boolean connectedSensors = false;
     
     public SoftwareProcessImpl() {
@@ -129,7 +126,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     @Override
     public void init() {
         super.init();
-        LIFECYCLE_TASKS.attachLifecycleEffectors(this);
+        getLifecycleEffectorTasks().attachLifecycleEffectors(this);
     }
     
     @Override
@@ -442,7 +439,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
 
     /** returns the ports that this entity wants to use;
      * default implementation returns {@link SoftwareProcess#REQUIRED_OPEN_LOGIN_PORTS} plus first value 
-     * for each {@link PortAttributeSensorAndConfigKey} config key {@link PortRange}
+     * for each {@link brooklyn.event.basic.PortAttributeSensorAndConfigKey} config key {@link PortRange}
      * plus any ports defined with a config keys ending in {@code .port}.
      */
     protected Collection<Integer> getRequiredOpenPorts() {
@@ -614,7 +611,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
      */
     @Deprecated
     protected final void doStart(Collection<? extends Location> locations) {
-        LIFECYCLE_TASKS.start(locations);
+        getLifecycleEffectorTasks().start(locations);
     }
     
     /**
@@ -624,7 +621,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
      */
     @Deprecated
     protected final void doStop() {
-        LIFECYCLE_TASKS.stop();
+        getLifecycleEffectorTasks().stop();
     }
     
     /**
@@ -634,12 +631,16 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
      */
     @Deprecated
     protected final void doRestart(ConfigBag parameters) {
-        LIFECYCLE_TASKS.restart(parameters);
+        getLifecycleEffectorTasks().restart(parameters);
     }
 
     @Deprecated /** @deprecated since 0.7.0 see {@link #doRestart(ConfigBag)} */
     protected final void doRestart() {
         doRestart(ConfigBag.EMPTY);
+    }
+
+    protected SoftwareProcessDriverLifecycleEffectorTasks getLifecycleEffectorTasks() {
+        return getConfig(LIFECYCLE_EFFECTOR_TASKS);
     }
 
 }

--- a/software/base/src/test/java/brooklyn/entity/basic/VanillaSoftwareProcessAndChildrenIntegrationTest.java
+++ b/software/base/src/test/java/brooklyn/entity/basic/VanillaSoftwareProcessAndChildrenIntegrationTest.java
@@ -56,7 +56,7 @@ public class VanillaSoftwareProcessAndChildrenIntegrationTest {
     private static final int PARENT_TASK_SLEEP_LENGTH_SECS = 10;
     private static final int CHILD_TASK_SLEEP_LENGTH_SECS = 10;
     private static final int CONCURRENT_MAX_ACCEPTABLE_DIFF_SECS = PARENT_TASK_SLEEP_LENGTH_SECS - 1;
-    private static final int SEQUENCTIAL_MIN_ACCEPTABLE_DIFF_SECS = PARENT_TASK_SLEEP_LENGTH_SECS - 1;
+    private static final int SEQUENTIAL_MIN_ACCEPTABLE_DIFF_SECS = PARENT_TASK_SLEEP_LENGTH_SECS - 1;
     private static final int EARLY_RETURN_GRACE_MS = 20;
     
     private TestApplication app;
@@ -102,7 +102,7 @@ public class VanillaSoftwareProcessAndChildrenIntegrationTest {
         long startTime = startApp();
 
         long timediff = timediff();
-        Assert.assertTrue( timediff >= SEQUENCTIAL_MIN_ACCEPTABLE_DIFF_SECS, "should have started later, not with time difference "+timediff+" ("+p1+", "+p2+")" );
+        Assert.assertTrue( timediff >= SEQUENTIAL_MIN_ACCEPTABLE_DIFF_SECS, "should have started later, not with time difference "+timediff+" ("+p1+", "+p2+")" );
         Assert.assertTrue(startTime >= 2*PARENT_TASK_SLEEP_LENGTH_SECS*1000 - EARLY_RETURN_GRACE_MS, "startTime="+Time.makeTimeStringRounded(startTime));
     }
 
@@ -127,7 +127,7 @@ public class VanillaSoftwareProcessAndChildrenIntegrationTest {
         checkChildComesUpSoon();
         
         long timediff = timediff();
-        Assert.assertTrue( Math.abs(timediff) >= SEQUENCTIAL_MIN_ACCEPTABLE_DIFF_SECS, "should have started later, not with time difference "+timediff+" ("+p1+", "+p2+")" );
+        Assert.assertTrue( Math.abs(timediff) >= SEQUENTIAL_MIN_ACCEPTABLE_DIFF_SECS, "should have started later, not with time difference "+timediff+" ("+p1+", "+p2+")" );
         Assert.assertTrue(startTime >= PARENT_TASK_SLEEP_LENGTH_SECS*1000 - EARLY_RETURN_GRACE_MS, "startTime="+Time.makeTimeStringRounded(startTime));
         
         // just to prevent warnings

--- a/software/webapp/src/test/java/brooklyn/test/entity/TestJavaWebAppEntityImpl.java
+++ b/software/webapp/src/test/java/brooklyn/test/entity/TestJavaWebAppEntityImpl.java
@@ -20,22 +20,12 @@ package brooklyn.test.entity;
 
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import brooklyn.entity.Entity;
-import brooklyn.entity.basic.Attributes;
-import brooklyn.entity.basic.Lifecycle;
-import brooklyn.entity.basic.ServiceStateLogic;
-import brooklyn.entity.basic.SoftwareProcessDriverLifecycleEffectorTasks;
 import brooklyn.entity.java.VanillaJavaAppImpl;
 import brooklyn.entity.webapp.WebAppServiceConstants;
-import brooklyn.location.Location;
 import brooklyn.util.flags.SetFromFlag;
 
 public class TestJavaWebAppEntityImpl extends VanillaJavaAppImpl implements TestJavaWebAppEntity {
-
-    private static final Logger LOG = LoggerFactory.getLogger(TestJavaWebAppEntity.class);
 
     @SetFromFlag public int a;
     @SetFromFlag public int b;
@@ -45,30 +35,6 @@ public class TestJavaWebAppEntityImpl extends VanillaJavaAppImpl implements Test
     
     // constructor required for use in DynamicCluster.factory
     public TestJavaWebAppEntityImpl(@SuppressWarnings("rawtypes") Map flags, Entity parent) { super(flags, parent); }
-
-    private static final SoftwareProcessDriverLifecycleEffectorTasks LIFECYCLE_TASKS =
-        new SoftwareProcessDriverLifecycleEffectorTasks() {
-        public void start(java.util.Collection<? extends Location> locations) {
-            ServiceStateLogic.setExpectedState(entity(), Lifecycle.STARTING);
-            LOG.trace("Starting {}", this);
-            entity().setAttribute(SERVICE_PROCESS_IS_RUNNING, true);
-            entity().setAttribute(Attributes.SERVICE_UP, true);
-            ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
-        }
-        public void stop() {
-            ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPING);
-            LOG.trace("Stopping {}", this);
-            entity().setAttribute(Attributes.SERVICE_UP, false);
-            entity().setAttribute(SERVICE_PROCESS_IS_RUNNING, false);
-            ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPED);
-        }
-    };
-
-    @Override
-    public void init() {
-        super.init();
-        LIFECYCLE_TASKS.attachLifecycleEffectors(this);
-    }
 
     @Override
     public synchronized void spoofRequest() {
@@ -91,4 +57,5 @@ public class TestJavaWebAppEntityImpl extends VanillaJavaAppImpl implements Test
     public int getC() {
         return c;
     }
+
 }


### PR DESCRIPTION
Thus it is much easier for subclasses of `SoftwareProcess` to customise which effectors they expose and how those effectors behave.