### PR TITLE
BROOKLYN-162 - fix type name in default catalog

### DIFF
--- a/usage/cli/src/main/resources/brooklyn/default.catalog.bom
+++ b/usage/cli/src/main/resources/brooklyn/default.catalog.bom
@@ -253,7 +253,7 @@ brooklyn.catalog:
                   period: 5s
                   command: "cat output.txt | grep HTTP | grep 200 | wc | awk '{print $1}'"
               # and publish the port as a sensor so the load-balancer can pick it up
-              - type:           org.apache.brooklyn.sensor.StaticSensor
+              - type:           org.apache.brooklyn.sensor.core.StaticSensor
                 brooklyn.config:
                   name:         app.port
                   targetType:   int


### PR DESCRIPTION
Fix path to StaticSensor