### PR TITLE
Don't leak machines on shutdown

### DIFF
--- a/usage/cli/src/test/java/brooklyn/cli/CliTest.java
+++ b/usage/cli/src/test/java/brooklyn/cli/CliTest.java
@@ -52,6 +52,7 @@ import org.testng.annotations.Test;
 import brooklyn.cli.AbstractMain.BrooklynCommand;
 import brooklyn.cli.AbstractMain.BrooklynCommandCollectingArgs;
 import brooklyn.cli.AbstractMain.HelpCommand;
+import brooklyn.cli.Main.AppShutdownHandler;
 import brooklyn.cli.Main.GeneratePasswordCommand;
 import brooklyn.cli.Main.LaunchCommand;
 import brooklyn.entity.Entity;
@@ -214,10 +215,10 @@ public class CliTest {
     
     @Test
     public void testWaitsForInterrupt() throws Exception {
-        final LaunchCommand launchCommand = new Main.LaunchCommand();
+        final AppShutdownHandler listener = new AppShutdownHandler();
         Thread t = new Thread(new Runnable() {
             @Override public void run() {
-                launchCommand.waitUntilInterrupted();
+                listener.waitOnShutdownRequest();
             }});
         
         t.start();

--- a/usage/launcher/pom.xml
+++ b/usage/launcher/pom.xml
@@ -194,6 +194,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-rest-server</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-software-messaging</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/usage/rest-server/src/main/java/brooklyn/rest/util/ShutdownHandler.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/util/ShutdownHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.util;
+
+public interface ShutdownHandler {
+    void onShutdownRequest();
+}

--- a/usage/rest-server/src/main/java/brooklyn/rest/util/ShutdownHandlerProvider.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/util/ShutdownHandlerProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.util;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.core.Context;
+
+import com.sun.jersey.spi.inject.SingletonTypeInjectableProvider;
+
+public class ShutdownHandlerProvider extends SingletonTypeInjectableProvider<Context, ShutdownHandler> {
+    public ShutdownHandlerProvider(@Nullable ShutdownHandler instance) {
+        super(ShutdownHandler.class, instance);
+    }
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/resources/ServerShutdownTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/resources/ServerShutdownTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.resources;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+import brooklyn.entity.basic.Attributes;
+import brooklyn.entity.basic.Entities;
+import brooklyn.entity.basic.Lifecycle;
+import brooklyn.entity.drivers.BasicEntityDriverManager;
+import brooklyn.entity.drivers.ReflectiveEntityDriverFactory;
+import brooklyn.entity.proxying.EntitySpec;
+import brooklyn.entity.trait.Startable;
+import brooklyn.management.EntityManager;
+import brooklyn.management.Task;
+import brooklyn.rest.resources.ServerResourceTest.StopLatchEntity;
+import brooklyn.rest.testing.BrooklynRestResourceTest;
+import brooklyn.test.Asserts;
+import brooklyn.test.EntityTestUtils;
+import brooklyn.test.entity.TestApplication;
+import brooklyn.util.exceptions.Exceptions;
+
+public class ServerShutdownTest extends BrooklynRestResourceTest {
+    private static final Logger log = LoggerFactory.getLogger(ServerResourceTest.class);
+
+    // Need to initialise the ManagementContext before each test as it is destroyed.
+    @Override
+    @BeforeClass(alwaysRun = true)
+    public void setUp() throws Exception {
+    }
+
+    @Override
+    @AfterClass(alwaysRun = true)
+    public void tearDown() throws Exception {
+    }
+
+    @Override
+    @BeforeMethod(alwaysRun = true)
+    public void setUpMethod() {
+        setUpJersey();
+        super.setUpMethod();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDownMethod() {
+        tearDownJersey();
+        destroyManagementContext();
+    }
+
+    @Test
+    public void testShutdown() throws Exception {
+        assertTrue(getManagementContext().isRunning());
+        assertFalse(shutdownListener.isRequested());
+
+        MultivaluedMap<String, String> formData = new MultivaluedMapImpl();
+        formData.add("requestTimeout", "0");
+        formData.add("delayForHttpReturn", "0");
+        client().resource("/v1/server/shutdown").entity(formData).post();
+
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertTrue(shutdownListener.isRequested());
+            }
+        });
+        Asserts.succeedsEventually(new Runnable() {
+            @Override public void run() {
+                assertFalse(getManagementContext().isRunning());
+            }});
+    }
+
+    @Test
+    public void testStopAppThenShutdownAndStopAppsWaitsForFirstStop() throws InterruptedException {
+        ReflectiveEntityDriverFactory f = ((BasicEntityDriverManager)getManagementContext().getEntityDriverManager()).getReflectiveDriverFactory();
+        f.addClassFullNameMapping("brooklyn.entity.basic.EmptySoftwareProcessDriver", "brooklyn.rest.resources.ServerResourceTest$EmptySoftwareProcessTestDriver");
+
+        // Second stop on SoftwareProcess could return early, while the first stop is still in progress
+        // This causes the app to shutdown prematurely, leaking machines.
+        EntityManager emgr = getManagementContext().getEntityManager();
+        EntitySpec<TestApplication> appSpec = EntitySpec.create(TestApplication.class);
+        TestApplication app = emgr.createEntity(appSpec);
+        emgr.manage(app);
+        EntitySpec<StopLatchEntity> latchEntitySpec = EntitySpec.create(StopLatchEntity.class);
+        final StopLatchEntity entity = app.createAndManageChild(latchEntitySpec);
+        app.start(ImmutableSet.of(app.newLocalhostProvisioningLocation()));
+        EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        try {
+            final Task<Void> firstStop = app.invoke(Startable.STOP, ImmutableMap.<String, Object>of());
+            Asserts.succeedsEventually(new Runnable() {
+                @Override
+                public void run() {
+                    assertTrue(entity.isBlocked());
+                }
+            });
+
+            final AtomicReference<Exception> shutdownError = new AtomicReference<>();
+            // Can't use ExecutionContext as it will be stopped on shutdown
+            Thread shutdownThread = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        MultivaluedMap<String, String> formData = new MultivaluedMapImpl();
+                        formData.add("stopAppsFirst", "true");
+                        formData.add("shutdownTimeout", "0");
+                        formData.add("requestTimeout", "0");
+                        formData.add("delayForHttpReturn", "0");
+                        client().resource("/v1/server/shutdown").entity(formData).post();
+                    } catch (Exception e) {
+                        log.error("Shutdown request error", e);
+                        shutdownError.set(e);
+                        throw Exceptions.propagate(e);
+                    }
+                }
+            };
+            shutdownThread.start();
+
+            //shutdown must wait until the first stop completes (or time out)
+            Asserts.succeedsContinually(new Runnable() {
+                @Override
+                public void run() {
+                    assertFalse(firstStop.isDone());
+                    assertEquals(getManagementContext().getApplications().size(), 1);
+                    assertFalse(shutdownListener.isRequested());
+                }
+            });
+
+            // NOTE test is not fully deterministic. Depending on thread scheduling this will
+            // execute before or after ServerResource.shutdown does the app stop loop. This
+            // means that the shutdown code might not see the app at all. In any case though
+            // the test must succeed.
+            entity.unblock();
+
+            Asserts.succeedsEventually(new Runnable() {
+                @Override
+                public void run() {
+                    assertTrue(firstStop.isDone());
+                    assertTrue(shutdownListener.isRequested());
+                    assertFalse(getManagementContext().isRunning());
+                }
+            });
+
+            shutdownThread.join();
+            assertNull(shutdownError.get(), "Shutdown request error, logged above");
+        } finally {
+            // Be sure we always unblock entity stop even in the case of an exception.
+            // In the success path the entity is already unblocked above.
+            entity.unblock();
+        }
+    }
+
+}

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -93,6 +93,10 @@ public abstract class BrooklynRestApiTest {
     
     @AfterClass
     public void tearDown() throws Exception {
+        destroyManagementContext();
+    }
+
+    protected void destroyManagementContext() {
         if (manager!=null) {
             Entities.destroyAll(manager);
             manager = null;

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/BrooklynRestResourceTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/BrooklynRestResourceTest.java
@@ -60,6 +60,7 @@ public abstract class BrooklynRestResourceTest extends BrooklynRestApiTest {
         setUpJersey();
     }
 
+    @Override
     @AfterClass(alwaysRun = true)
     public void tearDown() throws Exception {
         tearDownJersey();

--- a/usage/rest-server/src/test/java/brooklyn/rest/util/TestShutdownHandler.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/util/TestShutdownHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package brooklyn.rest.util;
+
+import brooklyn.rest.util.ShutdownHandler;
+
+public class TestShutdownHandler implements ShutdownHandler {
+    private volatile boolean isRequested;
+
+    @Override
+    public void onShutdownRequest() {
+        isRequested = true;
+    }
+
+    public boolean isRequested() {
+        return isRequested;
+    }
+
+    public void reset() {
+        isRequested = false;
+    }
+
+}


### PR DESCRIPTION
STOPping an app and then doing a shutdown-and-stop-apps could leak machines because the second stop (from the shutdown) can complete faster as it's not re-releasing the machines, then unmanage the app and cancel the first stop's tasks. Cancelling the tasks will not release the machines properly.

This PR works around the problem in the shutdown code. Double stopping an app will still keep the same behaviour.