### PR TITLE
PostgreSQL lifecycle improvements

### DIFF
--- a/software/database/src/main/java/brooklyn/entity/database/postgresql/PostgreSqlNode.java
+++ b/software/database/src/main/java/brooklyn/entity/database/postgresql/PostgreSqlNode.java
@@ -90,4 +90,6 @@ public interface PostgreSqlNode extends SoftwareProcess, HasShortName, Datastore
 
     String executeScript(String commands);
 
+    ConfigKey<StopSoftwareParameters.StopMode> STOP_MACHINE_MODE = ConfigKeys.newConfigKeyWithDefault(StopSoftwareParameters.STOP_MACHINE_MODE, StopSoftwareParameters.StopMode.NEVER);
+
 }

--- a/software/database/src/main/java/brooklyn/entity/database/postgresql/PostgreSqlNodeImpl.java
+++ b/software/database/src/main/java/brooklyn/entity/database/postgresql/PostgreSqlNodeImpl.java
@@ -23,7 +23,11 @@ import org.slf4j.LoggerFactory;
 
 import brooklyn.entity.basic.SoftwareProcessImpl;
 import brooklyn.entity.effector.EffectorBody;
+import brooklyn.entity.effector.Effectors;
+import brooklyn.entity.trait.Startable;
 import brooklyn.util.config.ConfigBag;
+import brooklyn.entity.Effector;
+import brooklyn.entity.basic.SoftwareProcessDriverLifecycleEffectorTasks;
 
 public class PostgreSqlNodeImpl extends SoftwareProcessImpl implements PostgreSqlNode {
 
@@ -55,6 +59,8 @@ public class PostgreSqlNodeImpl extends SoftwareProcessImpl implements PostgreSq
                 return executeScript((String) parameters.getStringKey("commands"));
             }
         });
+
+        new PostgreSqlMachineLifeCyclyEffectorTasks().attachLifecycleEffectors(this);
     }
 
     @Override
@@ -81,5 +87,16 @@ public class PostgreSqlNodeImpl extends SoftwareProcessImpl implements PostgreSq
                 .executeScriptAsync(commands)
                 .block()
                 .getStdout();
+    }
+
+    private class PostgreSqlMachineLifeCyclyEffectorTasks extends SoftwareProcessDriverLifecycleEffectorTasks {
+        @Override
+        public Effector<Void> newStopEffector() {
+            return Effectors.effector(Startable.STOP)
+                    .parameter(StopSoftwareParameters.STOP_PROCESS_MODE)
+                    .parameter(STOP_MACHINE_MODE)
+                    .impl(newStopEffectorTask())
+                    .build();
+        }
     }
 }

--- a/software/database/src/main/java/brooklyn/entity/database/postgresql/PostgreSqlSshDriver.java
+++ b/software/database/src/main/java/brooklyn/entity/database/postgresql/PostgreSqlSshDriver.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import brooklyn.entity.basic.AbstractSoftwareProcessSshDriver;
 import brooklyn.entity.basic.Attributes;
+import brooklyn.entity.basic.BrooklynConfigKeys;
 import brooklyn.entity.basic.SoftwareProcess;
 import brooklyn.entity.database.DatastoreMixins;
 import brooklyn.entity.software.SshEffectorTasks;
@@ -172,6 +173,23 @@ public class PostgreSqlSshDriver extends AbstractSoftwareProcessSshDriver implem
             setInstallDir(altInstallDir);
             setRunDir(newRunDir);
         }
+        
+        DynamicTasks.queue(SshEffectorTasks.ssh(
+            sudo("mkdir -p " + getDataDir()),
+            sudo("chown postgres:postgres " + getDataDir()),
+            sudo("chmod 700 " + getDataDir()),
+            sudo("touch " + getLogFile()),
+            sudo("chown postgres:postgres " + getLogFile()),
+            sudo("touch " + getPidFile()),
+            sudo("chown postgres:postgres " + getPidFile()),
+            alternativesGroup(
+                chainGroup(format("test -e %s", getInstallDir() + "/bin/initdb"),
+                    sudoAsUser("postgres", getInstallDir() + "/bin/initdb -D " + getDataDir())),
+                    callPgctl("initdb", true)))
+                    .requiringExitCodeZero());
+        DynamicTasks.waitForLast();
+
+        getEntity().setConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION, true);
     }
 
     private String getYumRepository(String version, String majorMinorVersion, String shortVersion) {
@@ -241,22 +259,6 @@ public class PostgreSqlSshDriver extends AbstractSoftwareProcessSshDriver implem
     public void customize() {
         // Some OSes start postgres during package installation
         DynamicTasks.queue(SshEffectorTasks.ssh(sudoAsUser("postgres", "/etc/init.d/postgresql stop")).allowingNonZeroExitCode()).get();
-
-        newScript(CUSTOMIZING)
-        .body.append(
-            sudo("mkdir -p " + getDataDir()),
-            sudo("chown postgres:postgres " + getDataDir()),
-            sudo("chmod 700 " + getDataDir()),
-            sudo("touch " + getLogFile()),
-            sudo("chown postgres:postgres " + getLogFile()),
-            sudo("touch " + getPidFile()),
-            sudo("chown postgres:postgres " + getPidFile()),
-            alternativesGroup(
-                chainGroup(format("test -e %s", getInstallDir() + "/bin/initdb"),
-                    sudoAsUser("postgres", getInstallDir() + "/bin/initdb -D " + getDataDir())),
-                    callPgctl("initdb", true)))
-                    .failOnNonZeroResultCode()
-                    .execute();
 
         String configUrl = getEntity().getConfig(PostgreSqlNode.CONFIGURATION_FILE_URL);
         if (Strings.isBlank(configUrl)) {


### PR DESCRIPTION
- Moving database's initialization to the install phase
- Skipping install phase when node was provisioned, stopped via its 
  effectors and then started
- Only Postgres service is stopped when stop effector is invoked
- VM stays up so the stopped Postgres service can be started again
  on the same machine