### PR TITLE
Fix/rebind machine lifecycle effector tasks

### DIFF
--- a/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/brooklyn/entity/software/MachineLifecycleEffectorTasks.java
@@ -171,6 +171,24 @@ public abstract class MachineLifecycleEffectorTasks {
      * Calls {@link #start(Collection)} in this class.
      */
     public EffectorBody<Void> newStartEffectorTask() {
+        // TODO included anonymous inner class for backwards compatibility with persisted state.
+        new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                Collection<? extends Location> locations  = null;
+
+                Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
+                locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
+
+                if (locations==null) {
+                    // null/empty will mean to inherit from parent
+                    locations = Collections.emptyList();
+                }
+
+                start(locations);
+                return null;
+            }
+        };
         return new StartEffectorBody();
     }
 
@@ -199,6 +217,14 @@ public abstract class MachineLifecycleEffectorTasks {
      * @see {@link #newStartEffectorTask()}
      */
     public EffectorBody<Void> newRestartEffectorTask() {
+        // TODO included anonymous inner class for backwards compatibility with persisted state.
+        new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                restart(parameters);
+                return null;
+            }
+        };
         return new RestartEffectorBody();
     }
 
@@ -216,6 +242,14 @@ public abstract class MachineLifecycleEffectorTasks {
      * @see {@link #newStartEffectorTask()}
      */
     public EffectorBody<Void> newStopEffectorTask() {
+        // TODO included anonymous inner class for backwards compatibility with persisted state.
+        new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                stop(parameters);
+                return null;
+            }
+        };
         return new StopEffectorBody();
     }
 


### PR DESCRIPTION
As discussed in https://github.com/apache/incubator-brooklyn/pull/763.

Fixes backwards compatibility failure in persistence by re-adding the anonymous inner classes to `MachineLifecycleEffectorTasks` (but they are no longer instantiated, so new things will use the new class names).