### PR TITLE
Support suspending machines

### DIFF
--- a/api/src/main/java/brooklyn/location/MachineManagementMixins.java
+++ b/api/src/main/java/brooklyn/location/MachineManagementMixins.java
@@ -20,18 +20,26 @@ package brooklyn.location;
 
 import java.util.Map;
 
+/**
+ * Defines mixins for interesting locations.
+ */
 public class MachineManagementMixins {
     
-    public interface RichMachineProvisioningLocation<T extends MachineLocation> extends MachineProvisioningLocation<T>, ListsMachines, GivesMachineMetadata, KillsMachines {}
-    
+    public interface RichMachineProvisioningLocation<T extends MachineLocation> extends
+            MachineProvisioningLocation<T>, ListsMachines, GivesMachineMetadata, KillsMachines {}
+
     public interface ListsMachines {
-        /** returns map of machine ID to metadata record for all machines known in a given cloud location */ 
+        /**
+         * @return A map of machine ID to metadata record for all machines known in a given cloud location.
+         */
         Map<String,MachineMetadata> listMachines();
     }
     
     public interface GivesMachineMetadata {
-        /** returns the MachineMetadata for a given (brooklyn) machine location instance, 
-         * or null if not matched */
+        /**
+         * @return the {@link MachineMetadata} for a given (brooklyn) machine location instance,
+         * or null if not matched.
+         */
         MachineMetadata getMachineMetadata(MachineLocation location);
     }
     
@@ -55,5 +63,26 @@ public class MachineManagementMixins {
         /** original metadata object, if available; e.g. ComputeMetadata when using jclouds */ 
         Object getOriginalMetadata();
     }
-    
+
+    /**
+     * Implement to indicate that a location can suspend and resume machines.
+     */
+    public interface SuspendResumeLocation<T extends MachineLocation> extends
+            SuspendsMachines, ResumesMachines {};
+
+
+    public interface SuspendsMachines {
+        /**
+         * Suspend the indicated machine.
+         */
+        void suspendMachine(MachineLocation location);
+    }
+
+    public interface ResumesMachines {
+        /**
+         * Resume the indicated machine.
+         */
+        void resumeMachine(MachineLocation location);
+    }
+
 }

--- a/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/brooklyn/location/jclouds/JcloudsLocation.java
@@ -105,6 +105,7 @@ import brooklyn.location.LocationSpec;
 import brooklyn.location.MachineLocation;
 import brooklyn.location.MachineManagementMixins.MachineMetadata;
 import brooklyn.location.MachineManagementMixins.RichMachineProvisioningLocation;
+import brooklyn.location.MachineManagementMixins.SuspendResumeLocation;
 import brooklyn.location.NoMachinesAvailableException;
 import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.access.PortMapping;
@@ -181,14 +182,15 @@ import com.google.common.collect.Sets.SetView;
 import com.google.common.io.Files;
 import com.google.common.net.HostAndPort;
 import com.google.common.primitives.Ints;
-import com.google.common.reflect.TypeToken;
 
 /**
  * For provisioning and managing VMs in a particular provider/region, using jclouds.
  * Configuration flags are defined in {@link JcloudsLocationConfig}.
  */
 @SuppressWarnings("serial")
-public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation implements JcloudsLocationConfig, RichMachineProvisioningLocation<MachineLocation>, LocationWithObjectStore {
+public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation implements
+        JcloudsLocationConfig, RichMachineProvisioningLocation<MachineLocation>,
+        LocationWithObjectStore, SuspendResumeLocation<MachineLocation> {
 
     // TODO After converting from Groovy to Java, this is now very bad code! It relies entirely on putting
     // things into and taking them out of maps; it's not type-safe, and it's thus very error-prone.
@@ -1006,6 +1008,18 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
             throw Exceptions.propagate(e);
         }
+    }
+
+    // ------------- suspend and resume ------------------------------------
+
+    @Override
+    public void suspendMachine(MachineLocation location) {
+        getComputeService().suspendNode(location.getId());
+    }
+
+    @Override
+    public void resumeMachine(MachineLocation location) {
+        getComputeService().resumeNode(location.getId());
     }
 
     // ------------- constructing the template, etc ------------------------

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -55,6 +55,7 @@ import brooklyn.entity.trait.StartableMethods;
 import brooklyn.event.feed.ConfigToAttributes;
 import brooklyn.location.Location;
 import brooklyn.location.MachineLocation;
