### PR TITLE
Test + fix BrooklynAccessUtils

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/access/BrooklynAccessUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/location/access/BrooklynAccessUtils.java
@@ -33,6 +33,8 @@ import brooklyn.event.basic.BasicConfigKey;
 import org.apache.brooklyn.location.basic.Machines;
 import org.apache.brooklyn.location.basic.SshMachineLocation;
 import org.apache.brooklyn.location.basic.SupportsPortForwarding;
+import org.python.google.common.base.Predicates;
+import org.python.google.common.collect.Iterables;
 
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.guava.Maybe;
@@ -66,27 +68,37 @@ public class BrooklynAccessUtils {
         PortForwardManager pfw = entity.getConfig(PORT_FORWARDING_MANAGER);
         if (pfw!=null) {
             Collection<Location> ll = entity.getLocations();
-            Maybe<SupportsPortForwarding> machine = Machines.findUniqueElement(ll, SupportsPortForwarding.class);
-            if (machine.isPresent()) {
-                synchronized (BrooklynAccessUtils.class) {
-                    // TODO finer-grained synchronization
-                    
-                    HostAndPort hp = pfw.lookup((MachineLocation)machine.get(), port);
-                    if (hp!=null) return hp;
-                    
-                    Location l = (Location) machine.get();
-                    if (l instanceof SupportsPortForwarding) {
-                        Cidr source = entity.getConfig(MANAGEMENT_ACCESS_CIDR);
-                        if (source!=null) {
-                            log.debug("BrooklynAccessUtils requesting new port-forwarding rule to access "+port+" on "+entity+" (at "+l+", enabled for "+source+")");
-                            // TODO discuss, is this the best way to do it
-                            // (will probably _create_ the port forwarding rule!)
-                            hp = ((SupportsPortForwarding) l).getSocketEndpointFor(source, port);
-                            if (hp!=null) return hp;
-                        } else {
-                            log.warn("No "+MANAGEMENT_ACCESS_CIDR.getName()+" configured for "+entity+", so cannot forward port "+port+" " +
-                                    "even though "+PORT_FORWARDING_MANAGER.getName()+" was supplied");
+            
+            synchronized (BrooklynAccessUtils.class) {
+                // TODO finer-grained synchronization
+                
+                for (MachineLocation machine : Iterables.filter(ll, MachineLocation.class)) {
+                    HostAndPort hp = pfw.lookup(machine, port);
+                    if (hp!=null) {
+                        log.debug("BrooklynAccessUtils found port-forwarded address {} for entity {}, port {}, using machine {}",
+                                new Object[] {hp, entity, port, machine});
+                        return hp;
+                    }
+                }
+                
+                Maybe<SupportsPortForwarding> supportPortForwardingLoc = Machines.findUniqueElement(ll, SupportsPortForwarding.class);
+                if (supportPortForwardingLoc.isPresent()) {
+                    Cidr source = entity.getConfig(MANAGEMENT_ACCESS_CIDR);
+                    SupportsPortForwarding loc = supportPortForwardingLoc.get();
+                    if (source!=null) {
+                        log.debug("BrooklynAccessUtils requesting new port-forwarding rule to access "+port+" on "+entity+" (at "+loc+", enabled for "+source+")");
+                        // TODO discuss, is this the best way to do it
+                        // (will probably _create_ the port forwarding rule!)
+                        HostAndPort hp = loc.getSocketEndpointFor(source, port);
+                        if (hp!=null) {
+                            log.debug("BrooklynAccessUtils created port-forwarded address {} for entity {}, port {}, using {}",
+                                    new Object[] {hp, entity, port, loc});
+                            return hp;
                         }
+                    } else {
+                        log.warn("No "+MANAGEMENT_ACCESS_CIDR.getName()+" configured for "+entity+", so cannot forward "
+                                +"port "+port+" "+"even though "+PORT_FORWARDING_MANAGER.getName()+" was supplied, and "
+                                +"have location supporting port forwarding "+loc);
                     }
                 }
             }

--- a/core/src/test/java/org/apache/brooklyn/location/access/BrooklynAccessUtilsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/access/BrooklynAccessUtilsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.access;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.brooklyn.api.entity.proxying.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.location.basic.SshMachineLocation;
+import org.apache.brooklyn.location.basic.SupportsPortForwarding;
+import org.apache.brooklyn.test.entity.TestEntity;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.net.HostAndPort;
+
+import brooklyn.entity.BrooklynAppUnitTestSupport;
+import brooklyn.entity.basic.Attributes;
+import brooklyn.util.net.Cidr;
+
+public class BrooklynAccessUtilsTest extends BrooklynAppUnitTestSupport {
+
+    protected PortForwardManager pfm;
+    private TestEntity entity;
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        
+        pfm = (PortForwardManager) mgmt.getLocationRegistry().resolve("portForwardManager(scope=global)");
+    }
+    
+    @Test
+    public void testBrooklynAccessibleAddressFindsPreexistingMapping() throws Exception {
+        final int privatePort = 8080;
+        final String publicNatIp = "1.2.3.4";
+        final int publicNatPort = 12000;
+        
+        SshMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+                .configure(SshMachineLocation.TCP_PORT_MAPPINGS, ImmutableMap.of(privatePort, publicNatIp+":"+publicNatPort)));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynAccessUtils.PORT_FORWARDING_MANAGER, pfm)
+                .location(machine));
+
+        assertEquals(BrooklynAccessUtils.getBrooklynAccessibleAddress(entity, privatePort), HostAndPort.fromParts(publicNatIp, publicNatPort));
+    }
+    
+    @Test
+    public void testBrooklynAccessibleAddressUsesPrivateHostPortIfNoMapping() throws Exception {
+        final String privateIp = "127.1.2.3";
+        final int privatePort = 8080;
+        
+        SshMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynAccessUtils.PORT_FORWARDING_MANAGER, pfm)
+                .location(machine));
+        entity.setAttribute(Attributes.HOSTNAME, privateIp);
+
+        assertEquals(BrooklynAccessUtils.getBrooklynAccessibleAddress(entity, privatePort), HostAndPort.fromParts(privateIp, privatePort));
+    }
+    
+    @Test
+    public void testBrooklynAccessibleAddressFailsIfNoMappingAndNoHostname() throws Exception {
+        final int privatePort = 8080;
+        
+        SshMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynAccessUtils.PORT_FORWARDING_MANAGER, pfm)
+                .location(machine));
+
+        try {
+            BrooklynAccessUtils.getBrooklynAccessibleAddress(entity, privatePort);
+            fail();
+        } catch (IllegalStateException e) {
+            if (!e.toString().contains("no host.name")) throw e;
+            // success
+        }
+    }
+    
+    @Test
+    public void testBrooklynAccessibleAddressRequestsNewPortForwarding() throws Exception {
+        final int privatePort = 8080;
+        
+        RecordingSupportsPortForwarding machine = mgmt.getLocationManager().createLocation(LocationSpec.create(RecordingSupportsPortForwarding.class));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynAccessUtils.PORT_FORWARDING_MANAGER, pfm)
+                .configure(BrooklynAccessUtils.MANAGEMENT_ACCESS_CIDR, Cidr.UNIVERSAL)
+                .location(machine));
+
+        HostAndPort result = BrooklynAccessUtils.getBrooklynAccessibleAddress(entity, privatePort);
+        HostAndPort portForwarded = machine.mappings.get(privatePort);
+        assertNotNull(portForwarded);
+        assertEquals(result, portForwarded);
+    }
+    
+    @SuppressWarnings("serial") // TODO location should not be serializable; will be changed in future release
+    public static class RecordingSupportsPortForwarding extends SshMachineLocation implements SupportsPortForwarding {
+        protected final String publicIp = "1.2.3.4";
+        protected final Map<Integer, HostAndPort> mappings = Maps.newConcurrentMap();
+        private final AtomicInteger nextPort = new AtomicInteger(12000);
+        
+        
+        @Override
+        public HostAndPort getSocketEndpointFor(Cidr accessor, int privatePort) {
+            HostAndPort result = mappings.get(privatePort);
+            if (result == null) {
+                int publicPort = nextPort.getAndIncrement();
+                result = HostAndPort.fromParts(publicIp, publicPort);
+                mappings.put(privatePort, result);
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
- Previously there were no unit tests!
- Previously would not look up PortForwardManager unless machine
  implemented SupportsPortForwarding (which broke BYON’s tcpPortMappings)