### PR TITLE
Update brooklyn-node.yaml example

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNode.java
+++ b/software/base/src/main/java/brooklyn/entity/brooklynnode/BrooklynNode.java
@@ -67,10 +67,9 @@ public interface BrooklynNode extends SoftwareProcess, UsesJava {
     @SetFromFlag("version")
     public static final ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.SUGGESTED_VERSION, "0.8.0-SNAPSHOT"); // BROOKLYN_VERSION
 
-    // Takes precedence over downloadUrl, if non-null
     @SetFromFlag("distroUploadUrl")
     public static final ConfigKey<String> DISTRO_UPLOAD_URL = ConfigKeys.newStringConfigKey(
-            "brooklynnode.distro.uploadurl", "URL for uploading the brooklyn distro (retrieved locally and pushed to remote install location)", null);
+            "brooklynnode.distro.uploadurl", "URL for uploading the brooklyn distro (retrieved locally and pushed to remote install location. Takes precedence over downloadUrl, if non-null)", null);
 
     // Note that download URL only supports versions in org.apache.brooklyn, so not 0.6.0 and earlier 
     // (which used maven group io.brooklyn). Aled thinks we can live with that.

--- a/software/base/src/main/resources/brooklyn/entity/brooklynnode/brooklyn-node.yaml
+++ b/software/base/src/main/resources/brooklyn/entity/brooklynnode/brooklyn-node.yaml
@@ -22,8 +22,8 @@ name: Example Brooklyn Node
 services:
 - type: brooklyn.entity.brooklynnode.BrooklynNode
 
-  ## to use a local file, specify something such as the following:   [BROOKLYN_VERSION_BELOW] 
-  # downloadUrl: file:///tmp/brooklyn-dist-0.8.0-SNAPSHOT-dist.tar.gz
+  ## URL for uploading the brooklyn distro (retrieved locally and pushed to remote install location)
+  # brooklynnode.distro.uploadurl: file:///tmp/brooklyn-dist-<version>-dist.tar.gz
 
   ## if deploying to anything other than localhost you must also configure login details, e.g.:
   # managementUsername: admin


### PR DESCRIPTION
Include the more reasonable `brooklynnode.distro.uploadurl` attribute in the `brooklyn-node.yaml` example