### PR TITLE
Fix LDAP dc parameter

### DIFF
--- a/usage/rest-server/src/main/java/brooklyn/rest/BrooklynWebConfig.java
+++ b/usage/rest-server/src/main/java/brooklyn/rest/BrooklynWebConfig.java
@@ -66,6 +66,9 @@ public class BrooklynWebConfig {
     public final static ConfigKey<String> LDAP_REALM = ConfigKeys.newStringConfigKey(
             BASE_NAME_SECURITY+".ldap.realm");
 
+    public final static ConfigKey<String> LDAP_OU = ConfigKeys.newStringConfigKey(
+            BASE_NAME_SECURITY+"ldap.ou");
+
     public final static ConfigKey<Boolean> HTTPS_REQUIRED = ConfigKeys.newBooleanConfigKey(
             BASE_NAME+".security.https.required",
             "Whether HTTPS is required; false here can be overridden by CLI option", false); 


### PR DESCRIPTION
Fix LDAP connection parameter.
I tested it locally If the parameters are not formatted in like this `cn=John Smith,ou=Users,dc=example,dc=com` then it fails to recognize the login format `error code 34 - Incorrect DN given`
@grkvlt @aledsage Can you review it please?