### PR TITLE
Support suspending machines

### DIFF
--- a/api/src/main/java/brooklyn/location/MachineManagementMixins.java
+++ b/api/src/main/java/brooklyn/location/MachineManagementMixins.java
@@ -20,18 +20,28 @@ package brooklyn.location;
 
 import java.util.Map;
 
+import com.google.common.annotations.Beta;
+
+/**
+ * Defines mixins for interesting locations.
+ */
 public class MachineManagementMixins {
     
-    public interface RichMachineProvisioningLocation<T extends MachineLocation> extends MachineProvisioningLocation<T>, ListsMachines, GivesMachineMetadata, KillsMachines {}
-    
+    public interface RichMachineProvisioningLocation<T extends MachineLocation> extends
+            MachineProvisioningLocation<T>, ListsMachines, GivesMachineMetadata, KillsMachines {}
+
     public interface ListsMachines {
-        /** returns map of machine ID to metadata record for all machines known in a given cloud location */ 
+        /**
+         * @return A map of machine ID to metadata record for all machines known in a given cloud location.
+         */
         Map<String,MachineMetadata> listMachines();
     }
     
     public interface GivesMachineMetadata {
-        /** returns the MachineMetadata for a given (brooklyn) machine location instance, 
-         * or null if not matched */
+        /**
+         * @return the {@link MachineMetadata} for a given (brooklyn) machine location instance,
+         * or null if not matched.
+         */
         MachineMetadata getMachineMetadata(MachineLocation location);
     }
     
@@ -55,5 +65,28 @@ public class MachineManagementMixins {
         /** original metadata object, if available; e.g. ComputeMetadata when using jclouds */ 
         Object getOriginalMetadata();
     }
-    
+
+    /**
+     * Implement to indicate that a location can suspend and resume machines.
+     */
+    @Beta
+    public interface SuspendResumeLocation extends SuspendsMachines, ResumesMachines {};
+
+
+    @Beta
+    public interface SuspendsMachines {
+        /**
+         * Suspend the indicated machine.
+         */
+        void suspendMachine(MachineLocation location);
+    }
+
+    @Beta
+    public interface ResumesMachines {
+        /**
+         * Resume the indicated machine.
+         */
+        void resumeMachine(MachineLocation location);
+    }
+
 }

--- a/software/base/src/main/java/brooklyn/entity/basic/SameServerDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/basic/SameServerDriverLifecycleEffectorTasks.java
@@ -84,7 +84,7 @@ public class SameServerDriverLifecycleEffectorTasks extends MachineLifecycleEffe
                 value = maybeValue.isPresent() ? maybeValue.get() : null;
             }
 
