### PR TITLE
Fix httpclient version mismatch in pom

### DIFF
--- a/usage/downstream-parent/pom.xml
+++ b/usage/downstream-parent/pom.xml
@@ -58,7 +58,7 @@
     <jackson.version>1.9.13</jackson.version>  <!-- codehaus jackson, used by brooklyn rest server -->
     <fasterxml.jackson.version>2.4.2</fasterxml.jackson.version>  <!-- more recent jackson, but not compatible with old annotations! -->
     <jersey.version>1.18.1</jersey.version>
-    <httpclient.version>4.2.5</httpclient.version>
+    <httpclient.version>4.4.1</httpclient.version>
     <commons-lang3.version>3.1</commons-lang3.version>
     <groovy.version>2.3.4</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.0-Release-Notes -->
     <jsr305.version>2.0.1</jsr305.version>


### PR DESCRIPTION
In commit 3fb4d9a @andreaturli bumped the httpclient version in the parent pom, but he didn't update the version in `brooklyn-downstream-parent` pom. This was causing dependency convergence errors in downstream projects.