### PR TITLE
More uniform handling of YAML flags

### DIFF
--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/BrooklynCampReservedKeys.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/BrooklynCampReservedKeys.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.brooklyn.camp.brooklyn;
+
+public interface BrooklynCampReservedKeys {
+    public static final String BROOKLYN_CONFIG = "brooklyn.config";
+    public static final String BROOKLYN_FLAGS = "brooklyn.flags";
+    public static final String BROOKLYN_POLICIES = "brooklyn.policies";
+    public static final String BROOKLYN_ENRICHERS = "brooklyn.enrichers";
+    public static final String BROOKLYN_CHILDREN = "brooklyn.children";
+    public static final String BROOKLYN_INITIALIZERS = "brooklyn.initializers";
+    public static final String BROOKLYN_CATALOG = "brooklyn.catalog";
+}

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -348,11 +348,17 @@ public class BrooklynComponentTemplateResolver {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     protected void configureEntityConfig(EntitySpec<?> spec) {
-        ConfigBag bag = ConfigBag.newInstance((Map<Object, Object>) attrs.getStringKey("brooklyn.config"));
-
         // first take *recognised* flags and config keys from the top-level, and put them in the bag (of brooklyn.config)
-        // (for component templates this will have been done already by BrooklynEntityMatcher, but for specs it is needed here)
+        // attrs will contain only brooklyn.xxx properties when coming from BrooklynEntityMatcher.
+        // Any top-level flags will go into "brooklyn.flags". When resolving a spec from $brooklyn:entitySpec
+        // top level flags remain in place. Have to support both cases.
+
+        ConfigBag bag = ConfigBag.newInstance((Map<Object, Object>) attrs.getStringKey(BrooklynCampReservedKeys.BROOKLYN_CONFIG));
         ConfigBag bagFlags = ConfigBag.newInstanceCopying(attrs);
+        if (attrs.containsKey(BrooklynCampReservedKeys.BROOKLYN_FLAGS)) {
+            bagFlags.putAll((Map<String, Object>) attrs.getStringKey(BrooklynCampReservedKeys.BROOKLYN_FLAGS));
+        }
+
         List<FlagConfigKeyAndValueRecord> topLevelApparentConfig = FlagUtils.findAllFlagsAndConfigKeys(null, spec.getType(), bagFlags);
         for (FlagConfigKeyAndValueRecord r: topLevelApparentConfig) {
             if (r.getConfigKeyMaybeValue().isPresent())

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -19,6 +19,7 @@
 package io.brooklyn.camp.brooklyn.spi.creation;
 
 import io.brooklyn.camp.brooklyn.BrooklynCampConstants;
+import io.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 import io.brooklyn.camp.brooklyn.spi.creation.service.BrooklynServiceTypeResolver;
 import io.brooklyn.camp.brooklyn.spi.creation.service.ServiceTypeResolver;
 import io.brooklyn.camp.spi.AbstractResource;
@@ -293,7 +294,7 @@ public class BrooklynComponentTemplateResolver {
         if (planId==null)
             planId = (String) attrs.getStringKey(BrooklynCampConstants.PLAN_ID_FLAG);
 
-        Object childrenObj = attrs.getStringKey("brooklyn.children");
+        Object childrenObj = attrs.getStringKey(BrooklynCampReservedKeys.BROOKLYN_CHILDREN);
         if (childrenObj != null) {
             // Creating a new set of encounteredCatalogTypes means that this won't check things recursively;
             // but we are looking at children so we probably *should* be resetting the recursive list we've looked at;
@@ -462,7 +463,7 @@ public class BrooklynComponentTemplateResolver {
     @SuppressWarnings("unchecked")
     protected List<Map<String, Object>> getChildren(Map<String, Object> attrs) {
         if (attrs==null) return null;
-        return (List<Map<String, Object>>) attrs.get("brooklyn.children");
+        return (List<Map<String, Object>>) attrs.get(BrooklynCampReservedKeys.BROOKLYN_CHILDREN);
     }
 
 }

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
@@ -18,6 +18,7 @@
  */
 package io.brooklyn.camp.brooklyn.spi.creation;
 
+import io.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 import io.brooklyn.camp.brooklyn.spi.creation.BrooklynYamlTypeInstantiator.InstantiatorFromKey;
 
 import java.util.List;
@@ -98,7 +99,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
         
         @Override
         protected Object getDecorationAttributeJsonValue(ConfigBag attrs) {
-            return attrs.getStringKey("brooklyn.policies");
+            return attrs.getStringKey(BrooklynCampReservedKeys.BROOKLYN_POLICIES);
         }
 
         @Override
@@ -144,7 +145,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
         
         @Override
         protected Object getDecorationAttributeJsonValue(ConfigBag attrs) {
-            return attrs.getStringKey("brooklyn.enrichers");
+            return attrs.getStringKey(BrooklynCampReservedKeys.BROOKLYN_ENRICHERS);
         }
 
         @Override
@@ -167,7 +168,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
         
         @Override
         protected Object getDecorationAttributeJsonValue(ConfigBag attrs) {
-            return attrs.getStringKey("brooklyn.initializers");
+            return attrs.getStringKey(BrooklynCampReservedKeys.BROOKLYN_INITIALIZERS);
         }
 
         @Override

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
@@ -32,6 +32,7 @@ import brooklyn.util.config.ConfigBag;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.guava.Maybe;
 import brooklyn.util.javalang.Reflections;
+import io.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
@@ -155,7 +156,7 @@ public abstract class BrooklynYamlTypeInstantiator {
         @Nonnull
         public Map<String,?> getConfigMap() {
             MutableMap<String,Object> result = MutableMap.of();
-            Object bc = data.getStringKey("brooklyn.config");
+            Object bc = data.getStringKey(BrooklynCampReservedKeys.BROOKLYN_CONFIG);
             if (bc!=null) {
                 if (bc instanceof Map)
                     result.putAll((Map<? extends String, ?>) bc);

--- a/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/usage/camp/src/main/java/io/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -18,6 +18,7 @@
  */
 package io.brooklyn.camp.brooklyn.spi.dsl.methods;
 
+import io.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 import io.brooklyn.camp.brooklyn.spi.creation.BrooklynYamlTypeInstantiator;
 import io.brooklyn.camp.brooklyn.spi.creation.EntitySpecConfiguration;
 import io.brooklyn.camp.brooklyn.spi.dsl.BrooklynDslDeferredSupplier;
@@ -144,7 +145,7 @@ public class BrooklynDslCommon {
         ConfigBag config = ConfigBag.newInstance(arguments);
         String typeName = BrooklynYamlTypeInstantiator.InstantiatorFromKey.extractTypeName("object", config).orNull();
         Map<String,Object> objectFields = (Map<String, Object>) config.getStringKeyMaybe("object.fields").or(MutableMap.of());
-        Map<String,Object> brooklynConfig = (Map<String, Object>) config.getStringKeyMaybe("brooklyn.config").or(MutableMap.of());
+        Map<String,Object> brooklynConfig = (Map<String, Object>) config.getStringKeyMaybe(BrooklynCampReservedKeys.BROOKLYN_CONFIG).or(MutableMap.of());
         try {
             // TODO Should use catalog's classloader, rather than Class.forName; how to get that? Should we return a future?!
             Class<?> type = Class.forName(typeName);

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -171,6 +171,23 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Assert.assertNull(dynamicConfNameValue);
     }
 
+    @Test
+    public void testExplicitFlags() throws Exception {
+        Entity testEntity = setupAndCheckTestEntityInBasicYamlWith( 
+            "  brooklyn.flags:",
+            "    confName: Foo Bar");
+        Assert.assertEquals(testEntity.getConfig(TestEntity.CONF_NAME), "Foo Bar");
+    }
+
+    @Test
+    public void testUndeclaredExplicitFlagsIgnored() throws Exception {
+        Entity testEntity = setupAndCheckTestEntityInBasicYamlWith( 
+            "  brooklyn.flags:",
+            "    test.dynamic.confName: Foo Bar");
+        String dynamicConfNameValue = testEntity.getConfig(ConfigKeys.newStringConfigKey("test.dynamic.confName"));
+        Assert.assertNull(dynamicConfNameValue);
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testEmptyConfig() throws Exception {
@@ -615,6 +632,27 @@ public class EntitiesYamlTest extends AbstractYamlTest {
                 "     $brooklyn:entitySpec:\n"+
                 "       type: brooklyn.test.entity.TestEntity\n"+
                 "       confName: inchildspec\n";
+        
+        Application app = (Application) createStartWaitAndLogApplication(new StringReader(yaml));
+        TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
+        
+        TestEntity child = (TestEntity) entity.createAndManageChildFromConfig();
+        assertEquals(child.getConfig(TestEntity.CONF_NAME), "inchildspec");
+    }
+
+    @Test
+    public void testEntitySpecExplicitFlags() throws Exception {
+        String yaml =
+                "services:\n"+
+                "- serviceType: brooklyn.test.entity.TestEntity\n"+
+                "  brooklyn.flags:\n"+
+                "    confName: inParent\n"+
+                "  brooklyn.config:\n"+
+                "   test.childSpec:\n"+
+                "     $brooklyn:entitySpec:\n"+
+                "       type: brooklyn.test.entity.TestEntity\n"+
+                "       brooklyn.flags:\n"+
+                "         confName: inchildspec\n";
         
         Application app = (Application) createStartWaitAndLogApplication(new StringReader(yaml));
         TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -156,6 +156,16 @@ public class EntitiesYamlTest extends AbstractYamlTest {
     }
 
     @Test
+    public void testFlagAtRootEntityImpl() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- serviceType: " + TestEntityImpl.class.getName(),
+                "  confName: Foo Bar");
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        Assert.assertEquals(testEntity.getConfig(TestEntity.CONF_NAME), "Foo Bar");
+    }
+
+    @Test
     public void testConfigKeyAtRoot() throws Exception {
         Entity testEntity = setupAndCheckTestEntityInBasicYamlWith( 
             "  test.confName: Foo Bar");
@@ -176,6 +186,17 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Entity testEntity = setupAndCheckTestEntityInBasicYamlWith( 
             "  brooklyn.flags:",
             "    confName: Foo Bar");
+        Assert.assertEquals(testEntity.getConfig(TestEntity.CONF_NAME), "Foo Bar");
+    }
+
+    @Test
+    public void testExplicitFlagsEntityImpl() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- serviceType: " + TestEntityImpl.class.getName(),
+                "  brooklyn.flags:",
+                "    confName: Foo Bar");
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
         Assert.assertEquals(testEntity.getConfig(TestEntity.CONF_NAME), "Foo Bar");
     }
 

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/JavaWebAppsMatchingTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/JavaWebAppsMatchingTest.java
@@ -87,7 +87,7 @@ public class JavaWebAppsMatchingTest {
         
         DeploymentPlan plan = platform.pdp().parseDeploymentPlan(input);
         log.info("DP is:\n"+plan.toString());
-        Map<?,?> cfg1 = (Map<?, ?>) plan.getServices().get(0).getCustomAttributes().get("brooklyn.config");
+        Map<?,?> cfg1 = (Map<?, ?>) plan.getServices().get(0).getCustomAttributes().get(BrooklynCampReservedKeys.BROOKLYN_CONFIG);
         Map<?,?> cfg = MutableMap.copyOf(cfg1);
         
         Assert.assertEquals(cfg.remove("literalValue1"), "$brooklyn: is a fun place");
@@ -106,7 +106,7 @@ public class JavaWebAppsMatchingTest {
         Assert.assertEquals(at.getCustomAttributes().get("location"), "localhost");
         
         PlatformComponentTemplate pct = at.getPlatformComponentTemplates().links().iterator().next().resolve();
-        Object cfg2 = pct.getCustomAttributes().get("brooklyn.config");
+        Object cfg2 = pct.getCustomAttributes().get(BrooklynCampReservedKeys.BROOKLYN_CONFIG);
         Assert.assertEquals(cfg2, cfg1);
     }
 
@@ -133,7 +133,7 @@ public class JavaWebAppsMatchingTest {
 
         PlatformComponentTemplate pct2 = pcti.next().resolve(); 
 
-        Map<?,?> config = (Map<?, ?>) pct1.getCustomAttributes().get("brooklyn.config");
+        Map<?,?> config = (Map<?, ?>) pct1.getCustomAttributes().get(BrooklynCampReservedKeys.BROOKLYN_CONFIG);
         Map<?,?> javaSysProps = (Map<?, ?>) config.get("java.sysprops");
         Object dbUrl = javaSysProps.get("brooklyn.example.db.url");
         Assert.assertTrue(dbUrl instanceof DeferredSupplier<?>, "url is: "+dbUrl);

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -38,6 +38,7 @@ import brooklyn.entity.basic.BasicEntity;
 import brooklyn.management.osgi.OsgiStandaloneTest;
 import brooklyn.management.osgi.OsgiTestResources;
 import brooklyn.test.TestResourceUnavailableException;
+import brooklyn.test.entity.TestEntity;
 import brooklyn.util.ResourceUtils;
 import brooklyn.util.collections.MutableList;
 import brooklyn.util.exceptions.Exceptions;
@@ -609,7 +610,54 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             assertTrue(e.toString().contains("recursive"), "Unexpected error message: "+e);
         }
     }
+
+    @Test
+    public void testConfigAppliedToCatalogItem() throws Exception {
+        addTestEntityCatalogItem();
+        String testName = "test-applies-config-on-catalog-item";
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + ver("test"),
+                "  brooklyn.config:",
+                "    test.confName: " + testName);
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
+    }
+
+    @Test
+    public void testFlagsAppliesToCatalogItem() throws Exception {
+        addTestEntityCatalogItem();
+        String testName = "test-applies-config-on-catalog-item";
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + ver("test"),
+                "  confName: " + testName);
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
+    }
+
+    @Test
+    public void testExplicitFlagsAppliesToCatalogItem() throws Exception {
+        addTestEntityCatalogItem();
+        String testName = "test-applies-config-on-catalog-item";
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + ver("test"),
+                "  brooklyn.flags:",
+                "    confName: " + testName);
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
+    }
     
+    private void addTestEntityCatalogItem() {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "   id: test",
+                "   version: " + TEST_VERSION,
+                "services:",
+                "- type: " + TestEntity.class.getName());
+    }
+
     private void registerAndLaunchAndAssertSimpleEntity(String symbolicName, String serviceType) throws Exception {
         addCatalogOSGiEntity(symbolicName, serviceType);
         String yaml = "name: simple-app-yaml\n" +

--- a/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/usage/camp/src/test/java/io/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -39,6 +39,7 @@ import brooklyn.management.osgi.OsgiStandaloneTest;
 import brooklyn.management.osgi.OsgiTestResources;
 import brooklyn.test.TestResourceUnavailableException;
 import brooklyn.test.entity.TestEntity;
+import brooklyn.test.entity.TestEntityImpl;
 import brooklyn.util.ResourceUtils;
 import brooklyn.util.collections.MutableList;
 import brooklyn.util.exceptions.Exceptions;
@@ -613,7 +614,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
 
     @Test
     public void testConfigAppliedToCatalogItem() throws Exception {
-        addTestEntityCatalogItem();
+        addCatalogOSGiEntity("test", TestEntity.class.getName());
         String testName = "test-applies-config-on-catalog-item";
         Entity app = createAndStartApplication(
                 "services:",
@@ -626,7 +627,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
 
     @Test
     public void testFlagsAppliesToCatalogItem() throws Exception {
-        addTestEntityCatalogItem();
+        addCatalogOSGiEntity("test", TestEntity.class.getName());
         String testName = "test-applies-config-on-catalog-item";
         Entity app = createAndStartApplication(
                 "services:",
@@ -638,7 +639,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
 
     @Test
     public void testExplicitFlagsAppliesToCatalogItem() throws Exception {
-        addTestEntityCatalogItem();
+        addCatalogOSGiEntity("test", TestEntity.class.getName());
         String testName = "test-applies-config-on-catalog-item";
         Entity app = createAndStartApplication(
                 "services:",
@@ -649,15 +650,45 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
     }
     
-    private void addTestEntityCatalogItem() {
-        addCatalogItems(
-                "brooklyn.catalog:",
-                "   id: test",
-                "   version: " + TEST_VERSION,
+
+    @Test
+    public void testConfigAppliedToCatalogItemImpl() throws Exception {
+        addCatalogOSGiEntity("test", TestEntityImpl.class.getName());
+        String testName = "test-applies-config-on-catalog-item";
+        Entity app = createAndStartApplication(
                 "services:",
-                "- type: " + TestEntity.class.getName());
+                "- type: " + ver("test"),
+                "  brooklyn.config:",
+                "    test.confName: " + testName);
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
     }
 
+    @Test
+    public void testFlagsAppliesToCatalogItemImpl() throws Exception {
+        addCatalogOSGiEntity("test", TestEntityImpl.class.getName());
+        String testName = "test-applies-config-on-catalog-item";
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + ver("test"),
+                "  confName: " + testName);
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
+    }
+
+    @Test
+    public void testExplicitFlagsAppliesToCatalogItemImpl() throws Exception {
+        addCatalogOSGiEntity("test", TestEntityImpl.class.getName());
+        String testName = "test-applies-config-on-catalog-item";
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + ver("test"),
+                "  brooklyn.flags:",
+                "    confName: " + testName);
+        Entity testEntity = Iterables.getOnlyElement(app.getChildren());
+        assertEquals(testEntity.config().get(TestEntity.CONF_NAME), testName);
+    }
+    
     private void registerAndLaunchAndAssertSimpleEntity(String symbolicName, String serviceType) throws Exception {
         addCatalogOSGiEntity(symbolicName, serviceType);
         String yaml = "name: simple-app-yaml\n" +


### PR DESCRIPTION
* Apply flags on catalog items
* Apply flags for fields declared in the entity implementation (or any of the non-primary interfaces)

Makes flags handling more uniform regardless of the entity type (i.e. interface, catalog item, implementation).
