### PR TITLE
Updates as suggested by Aled in PR #773 comments (and a few other tweaks)

### DIFF
--- a/docs/website/documentation/index.md
+++ b/docs/website/documentation/index.md
@@ -21,11 +21,7 @@ Our main user manual is organised by release version. Please pick the version th
 - [{{ site.brooklyn-stable-version }}]({{ site.path.v }}/latest) -
   This is the latest stable version.
 
-- [0.7.0-M1]({{ site.path.v }}/0.7.0-M1) -
-  Please note that this release was made prior to entering the Apache Incubator,
-  and therefore it is not endorsed by Apache.
-
-- [Other versions]({{ site.path.website }}/meta/versions.html)
+- [Older versions]({{ site.path.website }}/meta/versions.html)
 
 
 ## Other Docs

--- a/docs/website/download/index.md
+++ b/docs/website/download/index.md
@@ -15,7 +15,7 @@ children:
   </div>
   <div class="panel-body" markdown="1">
 A pre-built package that contains Apache Brooklyn and all of its dependencies in a single, easy-to-run package. Suitable for
-Linux and Windows servers and workstations that have Java 1.7 or newer.
+Linux and Windows servers and workstations that have Java 1.7<a href="#java-footnote">*</a>.
 
 **Choose your preferred file format to see the list of mirrors where you can download this file.**
 
@@ -53,6 +53,9 @@ contribute code changes to Apache Brooklyn, we recommend you get the source code
 </div><!-- row -->
 
 We also publish Maven artifacts for Apache Brooklyn. These are available from [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Corg.apache.brooklyn).
+
+<a name="java-footnote">*</a> We recommend Java 1.7 as this platform has had the most testing. Java 1.8 may also be suitable. Brooklyn is
+not compatible with Java 1.6 or earlier versions.
 
 ## What next?
 

--- a/docs/website/meta/versions.md
+++ b/docs/website/meta/versions.md
@@ -3,7 +3,7 @@ layout: website-normal
 title: Versions
 ---
 
-### Current Version: {{ site.brooklyn-stable-version }}
+## Current Version: {{ site.brooklyn-stable-version }}
 
 The current stable version of Brooklyn is {{ site.brooklyn-stable-version }}:
 
@@ -14,28 +14,35 @@ The current stable version of Brooklyn is {{ site.brooklyn-stable-version }}:
 This documentation was generated {{ site.time | date_to_string }}.
 
 
-### Version History
+## Version History
 
-Apache Brooklyn has made the following releases (links are to the user guides):
+Apache Brooklyn has made the following releases:
 
-* **[0.7.0-incubating](/v/0.7.0-incubating/)**: New policies, more clouds, improved Windows support and many other improvements. Apache-endorsed binary release! (July 2015)
+* **0.7.0-incubating**: New policies, more clouds, improved Windows support and many other improvements. Apache-endorsed binary release! (July 2015)
   * [User guide](/v/0.7.0-incubating/), download via mirrors
     &laquo;<a href="https://www.apache.org/dyn/closer.cgi/incubator/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.tar.gz">bin.tar.gz</a>&raquo;
     &laquo;<a href="https://www.apache.org/dyn/closer.cgi/incubator/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.zip">bin.zip</a>&raquo;
     &laquo;<a href="https://www.apache.org/dyn/closer.cgi/incubator/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.tar.gz">src.tar.gz</a>&raquo;
     &laquo;<a href="https://www.apache.org/dyn/closer.cgi/incubator/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.zip">src.zip</a>&raquo;
 
-* **[0.7.0-M2-incubating](/v/0.7.0-M2-incubating/)**: YAML, persistence, Chef, Windows, Docker. The first Apache release! (December 2014)
+* **0.7.0-M2-incubating**: YAML, persistence, Chef, Windows, Docker. The first Apache release! (December 2014)
   * [User guide](/v/0.7.0-M2-incubating/), download via mirrors
     &laquo;<a href="https://www.apache.org/dyn/closer.cgi/incubator/brooklyn/0.7.0-M2-incubating/apache-brooklyn-0.7.0-M2-incubating.tar.gz">src.tar.gz</a>&raquo;
 
-* **[0.7.0-SNAPSHOT](/v/0.7.0-SNAPSHOT/)**: bleeding-edge (not voted on or endorsed by Apache!)
+Note: To prevent accidentally referring to out-of-date information,
+a banner is displayed when accessing content from specific versions in the archive.
+You may
+<a href="javascript:void(0);" onclick="set_user_versions_all();">disable all warnings</a> or
+<a href="javascript:void(0);" onclick="clear_user_versions();">re-enable all warnings</a>.
 
 
-The versions below were made prior to joining the Apache Incubator, 
-therefore **they are not endorsed by Apache** and are not hosted by Apache or their mirrors. 
-You can obtain the source code by [inspecting the branches of the pre-Apache GitHub repository](https://github.com/brooklyncentral/brooklyn/branches/stale) 
-and binary releases by [querying Maven Central for io.brooklyn:brooklyn.dist](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.brooklyn%22%20AND%20a%3A%22brooklyn-dist%22).
+## Ancient Versions
+
+The versions below were made prior to joining The Apache Software Foundation, therefore **they are not endorsed by
+Apache** and are not hosted by Apache or their mirrors. You can obtain the source code by
+[inspecting the branches of the pre-Apache GitHub repository](https://github.com/brooklyncentral/brooklyn/branches/stale)
+and binary releases by
+[querying Maven Central for io.brooklyn:brooklyn.dist](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.brooklyn%22%20AND%20a%3A%22brooklyn-dist%22).
 
 * **[0.7.0-M1](/v/0.7.0-M1/)**: YAML, Chef, catalog, persistence (Apr 2014)
 
@@ -44,12 +51,6 @@ and binary releases by [querying Maven Central for io.brooklyn:brooklyn.dist](ht
 * **[0.5.0](/v/0.5.0/)**: includes new JS GUI and REST API, rebind/persistence support, cleaner model and naming conventions, more entities (May 2013)
 
 * **[0.4.0](/v/0.4.0/)**: initial public GA release of Brooklyn to Maven Central, supporting wide range of entities and examples (Jan 2013)
-
-Note: To prevent accidentally referring to out-of-date information,
-a banner is displayed when accessing content from specific versions in the archive.
-You may 
-<a href="javascript:void(0);" onclick="set_user_versions_all();">disable all warnings</a> or
-<a href="javascript:void(0);" onclick="clear_user_versions();">re-enable all warnings</a>.
 
 
 ### Versioning


### PR DESCRIPTION
In response to @aledsage's specific comments in PR #773:

* Documentation landing page refers to the latest version, and links to the versions page for everything else.
* Download page recommends Java 1.7 and footnote explains the position with 1.6 and 1.8.
* Versions page no longer links to any snapshot versions (that information should be restricted to the Developers section).