### PR TITLE
Fix launch classpath on Windows

### DIFF
--- a/usage/dist/src/main/dist/bin/brooklyn.ps1
+++ b/usage/dist/src/main/dist/bin/brooklyn.ps1
@@ -81,14 +81,14 @@ if ( $javabin -eq $null ) {
 # set up the classpath
 $cp = Get-ChildItem ${BROOKLYN_HOME}\conf | Select-Object -ExpandProperty FullName
 
-if ( Test-Path ${BROOKLYN_HOME}\patch ) {
-    $cp += Get-ChildItem ${BROOKLYN_HOME}\patch | Select-Object -ExpandProperty FullName
+if ( Test-Path ${BROOKLYN_HOME}\lib\patch ) {
+    $cp += Get-ChildItem ${BROOKLYN_HOME}\lib\patch | Select-Object -ExpandProperty FullName
 }
 
 $cp += Get-ChildItem ${BROOKLYN_HOME}\lib\brooklyn | Select-Object -ExpandProperty FullName
 
-if ( Test-Path ${BROOKLYN_HOME}\dropins ) {
-    $cp += Get-ChildItem ${BROOKLYN_HOME}\dropins | Select-Object -ExpandProperty FullName
+if ( Test-Path ${BROOKLYN_HOME}\lib\dropins ) {
+    $cp += Get-ChildItem ${BROOKLYN_HOME}\lib\dropins | Select-Object -ExpandProperty FullName
 }
 
 $INITIAL_CLASSPATH = $cp -join ';'


### PR DESCRIPTION
Adds missing 'lib' segment to library 'patch' and 'dropins' dirs