### PR TITLE
Entitlements improvements

### DIFF
--- a/core/src/main/java/brooklyn/management/entitlement/BasicEntitlementClassDefinition.java
+++ b/core/src/main/java/brooklyn/management/entitlement/BasicEntitlementClassDefinition.java
@@ -18,6 +18,7 @@
  */
 package brooklyn.management.entitlement;
 
+import com.google.common.base.Objects;
 import com.google.common.reflect.TypeToken;
 
 
@@ -46,4 +47,8 @@ public class BasicEntitlementClassDefinition<T> implements EntitlementClass<T> {
         return argumentType;
     }
 
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("identitifier", identifier).add("argumentType", argumentType).toString();
+    }
 }

--- a/core/src/main/java/brooklyn/management/internal/LocalManagementContext.java
+++ b/core/src/main/java/brooklyn/management/internal/LocalManagementContext.java
@@ -54,6 +54,7 @@ import brooklyn.management.ManagementContext;
 import brooklyn.management.SubscriptionManager;
 import brooklyn.management.Task;
 import brooklyn.management.TaskAdaptable;
+import brooklyn.management.entitlement.Entitlements;
 import brooklyn.management.ha.OsgiManager;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.guava.Maybe;
@@ -386,7 +387,8 @@ public class LocalManagementContext extends AbstractManagementContext {
             configMap.addFromMap(brooklynAdditionalProperties);
         }
         this.downloadsManager = BasicDownloadsManager.newDefault(configMap);
-
+        this.entitlementManager = Entitlements.newManager(this, configMap);
+        
         clearLocationRegistry();
         
         BrooklynFeatureEnablement.init(configMap);

--- a/core/src/test/java/brooklyn/management/entitlement/AcmeEntitlementManager.java
+++ b/core/src/test/java/brooklyn/management/entitlement/AcmeEntitlementManager.java
@@ -18,7 +18,7 @@
  */
 package brooklyn.management.entitlement;
 
-class AcmeEntitlementManager extends PerUserEntitlementManager {
+public class AcmeEntitlementManager extends PerUserEntitlementManager {
 
     public AcmeEntitlementManager() {
         // default mode (if no user specified) is root

--- a/core/src/test/java/brooklyn/management/entitlement/AcmeEntitlementManagerTestFixture.java
+++ b/core/src/test/java/brooklyn/management/entitlement/AcmeEntitlementManagerTestFixture.java
@@ -47,9 +47,9 @@ import brooklyn.util.exceptions.Exceptions;
 
 public abstract class AcmeEntitlementManagerTestFixture {
 
-    ManagementContext mgmt;
-    Application app;
-    ConfigBag configBag;
+    protected ManagementContext mgmt;
+    protected Application app;
+    protected ConfigBag configBag;
     
     public void setup(ConfigBag cfg) {
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newEmpty().addFrom(cfg));


### PR DESCRIPTION
- Adds toString in various places.
- Entitlements.allOf/anyOf takes Utterable<EntitlementManager>, as well
  as the overloaded varargs version.
- Clean up reflectively instantiating global EntitlementManager.
  - Use catalog-class-loader
  - Allow various constructors, for optionally having ManagementContext
    and/or BrooklynProperties
- On “reload brooklyn properties”, recreate EntitlementManager in case
  entitlements have changed.