### PR TITLE
Fix REST api app’s status as ERROR when ON_FIRE

### DIFF
--- a/usage/rest-server/src/main/java/brooklyn/rest/transform/ApplicationTransformer.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/transform/ApplicationTransformer.java
@@ -25,6 +25,7 @@ import static brooklyn.rest.domain.Status.STOPPED;
 import static brooklyn.rest.domain.Status.STOPPING;
 import static brooklyn.rest.domain.Status.UNKNOWN;
 import static brooklyn.rest.domain.Status.DESTROYED;
+import static brooklyn.rest.domain.Status.ERROR;
 
 import java.net.URI;
 import java.util.Collection;
@@ -81,6 +82,7 @@ public class ApplicationTransformer {
             case DESTROYED:
                 return DESTROYED;
             case ON_FIRE:
+                return ERROR;
             default:
                 return UNKNOWN;
         }

--- a/usage/rest-server/src/test/java/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/usage/rest-server/src/test/java/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -49,7 +49,7 @@ import io.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
 
 public abstract class BrooklynRestApiTest {
 
-    private ManagementContext manager;
+    protected ManagementContext manager;
     
     protected boolean useLocalScannedCatalog = false;
     protected TestShutdownHandler shutdownListener = createShutdownHandler();


### PR DESCRIPTION
Previously, if the app’s status was ON_FIRE, the rest api translated
that into “UNKNOWN”. Now it will report it as “ERROR”.