-            Maybe<PortRange> maybePortRange = TypeCoercions.tryCoerce(value, new TypeToken<PortRange>() {});
+            Maybe<PortRange> maybePortRange = TypeCoercions.tryCoerce(value, TypeToken.of(PortRange.class));
 
             if (maybePortRange.isPresentAndNonNull()) {
                 PortRange p = maybePortRange.get();

--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -171,23 +171,26 @@ public abstract class MachineLifecycleEffectorTasks {
      * Calls {@link #start(Collection)} in this class.
      */
     public EffectorBody<Void> newStartEffectorTask() {
-        return new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                Collection<? extends Location> locations  = null;
+        return new StartEffectorBody();
+    }
 
-                Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
-                locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
+    private class StartEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            Collection<? extends Location> locations = null;
 
-                if (locations==null) {
-                    // null/empty will mean to inherit from parent
-                    locations = Collections.emptyList();
-                }
+            Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
+            locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
 
-                start(locations);
-                return null;
+            if (locations == null) {
+                // null/empty will mean to inherit from parent
+                locations = Collections.emptyList();
             }
-        };
+
+            start(locations);
+            return null;
+        }
+
     }
 
     /**
@@ -196,13 +199,15 @@ public abstract class MachineLifecycleEffectorTasks {
      * @see {@link #newStartEffectorTask()}
      */
     public EffectorBody<Void> newRestartEffectorTask() {
-        return new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                restart(parameters);
-                return null;
-            }
-        };
+        return new RestartEffectorBody();
+    }
+
+    private class RestartEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            restart(parameters);
+            return null;
+        }
     }
 
     /**
@@ -211,13 +216,15 @@ public abstract class MachineLifecycleEffectorTasks {
      * @see {@link #newStartEffectorTask()}
      */
     public EffectorBody<Void> newStopEffectorTask() {
-        return new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                stop(parameters);
-                return null;
-            }
-        };
+        return new StopEffectorBody();
+    }
+
+    private class StopEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            stop(parameters);
+            return null;
+        }
     }
 
     /**
@@ -226,13 +233,15 @@ public abstract class MachineLifecycleEffectorTasks {
      * @see {@link #newStartEffectorTask()}
      */
     public EffectorBody<Void> newSuspendEffectorTask() {
-        return new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                suspend(parameters);
-                return null;
-            }
-        };
+        return new SuspendEffectorBody();
+    }
+
+    private class SuspendEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            suspend(parameters);
+            return null;
+        }
     }
 
     protected EntityInternal entity() {
@@ -288,11 +297,19 @@ public abstract class MachineLifecycleEffectorTasks {
 
         final Supplier<MachineLocation> locationSF = locationS;
         preStartAtMachineAsync(locationSF);
-        DynamicTasks.queue("start (processes)", new Runnable() { public void run() {
-            startProcessesAtMachine(locationSF);
-        }});
+        DynamicTasks.queue("start (processes)", new StartProcessesAtMachineTask(locationSF));
         postStartAtMachineAsync();
-        return;
+    }
+
+    private class StartProcessesAtMachineTask implements Runnable {
+        private final Supplier<MachineLocation> machineSupplier;
+        private StartProcessesAtMachineTask(Supplier<MachineLocation> machineSupplier) {
+            this.machineSupplier = machineSupplier;
+        }
+        @Override
+        public void run() {
+            startProcessesAtMachine(machineSupplier);
+        }
     }
 
     /**
@@ -300,62 +317,89 @@ public abstract class MachineLifecycleEffectorTasks {
      * and returns that machine. The task can be used as a supplier to subsequent methods.
      */
     protected Task<MachineLocation> provisionAsync(final MachineProvisioningLocation<?> location) {
-        return DynamicTasks.queue(Tasks.<MachineLocation>builder().name("provisioning ("+location.getDisplayName()+")").body(
-                new Callable<MachineLocation>() {
-                    public MachineLocation call() throws Exception {
-                        // Blocks if a latch was configured.
-                        entity().getConfig(BrooklynConfigKeys.PROVISION_LATCH);
-                        final Map<String,Object> flags = obtainProvisioningFlags(location);
-                        if (!(location instanceof LocalhostMachineProvisioningLocation))
-                            log.info("Starting {}, obtaining a new location instance in {} with ports {}", new Object[] {entity(), location, flags.get("inboundPorts")});
-                        entity().setAttribute(SoftwareProcess.PROVISIONING_LOCATION, location);
-                        MachineLocation machine;
-                        try {
-                            machine = Tasks.withBlockingDetails("Provisioning machine in "+location, new Callable<MachineLocation>() {
-                                public MachineLocation call() throws NoMachinesAvailableException {
-                                    return location.obtain(flags);
-                                }});
-                            if (machine == null) throw new NoMachinesAvailableException("Failed to obtain machine in "+location.toString());
-                        } catch (Exception e) {
-                            throw Exceptions.propagate(e);
-                        }
+        return DynamicTasks.queue(Tasks.<MachineLocation>builder().name("provisioning (" + location.getDisplayName() + ")").body(
+                new ProvisionMachineTask(location)).build());
+    }
 
-                        if (log.isDebugEnabled())
-                            log.debug("While starting {}, obtained new location instance {}", entity(),
-                                    (machine instanceof SshMachineLocation ?
-                                            machine+", details "+((SshMachineLocation)machine).getUser()+":"+Sanitizer.sanitize(((SshMachineLocation)machine).config().getLocalBag())
-                                            : machine));
-                        return machine;
-                    }
-                }).build());
+    private class ProvisionMachineTask implements Callable<MachineLocation> {
+        final MachineProvisioningLocation<?> location;
+
+        private ProvisionMachineTask(MachineProvisioningLocation<?> location) {
+            this.location = location;
+        }
+
+        public MachineLocation call() throws Exception {
+            // Blocks if a latch was configured.
+            entity().getConfig(BrooklynConfigKeys.PROVISION_LATCH);
+            final Map<String, Object> flags = obtainProvisioningFlags(location);
+            if (!(location instanceof LocalhostMachineProvisioningLocation))
+                log.info("Starting {}, obtaining a new location instance in {} with ports {}", new Object[]{entity(), location, flags.get("inboundPorts")});
+            entity().setAttribute(SoftwareProcess.PROVISIONING_LOCATION, location);
+            MachineLocation machine;
+            try {
+                machine = Tasks.withBlockingDetails("Provisioning machine in " + location, new ObtainLocationTask(location, flags));
+                if (machine == null)
+                    throw new NoMachinesAvailableException("Failed to obtain machine in " + location.toString());
+            } catch (Exception e) {
+                throw Exceptions.propagate(e);
+            }
+
+            if (log.isDebugEnabled())
+                log.debug("While starting {}, obtained new location instance {}", entity(),
+                        (machine instanceof SshMachineLocation ?
+                         machine + ", details " + ((SshMachineLocation) machine).getUser() + ":" + Sanitizer.sanitize(((SshMachineLocation) machine).config().getLocalBag())
+                                                               : machine));
+            return machine;
+        }
+    }
+
+    private static class ObtainLocationTask implements Callable<MachineLocation> {
+        final MachineProvisioningLocation<?> location;
+        final Map<String, Object> flags;
+
+        private ObtainLocationTask(MachineProvisioningLocation<?> location, Map<String, Object> flags) {
+            this.flags = flags;
+            this.location = location;
+        }
+
+        public MachineLocation call() throws NoMachinesAvailableException {
+            return location.obtain(flags);
+        }
     }
 
     /** Wraps a call to {@link #preStartCustom(MachineLocation)}, after setting the hostname and address. */
     protected void preStartAtMachineAsync(final Supplier<MachineLocation> machineS) {
-        DynamicTasks.queue("pre-start", new Runnable() { public void run() {
-            MachineLocation machine = machineS.get();
+        DynamicTasks.queue("pre-start", new PreStartTask(machineS.get()));
+    }
+
+    private class PreStartTask implements Runnable {
+        final MachineLocation machine;
+        private PreStartTask(MachineLocation machine) {
+            this.machine = machine;
+        }
+        public void run() {
             log.info("Starting {} on machine {}", entity(), machine);
             Collection<Location> oldLocs = entity().getLocations();
             if (!oldLocs.isEmpty()) {
                 List<MachineLocation> oldSshLocs = ImmutableList.copyOf(Iterables.filter(oldLocs, MachineLocation.class));
                 if (!oldSshLocs.isEmpty()) {
                     // check if existing locations are compatible
-                    log.debug("Entity "+entity()+" had machine locations "+oldSshLocs+" when starting at "+machine+"; checking if they are compatible");
-                    for (MachineLocation oldLoc: oldSshLocs) {
+                    log.debug("Entity " + entity() + " had machine locations " + oldSshLocs + " when starting at " + machine + "; checking if they are compatible");
+                    for (MachineLocation oldLoc : oldSshLocs) {
                         // machines are deemed compatible if hostname and address are the same, or they are localhost
                         // this allows a machine create by jclouds to then be defined with an ip-based spec
                         if (!"localhost".equals(machine.getConfig(AbstractLocation.ORIGINAL_SPEC))) {
                             checkLocationParametersCompatible(machine, oldLoc, "hostname",
-                                oldLoc.getAddress().getHostName(), machine.getAddress().getHostName());
+                                    oldLoc.getAddress().getHostName(), machine.getAddress().getHostName());
                             checkLocationParametersCompatible(machine, oldLoc, "address",
-                                oldLoc.getAddress().getHostAddress(), machine.getAddress().getHostAddress());
+                                    oldLoc.getAddress().getHostAddress(), machine.getAddress().getHostAddress());
                         }
                     }
-                    log.debug("Entity "+entity()+" old machine locations "+oldSshLocs+" were compatible, removing them to start at "+machine);
+                    log.debug("Entity " + entity() + " old machine locations " + oldSshLocs + " were compatible, removing them to start at " + machine);
                     entity().removeLocations(oldSshLocs);
                 }
             }
-            entity().addLocations(ImmutableList.of((Location)machine));
+            entity().addLocations(ImmutableList.of((Location) machine));
 
             // elsewhere we rely on (public) hostname being set _after_ subnet_hostname
             // (to prevent the tiny possibility of races resulting in hostname being returned
@@ -397,7 +441,7 @@ public abstract class MachineLifecycleEffectorTasks {
             }
             resolveOnBoxDir(entity(), machine);
             preStartCustom(machine);
-        }});
+        }
     }
 
     /**
@@ -480,9 +524,13 @@ public abstract class MachineLifecycleEffectorTasks {
     protected abstract String startProcessesAtMachine(final Supplier<MachineLocation> machineS);
 
     protected void postStartAtMachineAsync() {
-        DynamicTasks.queue("post-start", new Runnable() { public void run() {
+        DynamicTasks.queue("post-start", new PostStartTask());
+    }
+
+    private class PostStartTask implements Runnable {
+        public void run() {
             postStartCustom();
-        }});
+        }
     }
 
     /**
@@ -515,7 +563,7 @@ public abstract class MachineLifecycleEffectorTasks {
     protected boolean getDefaultRestartStopsMachine() {
         return false;
     }
-    
+
     /**
      * Default restart implementation for an entity.
      * <p>
@@ -523,51 +571,52 @@ public abstract class MachineLifecycleEffectorTasks {
      */
     public void restart(ConfigBag parameters) {
         ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPING);
