### PR TITLE
brooklyn-software-osgi: add org.apache package prefix

### DIFF
--- a/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainer.java
+++ b/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainer.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.osgi.karaf;
+package org.apache.brooklyn.entity.osgi.karaf;
 
 import java.net.URISyntaxException;
 import java.util.Map;

--- a/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerImpl.java
+++ b/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.osgi.karaf;
+package org.apache.brooklyn.entity.osgi.karaf;
 
 import java.io.File;
 import java.net.URI;

--- a/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafDriver.java
+++ b/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafDriver.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.osgi.karaf;
+package org.apache.brooklyn.entity.osgi.karaf;
 
 import java.io.File;
 

--- a/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafSshDriver.java
+++ b/software/osgi/src/main/java/org/apache/brooklyn/entity/osgi/karaf/KarafSshDriver.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.osgi.karaf;
+package org.apache.brooklyn.entity.osgi.karaf;
 
 import static java.lang.String.format;
 

--- a/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerEc2LiveTest.java
+++ b/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerEc2LiveTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.osgi.karaf;
+package org.apache.brooklyn.entity.osgi.karaf;
 
 import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;

--- a/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerTest.java
+++ b/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package brooklyn.entity.osgi.karaf;
+package org.apache.brooklyn.entity.osgi.karaf;
 
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;


### PR DESCRIPTION
Refs BROOKLYN-162

All tests that are part of the Integration profile are marked WIP.
I did not run any live tests.

There are 2 more issues for this project:

1. src/test/resources contains a hello-world.jar that is used as test OSGi bundle. Shouldn't this be part of the osgi-test-bundles processed by hadrian?

2. Talking of split packages: the sources also contain the classes org.osgi.jmx.Item and org.osgi.jmx.JmxConstants, each with the following note:

```java
/*
 * BROOKLYN NOTE: This is a verbatim copy of the original in org.osgi.enterprise-4.2.0, 
 * reproduced here to avoid pulling in the rest of that bundle and its chain of dependencies.
 * The only difference is this comment and the suppress warnings.
 */
```

As far as I can see org.osgi.enterprise-4.2.0 has no dependencies, though it does bundle a lot more classes.