+import brooklyn.location.MachineManagementMixins.SuspendsMachines;
 import brooklyn.location.MachineProvisioningLocation;
 import brooklyn.location.NoMachinesAvailableException;
 import brooklyn.location.basic.AbstractLocation;
@@ -63,7 +64,6 @@ import brooklyn.location.basic.Locations;
 import brooklyn.location.basic.Machines;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.management.Task;
-import brooklyn.management.TaskFactory;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.config.ConfigBag;
 import brooklyn.util.exceptions.Exceptions;
@@ -151,8 +151,18 @@ public abstract class MachineLifecycleEffectorTasks {
                 .build();
     }
 
+    /** @see {@link #newStartEffector()} */
+    public Effector<Void> newSuspendEffector() {
+        return Effectors.effector(Void.class, "suspend")
+                .description("Suspend the process/service represented by an entity")
+                .parameter(StopSoftwareParameters.STOP_PROCESS_MODE)
+                .parameter(StopSoftwareParameters.STOP_MACHINE_MODE)
+                .impl(newSuspendEffectorTask())
+                .build();
+    }
+
     /**
-     * Returns the {@link TaskFactory} which supplies the implementation for the start effector.
+     * Returns the {@link EffectorBody} which supplies the implementation for the start effector.
      * <p>
      * Calls {@link #start(Collection)} in this class.
      */
@@ -192,7 +202,7 @@ public abstract class MachineLifecycleEffectorTasks {
     }
 
     /**
-     * Calls {@link #stop()}.
+     * Calls {@link #stop(ConfigBag)}.
      *
      * @see {@link #newStartEffectorTask()}
      */
