### PR TITLE
Skip Maven install for the OSGi test bundles

### DIFF
--- a/utils/test-bundles/entities/pom.xml
+++ b/utils/test-bundles/entities/pom.xml
@@ -38,6 +38,11 @@
         <version>0.8.0-SNAPSHOT</version><!-- BROOKLYN_VERSION -->
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>

--- a/utils/test-bundles/more-entities-v1/pom.xml
+++ b/utils/test-bundles/more-entities-v1/pom.xml
@@ -55,7 +55,11 @@
             <version>${brooklyn.version}</version>
         </dependency>
     </dependencies>
-    
+
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/utils/test-bundles/more-entities-v2-evil-twin/pom.xml
+++ b/utils/test-bundles/more-entities-v2-evil-twin/pom.xml
@@ -38,6 +38,11 @@
         <version>0.8.0-SNAPSHOT</version><!-- BROOKLYN_VERSION -->
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>

--- a/utils/test-bundles/more-entities-v2/pom.xml
+++ b/utils/test-bundles/more-entities-v2/pom.xml
@@ -38,6 +38,11 @@
         <version>0.8.0-SNAPSHOT</version><!-- BROOKLYN_VERSION -->
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+
+    <properties>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>


### PR DESCRIPTION
These cannot be installed into a repository and uploaded to Nexus as they do not use the same version number as Brooklyn. They have been breaking our Jenkins CI builds as Nexus refuses to accept non-SNAPSHOT-versioned artifacts into the snapshot repository. We would also likely encounter versioning conflicts for release, too.

This change sets `maven.install.skip` on the affected modules so they are not installed into the local repository, therefore Jenkins will not attempt to deploy them into the remote repository.