-        
-        RestartMachineMode isRestartMachine = parameters.get(RestartSoftwareParameters.RESTART_MACHINE_TYPED);
-        if (isRestartMachine==null) 
-            isRestartMachine=RestartMachineMode.AUTO;
-        if (isRestartMachine==RestartMachineMode.AUTO) 
-            isRestartMachine = getDefaultRestartStopsMachine() ? RestartMachineMode.TRUE : RestartMachineMode.FALSE; 
 
-        DynamicTasks.queue("pre-restart", new Runnable() { public void run() {
-            //Calling preStopCustom without a corresponding postStopCustom invocation
-            //doesn't look right so use a separate callback pair; Also depending on the arguments
-            //stop() could be called which will call the {pre,post}StopCustom on its own.
-            preRestartCustom();
-        }});
+        RestartMachineMode isRestartMachine = parameters.get(RestartSoftwareParameters.RESTART_MACHINE_TYPED);
+        if (isRestartMachine==null)
+            isRestartMachine=RestartMachineMode.AUTO;
+        if (isRestartMachine==RestartMachineMode.AUTO)
+            isRestartMachine = getDefaultRestartStopsMachine() ? RestartMachineMode.TRUE : RestartMachineMode.FALSE;
+
+        // Calling preStopCustom without a corresponding postStopCustom invocation
+        // doesn't look right so use a separate callback pair; Also depending on the arguments
+        // stop() could be called which will call the {pre,post}StopCustom on its own.
+        DynamicTasks.queue("pre-restart", new PreRestartTask());
 
         if (isRestartMachine==RestartMachineMode.FALSE) {
-            DynamicTasks.queue("stopping (process)", new Callable<String>() { public String call() {
-                DynamicTasks.markInessential();
-                stopProcessesAtMachine();
-                DynamicTasks.waitForLast();
-                return "Stop of process completed with no errors.";
-            }});
+            DynamicTasks.queue("stopping (process)", new StopProcessesAtMachineTask());
         } else {
-            DynamicTasks.queue("stopping (machine)", new Callable<String>() { public String call() {
-                DynamicTasks.markInessential();
-                stop(ConfigBag.newInstance().configure(StopSoftwareParameters.STOP_MACHINE_MODE, StopMode.IF_NOT_STOPPED));
-                DynamicTasks.waitForLast();
-                return "Stop of machine completed with no errors.";
-            }});
+            DynamicTasks.queue("stopping (machine)", new StopMachineTask());
         }
 
