### PR TITLE
Fix dist to have suitable name, and suitably-named directory inside

### DIFF
--- a/usage/dist/pom.xml
+++ b/usage/dist/pom.xml
@@ -134,11 +134,8 @@
                             <descriptors>
                                 <descriptor>src/main/config/build-distribution.xml</descriptor>
                             </descriptors>
-                          <!-- finalName affects name in `target/` but we cannot influence name when it is attached/installed,
-                               so `apache-` prefix would be lost there. to keep it consistent this is commented out, 
-                               but would be nice to have if there is a way!
-                            <finalName>apache-brooklyn-${project.version}</finalName>
-                          -->
+                            <finalName>apache-brooklyn-${project.version}-bin</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
                             <formats>
                                 <format>tar.gz</format>
                                 <format>zip</format>

--- a/usage/dist/src/main/config/build-distribution.xml
+++ b/usage/dist/src/main/config/build-distribution.xml
@@ -90,7 +90,7 @@
             <outputDirectory>lib/brooklyn</outputDirectory>
             <fileMode>0644</fileMode>
             <directoryMode>0755</directoryMode>
-            <outputFileNameMapping>${artifact.groupId}-${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
+            <outputFileNameMapping>${artifact.groupId}-${artifact.artifactId}-${artifact.version}-bin.${artifact.extension}</outputFileNameMapping>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
In commit 56285ad89cc2ba7b9ea540cfb0de25f411d14e29, which modifies the way that Brooklyn dist is built, @ahgittin notes: *"finalName affects name in `target/` but we cannot influence name when it is attached/installed, so `apache-` prefix would be lost there. to keep it consistent this is commented out, but would be nice to have if there is a way!"*

However I am not certain why this is an issue, and why we need to insist that the built artifact name must be consistent with the attached-artifact name. The primary concern of the distribution is a single downloadable binary archive. This archive should be named appropriately for the product, and convention dictates that the archive contains a single directory with the same name as the archive, and that directory contains all the files. maven-assembly-plugin will also upload them to the repository, but forces them to be a particular name. However, *that isn't important* - users aren't going to get the binary download by digging through Maven repositories, they are going to get it from the Apache download page. The Maven artifact of the distribution is merely a side effect, so does it really matter what its name is?

This PR changes the name of the archives to `apache-brooklyn-VERSION-bin.tar.gz` and `.zip`. Each contains a single folder, `apache-brooklyn-VERSION-bin`, which contains all the files for the distribution.

This corresponds to the release process, which is producing names and formats identical except that `bin` is substituted for `src`.