@@ -201,6 +211,21 @@ public abstract class MachineLifecycleEffectorTasks {
             @Override
             public Void call(ConfigBag parameters) {
                 stop(parameters);
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Calls {@link #suspend(ConfigBag)}.
+     *
+     * @see {@link #newStartEffectorTask()}
+     */
+    public EffectorBody<Void> newSuspendEffectorTask() {
+        return new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                suspend(parameters);
                 return null;
             }
         };
@@ -550,6 +575,27 @@ public abstract class MachineLifecycleEffectorTasks {
      * If no errors were encountered call {@link #postStopCustom()} at the end.
      */
     public void stop(ConfigBag parameters) {
+        doStop(parameters, new Callable<StopMachineDetails<Integer>>() {
+            public StopMachineDetails<Integer> call() {
+                return stopAnyProvisionedMachines();
+            }
+        });
+    }
+
+    /**
+     * As {@link #stop} but calling {@link #suspendAnyProvisionedMachines} rather than
+     * {@link #stopAnyProvisionedMachines}.
+     */
+    public void suspend(ConfigBag parameters) {
+        doStop(parameters, new Callable<StopMachineDetails<Integer>>() {
+            @Override
+            public StopMachineDetails<Integer> call() throws Exception {
+                return suspendAnyProvisionedMachines();
+            }
+        });
+    }
+
+    protected void doStop(ConfigBag parameters, Callable<StopMachineDetails<Integer>> stopTask) {
         preStopConfirmCustom();
 
         log.info("Stopping {} in {}", entity(), entity().getLocations());
@@ -582,11 +628,7 @@ public abstract class MachineLifecycleEffectorTasks {
         Task<StopMachineDetails<Integer>> stoppingMachine = null;
         if (canStop(stopMachineMode, machine.isAbsent())) {
             // Release this machine (even if error trying to stop process - we rethrow that after)
-            stoppingMachine = DynamicTasks.queue("stopping (machine)", new Callable<StopMachineDetails<Integer>>() {
-                public StopMachineDetails<Integer> call() {
-                    return stopAnyProvisionedMachines();
-                }
-            });
+            stoppingMachine = DynamicTasks.queue("stopping (machine)", stopTask);
 
             DynamicTasks.drain(entity().getConfig(STOP_PROCESS_TIMEOUT), false);
 
@@ -724,7 +766,7 @@ public abstract class MachineLifecycleEffectorTasks {
     protected abstract String stopProcessesAtMachine();
 
     /**
-     * Stop the {@link MachineLocation} the entity is provisioned at.
+     * Stop and release the {@link MachineLocation} the entity is provisioned at.
      * <p>
      * Can run synchronously or not, caller will submit/queue as needed, and will block on any submitted tasks.
      */
@@ -749,17 +791,70 @@ public abstract class MachineLifecycleEffectorTasks {
             return new StopMachineDetails<Integer>("No machine decommissioning necessary - not a machine ("+machine+")", 0);
         }
         
+        clearEntityLocationAttributes(machine);
         try {
-            entity().removeLocations(ImmutableList.of(machine));
-            entity().setAttribute(Attributes.HOSTNAME, null);
-            entity().setAttribute(Attributes.ADDRESS, null);
-            entity().setAttribute(Attributes.SUBNET_HOSTNAME, null);
-            entity().setAttribute(Attributes.SUBNET_ADDRESS, null);
-            if (provisioner != null) provisioner.release((MachineLocation)machine);
+            provisioner.release((MachineLocation)machine);
         } catch (Throwable t) {
             throw Exceptions.propagate(t);
         }
         return new StopMachineDetails<Integer>("Decommissioned "+machine, 1);
+    }
+
+    /**
+     * Suspend the {@link MachineLocation} the entity is provisioned at.
+     * <p>
+     * Expects the entity's {@link SoftwareProcess#PROVISIONING_LOCATION provisioner} to be capable of
+     * {@link SuspendsMachines suspending machines}.
+     *
+     * @throws java.lang.UnsupportedOperationException if the entity's provisioner cannot suspend machines.
+     * @see brooklyn.location.MachineManagementMixins.SuspendsMachines
+     */
+    protected StopMachineDetails<Integer> suspendAnyProvisionedMachines() {
+        @SuppressWarnings("unchecked")
+        MachineProvisioningLocation<MachineLocation> provisioner = entity().getAttribute(SoftwareProcess.PROVISIONING_LOCATION);
+
+        if (Iterables.isEmpty(entity().getLocations())) {
+            log.debug("No machine decommissioning necessary for " + entity() + " - no locations");
+            return new StopMachineDetails<>("No machine suspend necessary - no locations", 0);
+        }
+
+        // Only release this machine if we ourselves provisioned it (e.g. it might be running other services)
+        if (provisioner == null) {
+            log.debug("No machine decommissioning necessary for " + entity() + " - did not provision");
+            return new StopMachineDetails<>("No machine suspend necessary - did not provision", 0);
+        }
+
+        Location machine = getLocation(null);
+        if (!(machine instanceof MachineLocation)) {
+            log.debug("No decommissioning necessary for " + entity() + " - not a machine location (" + machine + ")");
+            return new StopMachineDetails<>("No machine suspend necessary - not a machine (" + machine + ")", 0);
+        }
+
+        if (!(provisioner instanceof SuspendsMachines)) {
+            log.debug("Location provisioner ({}) cannot suspend machines", provisioner);
+            throw new UnsupportedOperationException("Location provisioner cannot suspend machines: " + provisioner);
+        }
+
+        clearEntityLocationAttributes(machine);
+        try {
+            SuspendsMachines.class.cast(provisioner).suspendMachine(MachineLocation.class.cast(machine));
+        } catch (Throwable t) {
+            throw Exceptions.propagate(t);
+        }
+
+        return new StopMachineDetails<>("Suspended " + machine, 1);
+    }
+
+    /**
+     * Nulls the attached entity's hostname, address, subnet hostname and subnet address sensors
+     * and removes the given machine from its locations.
+     */
+    protected void clearEntityLocationAttributes(Location machine) {
+        entity().removeLocations(ImmutableList.of(machine));
+        entity().setAttribute(Attributes.HOSTNAME, null);
+        entity().setAttribute(Attributes.ADDRESS, null);
+        entity().setAttribute(Attributes.SUBNET_HOSTNAME, null);
+        entity().setAttribute(Attributes.SUBNET_ADDRESS, null);
     }
 
 }


### PR DESCRIPTION
Locations can indicate that they can suspend machines by implementing a new `SuspendsMachines` interface. 

A use of this is given in `MachineLifecycleEffectorTasks`, which provides a `suspend` effector implementation. Attaching this effector to entities is left to subclasses of MLET.