### PR TITLE
Rename base package from brooklyn to org.apache.brooklyn - step 2

### DIFF
--- a/usage/dist/src/test/java/org/apache/brooklyn/cli/BaseCliIntegrationTest.java
+++ b/usage/dist/src/test/java/org/apache/brooklyn/cli/BaseCliIntegrationTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.cli;
+package org.apache.brooklyn.cli;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;

--- a/usage/dist/src/test/java/org/apache/brooklyn/cli/CliIntegrationTest.java
+++ b/usage/dist/src/test/java/org/apache/brooklyn/cli/CliIntegrationTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.cli;
+package org.apache.brooklyn.cli;
 
 import org.testng.annotations.Test;
 

--- a/usage/jsgui/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncher.java
+++ b/usage/jsgui/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncher.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.rest.jsgui;
+package org.apache.brooklyn.rest.jsgui;
 
 import java.net.InetSocketAddress;
 

--- a/usage/jsgui/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncherTest.java
+++ b/usage/jsgui/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncherTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.rest.jsgui;
+package org.apache.brooklyn.rest.jsgui;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;

--- a/usage/rest-client/src/main/java/org/apache/brooklyn/rest/client/BrooklynApi.java
+++ b/usage/rest-client/src/main/java/org/apache/brooklyn/rest/client/BrooklynApi.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.rest.client;
+package org.apache.brooklyn.rest.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -62,7 +62,7 @@ import brooklyn.rest.api.ServerApi;
 import brooklyn.rest.api.UsageApi;
 import brooklyn.rest.api.VersionApi;
 import brooklyn.util.exceptions.Exceptions;
-import brooklyn.util.http.BuiltResponsePreservingError;
+import org.apache.brooklyn.util.http.BuiltResponsePreservingError;
 
 import com.wordnik.swagger.core.ApiOperation;
 

--- a/usage/rest-client/src/main/java/org/apache/brooklyn/util/http/BuiltResponsePreservingError.java
+++ b/usage/rest-client/src/main/java/org/apache/brooklyn/util/http/BuiltResponsePreservingError.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.util.http;
+package org.apache.brooklyn.util.http;
 
 import java.lang.annotation.Annotation;
 

--- a/usage/rest-client/src/test/java/org/apache/brooklyn/rest/client/ApplicationResourceIntegrationTest.java
+++ b/usage/rest-client/src/test/java/org/apache/brooklyn/rest/client/ApplicationResourceIntegrationTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.rest.client;
+package org.apache.brooklyn.rest.client;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;

--- a/usage/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
+++ b/usage/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.rest.client;
+package org.apache.brooklyn.rest.client;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Rename more packages to add the org.apache prefix.

I have run mvn clean install (which runs the unit tests). For some reason running mvn test alone fails with the following error:

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:2.8:copy (copy) on project brooklyn-software-base: Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187. -> [Help 1]

Maybe some dependencies were missed?

Please review.