### PR TITLE
Unescapes sensor and config values before copying to clipboard

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-config.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-config.js
@@ -180,11 +180,11 @@ define([
                     // the zeroClipboard instance is a singleton so check our scope first
                     if (!$(this).closest("#config-table").length) return;
                     var text = $(this).attr('copy-value');
-                    if (!text) text = $(this).closest('.floatGroup').find('.value').html();
+                    if (!text) text = $(this).closest('.floatGroup').find('.value').text();
                     
 //                    log("Copying config text '"+text+"' to clipboard");
                     client.setText(text);
-                    
+
                     // show the word "copied" for feedback;
                     // NB this occurs on mousedown, due to how flash plugin works
                     // (same style of feedback and interaction as github)

--- a/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/entity-sensors.js
@@ -188,8 +188,8 @@ define([
                     // the zeroClipboard instance is a singleton so check our scope first
                     if (!$(this).closest("#sensors-table").length) return;
                     var text = $(this).attr('copy-value');
-                    if (!text) text = $(this).closest('.floatGroup').find('.value').html();
-                    
+                    if (!text) text = $(this).closest('.floatGroup').find('.value').text();
+
 //                    log("Copying sensors text '"+text+"' to clipboard");
                     client.setText(text);
                     


### PR DESCRIPTION
Previously `foo&bar` was being copied to the clipboard as `foo&amp;bar`