### PR TITLE
Add convenience ManagementContext accessor.

### DIFF
--- a/core/src/main/java/brooklyn/entity/basic/Entities.java
+++ b/core/src/main/java/brooklyn/entity/basic/Entities.java
@@ -931,6 +931,10 @@ public class Entities {
         return new LocalManagementContext( BrooklynProperties.Factory.newEmpty().addFromMap(props));
     }
 
+    public static ManagementContext getManagementContext(Entity entity) {
+        return ((EntityInternal) entity).getManagementContext();
+    }
+
     public static void unmanage(Entity entity) {
         if (((EntityInternal)entity).getManagementSupport().isDeployed()) {
             ((EntityInternal)entity).getManagementContext().getEntityManager().unmanage(entity);


### PR DESCRIPTION
Simple utility method to obtain a given entity's `ManagementContext`, hiding the cast to the non-public `EntityInternal` class.