-        DynamicTasks.queue("starting", new Runnable() { public void run() {
+        DynamicTasks.queue("starting", new StartInLocationsTask());
+        restartChildren(parameters);
+        DynamicTasks.queue("post-restart", new PostRestartTask());
+
+        DynamicTasks.waitForLast();
+        ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
+    }
+
+    private class PreRestartTask implements Runnable {
+        @Override
+        public void run() {
+            preRestartCustom();
+        }
+    }
+    private class PostRestartTask implements Runnable {
+        @Override
+        public void run() {
+            postRestartCustom();
+        }
+    }
+    private class StartInLocationsTask implements Runnable {
+        @Override
+        public void run() {
             // startInLocations will look up the location, and provision a machine if necessary
             // (if it remembered the provisioning location)
             ServiceStateLogic.setExpectedState(entity(), Lifecycle.STARTING);
             startInLocations(null);
-        }});
-        
-        restartChildren(parameters);
-
-        DynamicTasks.queue("post-restart", new Runnable() { public void run() {
-            postRestartCustom();
-        }});
-
-        DynamicTasks.waitForLast();
-        ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
+        }
     }
 
     protected void restartChildren(ConfigBag parameters) {
@@ -577,12 +626,12 @@ public abstract class MachineLifecycleEffectorTasks {
         if (isRestartChildren==null || !isRestartChildren) {
             return;
         }
-        
+
         if (isRestartChildren) {
             DynamicTasks.queue(StartableMethods.restartingChildren(entity(), parameters));
             return;
         }
-        
+
         throw new IllegalArgumentException("Invalid value '"+isRestartChildren+"' for "+RestartSoftwareParameters.RESTART_CHILDREN.getName());
     }
 
@@ -601,11 +650,7 @@ public abstract class MachineLifecycleEffectorTasks {
      * If no errors were encountered call {@link #postStopCustom()} at the end.
      */
     public void stop(ConfigBag parameters) {
-        doStop(parameters, new Callable<StopMachineDetails<Integer>>() {
-            public StopMachineDetails<Integer> call() {
-                return stopAnyProvisionedMachines();
-            }
-        });
+        doStop(parameters, new StopAnyProvisionedMachinesTask());
     }
 
     /**
@@ -613,12 +658,7 @@ public abstract class MachineLifecycleEffectorTasks {
      * {@link #stopAnyProvisionedMachines}.
      */
     public void suspend(ConfigBag parameters) {
-        doStop(parameters, new Callable<StopMachineDetails<Integer>>() {
-            @Override
-            public StopMachineDetails<Integer> call() throws Exception {
-                return suspendAnyProvisionedMachines();
-            }
-        });
+        doStop(parameters, new SuspendAnyProvisionedMachinesTask());
     }
 
     protected void doStop(ConfigBag parameters, Callable<StopMachineDetails<Integer>> stopTask) {
@@ -629,26 +669,12 @@ public abstract class MachineLifecycleEffectorTasks {
         StopMode stopMachineMode = getStopMachineMode(parameters);
         StopMode stopProcessMode = parameters.get(StopSoftwareParameters.STOP_PROCESS_MODE);
 
-        DynamicTasks.queue("pre-stop", new Callable<String>() { public String call() {
-            if (entity().getAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL)==Lifecycle.STOPPED) {
-                log.debug("Skipping stop of entity "+entity()+" when already stopped");
-                return "Already stopped";
-            }
-            ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPING);
-            entity().setAttribute(SoftwareProcess.SERVICE_UP, false);
-            preStopCustom();
-            return null;
-        }});
+        DynamicTasks.queue("pre-stop", new PreStopCustomTask());
 
         Maybe<MachineLocation> machine = Machines.findUniqueMachineLocation(entity().getLocations());
         Task<String> stoppingProcess = null;
         if (canStop(stopProcessMode, entity())) {
-            stoppingProcess = DynamicTasks.queue("stopping (process)", new Callable<String>() { public String call() {
-                DynamicTasks.markInessential();
-                stopProcessesAtMachine();
-                DynamicTasks.waitForLast();
-                return "Stop at machine completed with no errors.";
-            }});
+            stoppingProcess = DynamicTasks.queue("stopping (process)", new StopProcessesAtMachineTask());
         }
 
         Task<StopMachineDetails<Integer>> stoppingMachine = null;
@@ -696,12 +722,59 @@ public abstract class MachineLifecycleEffectorTasks {
         entity().setAttribute(SoftwareProcess.SERVICE_UP, false);
         ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPED);
 
-        DynamicTasks.queue("post-stop", new Callable<Void>() { public Void call() {
-            postStopCustom();
-            return null;
-        }});
+        DynamicTasks.queue("post-stop", new PostStopCustomTask());
 
         if (log.isDebugEnabled()) log.debug("Stopped software process entity "+entity());
+    }
+
+    private class StopAnyProvisionedMachinesTask implements Callable<StopMachineDetails<Integer>> {
+        public StopMachineDetails<Integer> call() {
+            return stopAnyProvisionedMachines();
+        }
+    }
+
+    private class SuspendAnyProvisionedMachinesTask implements Callable<StopMachineDetails<Integer>> {
+        public StopMachineDetails<Integer> call() {
+            return suspendAnyProvisionedMachines();
+        }
+    }
+
+    private class StopProcessesAtMachineTask implements Callable<String> {
+        public String call() {
+            DynamicTasks.markInessential();
+            stopProcessesAtMachine();
+            DynamicTasks.waitForLast();
+            return "Stop processes completed with no errors.";
+        }
+    }
+
+    private class StopMachineTask implements Callable<String> {
+        public String call() {
+            DynamicTasks.markInessential();
+            stop(ConfigBag.newInstance().configure(StopSoftwareParameters.STOP_MACHINE_MODE, StopMode.IF_NOT_STOPPED));
+            DynamicTasks.waitForLast();
+            return "Stop of machine completed with no errors.";
+        }
+    }
+
+    private class PreStopCustomTask implements Callable<String> {
+        public String call() {
+            if (entity().getAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL) == Lifecycle.STOPPED) {
+                log.debug("Skipping stop of entity " + entity() + " when already stopped");
+                return "Already stopped";
+            }
+            ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPING);
+            entity().setAttribute(SoftwareProcess.SERVICE_UP, false);
+            preStopCustom();
+            return null;
+        }
+    }
+
+    private class PostStopCustomTask implements Callable<Void> {
+        public Void call() {
+            postStopCustom();
+            return null;
+        }
     }
 
     public static StopMode getStopMachineMode(ConfigBag parameters) {


### PR DESCRIPTION
Locations can indicate that they can suspend machines by implementing a new `SuspendsMachines` interface. 

A use of this is given in `MachineLifecycleEffectorTasks`, which provides a `suspend` effector implementation. Attaching this effector to entities is left to subclasses of MLET.

An interface for locations that can resume machines is also given but unused. I began an implementation but realised that we need to discuss what it means to "resume" a machine. Eventually `JcloudsLocation` should implement `SuspendResumeLocation` rather than `SuspendsMachines`.