### PR TITLE
Fix build order - launcher has build-time depency on jsgui

### DIFF
--- a/usage/launcher/pom.xml
+++ b/usage/launcher/pom.xml
@@ -77,6 +77,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-jsgui</artifactId>
+            <type>war</type>
+            <!-- Needed during build time only -->
+            <scope>provided</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
         </dependency>


### PR DESCRIPTION
Also make the ordering more natural - almost all projects depend on `utils`. `all`, `dist`, `qa` are includes-all modules.

The build would use an older version of `jsgui` (not the one being compiled with the project), or fail if none is available because `launcher` was built before `jsgui`.  Since `launcher` has only build time dependency on `jsgui` it's not convenient to include it in the dependencies section because it would have to be excluded manually in every project that depends on `launcher`.