### PR TITLE
Resuming locations

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/location/MachineManagementMixins.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/MachineManagementMixins.java
@@ -70,8 +70,7 @@ public class MachineManagementMixins {
      * Implement to indicate that a location can suspend and resume machines.
      */
     @Beta
-    public interface SuspendResumeLocation extends SuspendsMachines, ResumesMachines {};
-
+    public interface SuspendResumeLocation extends SuspendsMachines, ResumesMachines {}
 
     @Beta
     public interface SuspendsMachines {
@@ -86,7 +85,7 @@ public class MachineManagementMixins {
         /**
          * Resume the indicated machine.
          */
-        void resumeMachine(MachineLocation location);
+        MachineLocation resumeMachine(Map<?, ?> flags);
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
@@ -334,7 +334,7 @@ public class BasicLocationRegistry implements LocationRegistry {
                 try {
                     return Maybe.of(resolver.newLocationFromString(locationFlags, spec, this));
                 } catch (RuntimeException e) {
-                    return Maybe.absent(Suppliers.ofInstance(e));
+                     return Maybe.absent(Suppliers.ofInstance(e));
                 }
             }
 

--- a/core/src/main/java/org/apache/brooklyn/location/byon/ByonLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/ByonLocationResolver.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.brooklyn.api.location.Location;
@@ -98,7 +99,7 @@ public class ByonLocationResolver extends AbstractLocationResolver {
         config.remove("hosts");
         String user = (String) config.getStringKey("user");
         Integer port = (Integer) TypeCoercions.coerce(config.getStringKey("port"), Integer.class);
-        Class<? extends MachineLocation> locationClass = OS_TO_MACHINE_LOCATION_TYPE.get(config.get(OS_FAMILY));
+        Class<? extends MachineLocation> locationClass = getLocationClass(config.get(OS_FAMILY));
 
         MutableMap<String, Object> defaultProps = MutableMap.of();
         defaultProps.addIfNotNull("user", user);
@@ -199,10 +200,14 @@ public class ByonLocationResolver extends AbstractLocationResolver {
         
         Class<? extends MachineLocation> locationClassHere = locationClass;
         if (osfamily != null) {
-            locationClassHere = OS_TO_MACHINE_LOCATION_TYPE.get(osfamily);
+            locationClassHere = getLocationClass(osfamily);
         }
 
         return LocationSpec.create(locationClassHere).configure(machineConfig);
+    }
+
+    private Class<? extends MachineLocation> getLocationClass(String osFamily) {
+        return osFamily == null ? null : OS_TO_MACHINE_LOCATION_TYPE.get(osFamily.toLowerCase(Locale.ENGLISH));
     }
 
     protected LocationSpec<? extends MachineLocation> parseMachine(String val, Class<? extends MachineLocation> locationClass, Map<String, ?> defaults, String specForErrMsg) {

--- a/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
@@ -332,14 +333,19 @@ public class ByonLocationResolverTest {
         Assert.assertEquals("1.1.1.1", location1.getAddress().getHostAddress());
     }
 
-    @Test
-    public void testWindowsMachines() throws Exception {
+    @DataProvider(name = "windowsOsFamilies")
+    public Object[][] getWindowsOsFamilies() {
+        return new Object[][]{{"windows"}, {"WINDOWS"}, {"wInDoWs"}};
+    }
+
+    @Test(dataProvider = "windowsOsFamilies")
+    public void testWindowsMachines(String osFamily) throws Exception {
         brooklynProperties.put("brooklyn.location.byon.user", "myuser");
         brooklynProperties.put("brooklyn.location.byon.password", "mypassword");
         String spec = "byon";
         Map<String, ?> flags = ImmutableMap.of(
                 "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),
-                "osfamily", "windows"
+                "osfamily", osFamily
         );
         MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
         WinRmMachineLocation location = (WinRmMachineLocation) provisioner.obtain(ImmutableMap.of());
@@ -350,7 +356,7 @@ public class ByonLocationResolverTest {
     }
 
     @Test
-    public void testNoneWindowsMachines() throws Exception {
+    public void testNonWindowsMachines() throws Exception {
         String spec = "byon";
         Map<String, ?> flags = ImmutableMap.of(
                 "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1903,9 +1903,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
      * <p>
      * Required fields are:
      * <ul>
-     *   <li>id: the jclouds VM id, e.g. "eu-west-1/i-5504f21d" (NB this is @see JcloudsSshMachineLocation#getJcloudsId() not #getId())
+     *   <li>id: the jclouds VM id, e.g. "eu-west-1/i-5504f21d" (NB this is {@see JcloudsMachineLocation#getJcloudsId()} not #getId())
      *   <li>hostname: the public hostname or IP of the machine, e.g. "ec2-176-34-93-58.eu-west-1.compute.amazonaws.com"
-     *   <li>userName: the username for ssh'ing into the machine
+     *   <li>userName: the username for sshing into the machine if it is not a Windows system
      * <ul>
      */
     public MachineLocation registerMachine(ConfigBag setup) throws NoMachinesAvailableException {
@@ -1941,7 +1941,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             // TODO confirm we can SSH ?
             // NB if rawHostname not set, get the hostname using getPublicHostname(node, Optional.<HostAndPort>absent(), setup);
 
-            return registerJcloudsSshMachineLocation(computeService, node, null, Optional.<HostAndPort>absent(), setup);
+            if (isWindows(node, setup)) {
+                return registerWinRmMachineLocation(computeService, node, null, Optional.<HostAndPort>absent(), setup);
+            } else {
+                return registerJcloudsSshMachineLocation(computeService, node, null, Optional.<HostAndPort>absent(), setup);
+            }
 
         } catch (IOException e) {
             throw Exceptions.propagate(e);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1861,16 +1861,41 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     }
 
 
-    // ----------------- rebinding to existing machine ------------------------
+    // ----------------- registering existing machines ------------------------
 
+    /**
+     * @deprecated since 0.8.0 use {@link #registerMachine(NodeMetadata)} instead.
+     */
+    @Deprecated
     public JcloudsSshMachineLocation rebindMachine(NodeMetadata metadata) throws NoMachinesAvailableException {
-        return rebindMachine(MutableMap.of(), metadata);
+        return (JcloudsSshMachineLocation) registerMachine(metadata);
     }
+
+    public MachineLocation registerMachine(NodeMetadata metadata) throws NoMachinesAvailableException {
+        return registerMachine(MutableMap.of(), metadata);
+    }
+
+    /**
+     * @deprecated since 0.8.0 use {@link #registerMachine(Map, NodeMetadata)} instead.
+     */
+    @Deprecated
     public JcloudsSshMachineLocation rebindMachine(Map<?,?> flags, NodeMetadata metadata) throws NoMachinesAvailableException {
+        return (JcloudsSshMachineLocation) registerMachine(flags, metadata);
+    }
+
+    public MachineLocation registerMachine(Map<?, ?> flags, NodeMetadata metadata) throws NoMachinesAvailableException {
         ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags);
         if (!setup.containsKey("id")) setup.putStringKey("id", metadata.getId());
         setHostnameUpdatingCredentials(setup, metadata);
-        return rebindMachine(setup);
+        return registerMachine(setup);
+    }
+
+    /**
+     * @deprecated since 0.8.0 use {@link #registerMachine(ConfigBag)} instead.
+     */
+    @Deprecated
+    public JcloudsSshMachineLocation rebindMachine(ConfigBag setup) throws NoMachinesAvailableException {
+        return (JcloudsSshMachineLocation) registerMachine(setup);
     }
 
     /**
@@ -1883,7 +1908,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
      *   <li>userName: the username for ssh'ing into the machine
      * <ul>
      */
-    public JcloudsSshMachineLocation rebindMachine(ConfigBag setup) throws NoMachinesAvailableException {
+    public MachineLocation registerMachine(ConfigBag setup) throws NoMachinesAvailableException {
         try {
             if (setup.getDescription() == null) setCreationString(setup);
             String user = checkNotNull(getUser(setup), "user");
@@ -1923,9 +1948,17 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         }
     }
 
-    public JcloudsSshMachineLocation rebindMachine(Map<?,?> flags) throws NoMachinesAvailableException {
+    /**
+     * @deprecated since 0.8.0 use {@link #registerMachine(Map)} instead.
+     */
+    @Deprecated
+    public JcloudsSshMachineLocation rebindMachine(Map<?, ?> flags) throws NoMachinesAvailableException {
+        return (JcloudsSshMachineLocation) registerMachine(flags);
+    }
+
+    public MachineLocation registerMachine(Map<?,?> flags) throws NoMachinesAvailableException {
         ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags);
-        return rebindMachine(setup);
+        return registerMachine(setup);
     }
 
     /**

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -189,7 +189,7 @@ import io.cloudsoft.winrm4j.pywinrm.WinRMFactory;
 @SuppressWarnings("serial")
 public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation implements
         JcloudsLocationConfig, MachineManagementMixins.RichMachineProvisioningLocation<MachineLocation>,
-        LocationWithObjectStore, MachineManagementMixins.SuspendsMachines {
+        LocationWithObjectStore, MachineManagementMixins.SuspendResumeLocation {
 
     // TODO After converting from Groovy to Java, this is now very bad code! It relies entirely on putting
     // things into and taking them out of maps; it's not type-safe, and it's thus very error-prone.
@@ -514,7 +514,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         ConfigBag conf = (flags==null || flags.isEmpty())
                 ? config().getBag()
                 : ConfigBag.newInstanceExtending(config().getBag(), flags);
-        return getConfig(COMPUTE_SERVICE_REGISTRY).findComputeService(conf, true);
+        return getComputeService(conf);
+    }
+
+    public ComputeService getComputeService(ConfigBag config) {
+        return getConfig(COMPUTE_SERVICE_REGISTRY).findComputeService(config, true);
     }
 
     /** @deprecated since 0.7.0 use {@link #listMachines()} */ @Deprecated
@@ -1052,6 +1056,32 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         if (toThrow != null) {
             throw Exceptions.propagate(toThrow);
         }
+    }
+
+    /**
+     * Brings an existing machine with the given details under management.
+     * <p/>
+     * Note that this method does <b>not</b> call the lifecycle methods of any
+     * {@link #getCustomizers(ConfigBag) customizers} attached to this location.
+     *
+     * @param flags See {@link #registerMachine(ConfigBag)} for a description of required fields.
+     * @see #registerMachine(ConfigBag)
+     */
+    @Override
+    public MachineLocation resumeMachine(Map<?, ?> flags) {
+        ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags);
+        LOG.info("{} using resuming node matching properties: {}", this, setup);
+        ComputeService computeService = getComputeService(setup);
+        NodeMetadata node = findNodeOrThrow(setup);
+        LOG.debug("{} resuming {}", this, node);
+        computeService.resumeNode(node.getId());
+        // Load the node a second time once it is resumed to get an object with
+        // hostname and addresses populated.
+        node = findNodeOrThrow(setup);
+        LOG.debug("{} resumed {}", this, node);
+        MachineLocation registered = registerMachineLocation(setup, node);
+        LOG.info("{} resumed and registered {}", this, registered);
+        return registered;
     }
 
     // ------------- constructing the template, etc ------------------------
@@ -1871,7 +1901,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         return (JcloudsSshMachineLocation) registerMachine(metadata);
     }
 
-    public MachineLocation registerMachine(NodeMetadata metadata) throws NoMachinesAvailableException {
+    protected MachineLocation registerMachine(NodeMetadata metadata) throws NoMachinesAvailableException {
         return registerMachine(MutableMap.of(), metadata);
     }
 
@@ -1883,7 +1913,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         return (JcloudsSshMachineLocation) registerMachine(flags, metadata);
     }
 
-    public MachineLocation registerMachine(Map<?, ?> flags, NodeMetadata metadata) throws NoMachinesAvailableException {
+    protected MachineLocation registerMachine(Map<?, ?> flags, NodeMetadata metadata) throws NoMachinesAvailableException {
         ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags);
         if (!setup.containsKey("id")) setup.putStringKey("id", metadata.getId());
         setHostnameUpdatingCredentials(setup, metadata);
@@ -1891,6 +1921,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     }
 
     /**
+     * Brings an existing machine with the given details under management.
+     * <p>
+     * This method will throw an exception if used to reconnect to a Windows VM.
      * @deprecated since 0.8.0 use {@link #registerMachine(ConfigBag)} instead.
      */
     @Deprecated
@@ -1905,51 +1938,64 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
      * <ul>
      *   <li>id: the jclouds VM id, e.g. "eu-west-1/i-5504f21d" (NB this is {@see JcloudsMachineLocation#getJcloudsId()} not #getId())
      *   <li>hostname: the public hostname or IP of the machine, e.g. "ec2-176-34-93-58.eu-west-1.compute.amazonaws.com"
-     *   <li>userName: the username for sshing into the machine if it is not a Windows system
+     *   <li>userName: the username for sshing into the machine (for use if it is not a Windows system)
      * <ul>
      */
     public MachineLocation registerMachine(ConfigBag setup) throws NoMachinesAvailableException {
-        try {
-            if (setup.getDescription() == null) setCreationString(setup);
-            String user = checkNotNull(getUser(setup), "user");
-            String rawId = (String) setup.getStringKey("id");
-            String rawHostname = (String) setup.getStringKey("hostname");
-            Predicate<ComputeMetadata> predicate = getRebindToMachinePredicate(setup);
-            LOG.info("Rebinding to VM {} ({}@{}), in jclouds location for provider {} matching {}", new Object[]{
-                    rawId != null ? rawId : "<lookup>",
-                    user,
-                    rawHostname != null ? rawHostname : "<unspecified>",
-                    getProvider(),
-                    predicate
-                    });
-            ComputeService computeService = getConfig(COMPUTE_SERVICE_REGISTRY).findComputeService(setup, true);
-            Set<? extends NodeMetadata> candidateNodes = computeService.listNodesDetailsMatching(predicate);
-            if (candidateNodes.isEmpty()) {
-                throw new IllegalArgumentException("Jclouds node not found for rebind with predicate " + predicate);
-            } else if (candidateNodes.size() > 1) {
-                throw new IllegalArgumentException("Jclouds node for rebind matched multiple with " + predicate + ": " + candidateNodes);
-            }
+        NodeMetadata node = findNodeOrThrow(setup);
+        return registerMachineLocation(setup, node);
+    }
 
-            NodeMetadata node = Iterables.getOnlyElement(candidateNodes);
-            String pkd = LocationConfigUtils.getOsCredential(setup).checkNoErrors().logAnyWarnings().getPrivateKeyData();
-            if (Strings.isNonBlank(pkd)) {
-                LoginCredentials expectedCredentials = LoginCredentials.fromCredentials(new Credentials(user, pkd));
-                //override credentials
-                node = NodeMetadataBuilder.fromNodeMetadata(node).credentials(expectedCredentials).build();
-            }
-
-            // TODO confirm we can SSH ?
-            // NB if rawHostname not set, get the hostname using getPublicHostname(node, Optional.<HostAndPort>absent(), setup);
-
-            if (isWindows(node, setup)) {
-                return registerWinRmMachineLocation(computeService, node, null, Optional.<HostAndPort>absent(), setup);
-            } else {
+    protected MachineLocation registerMachineLocation(ConfigBag setup, NodeMetadata node) {
+        ComputeService computeService = getComputeService(setup);
+        if (isWindows(node, setup)) {
+            return registerWinRmMachineLocation(computeService, node, null, Optional.<HostAndPort>absent(), setup);
+        } else {
+            try {
                 return registerJcloudsSshMachineLocation(computeService, node, null, Optional.<HostAndPort>absent(), setup);
+            } catch (IOException e) {
+                throw Exceptions.propagate(e);
             }
-
-        } catch (IOException e) {
-            throw Exceptions.propagate(e);
         }
+    }
+
+    /**
+     * Finds a node matching the properties given in config or throws an exception.
+     * @param config
+     * @return
+     */
+    protected NodeMetadata findNodeOrThrow(ConfigBag config) {
+        if (config.getDescription() == null) {
+            setCreationString(config);
+        }
+        String user = checkNotNull(getUser(config), "user");
+        String rawId = (String) config.getStringKey("id");
+        String rawHostname = (String) config.getStringKey("hostname");
+        Predicate<ComputeMetadata> predicate = getRebindToMachinePredicate(config);
+        LOG.debug("Finding VM {} ({}@{}), in jclouds location for provider {} matching {}", new Object[]{
+                rawId != null ? rawId : "<lookup>",
+                user,
+                rawHostname != null ? rawHostname : "<unspecified>",
+                getProvider(),
+                predicate
+        });
+        ComputeService computeService = getComputeService(config);
+        Set<? extends NodeMetadata> candidateNodes = computeService.listNodesDetailsMatching(predicate);
+        if (candidateNodes.isEmpty()) {
+            throw new IllegalArgumentException("Jclouds node not found for rebind with predicate " + predicate);
+        } else if (candidateNodes.size() > 1) {
+            throw new IllegalArgumentException("Jclouds node for rebind matched multiple with " + predicate + ": " + candidateNodes);
+        }
+        NodeMetadata node = Iterables.getOnlyElement(candidateNodes);
+
+        String pkd = LocationConfigUtils.getOsCredential(config).checkNoErrors().logAnyWarnings().getPrivateKeyData();
+        if (Strings.isNonBlank(pkd)) {
+            LoginCredentials expectedCredentials = LoginCredentials.fromCredentials(new Credentials(user, pkd));
+            //override credentials
+            node = NodeMetadataBuilder.fromNodeMetadata(node).credentials(expectedCredentials).build();
+        }
+
+        return node;
     }
 
     /**

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.brooklyn.util.exceptions.CompoundRuntimeException;
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -154,4 +155,18 @@ public class AbstractJcloudsLiveTest {
         machines.remove(machine);
         jcloudsLocation.release(machine);
     }
+
+    protected void suspendMachine(MachineLocation machine) {
+        assertNotNull(jcloudsLocation);
+        machines.remove(machine);
+        jcloudsLocation.suspendMachine(machine);
+    }
+
+    protected MachineLocation resumeMachine(Map<?, ?> flags) {
+        assertNotNull(jcloudsLocation);
+        MachineLocation location = jcloudsLocation.resumeMachine(flags);
+        machines.add((JcloudsSshMachineLocation) location);
+        return location;
+    }
+
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationRebindMachineLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationRebindMachineLiveTest.java
@@ -52,7 +52,7 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
     @Test(groups = { "Live", "Live-sanity" })
     public void testRebindWithIncorrectId() throws Exception {
         try {
-            jcloudsLocation.rebindMachine(ImmutableMap.of("id", "incorrectid", "hostname", "myhostname", "user", "myusername"));
+            jcloudsLocation.registerMachine(ImmutableMap.of("id", "incorrectid", "hostname", "myhostname", "user", "myusername"));
         } catch (IllegalArgumentException e) {
             if (e.getMessage().contains("node not found")) {
                 // success

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationRegisterMachineLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationRegisterMachineLiveTest.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.util.Collections;
 
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
@@ -35,12 +36,11 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTest {
+public class JcloudsLocationRegisterMachineLiveTest extends AbstractJcloudsLiveTest {
     
-    private static final Logger LOG = LoggerFactory.getLogger(JcloudsLocationRebindMachineLiveTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JcloudsLocationRegisterMachineLiveTest.class);
     
-    private static final String EUWEST_IMAGE_ID = AWS_EC2_EUWEST_REGION_NAME+"/"+"ami-89def4fd";
-    private static final String IMAGE_OWNER = "411009282317";
+    private static final String EUWEST_IMAGE_ID = AWS_EC2_EUWEST_REGION_NAME+"/"+"ami-ce7b6fba";
 
     @BeforeMethod(alwaysRun=true)
     @Override
@@ -50,7 +50,7 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
     }
 
     @Test(groups = { "Live", "Live-sanity" })
-    public void testRebindWithIncorrectId() throws Exception {
+    public void testRegisterWithIncorrectId() throws Exception {
         try {
             jcloudsLocation.registerMachine(ImmutableMap.of("id", "incorrectid", "hostname", "myhostname", "user", "myusername"));
         } catch (IllegalArgumentException e) {
@@ -63,12 +63,12 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
     }
     
     @Test(groups = { "Live" })
-    public void testRebindVm() throws Exception {
+    public void testRegisterVm() throws Exception {
         // FIXME How to create a machine - go directly through jclouds instead?
         //       Going through LocationRegistry.resolve, loc and loc2 might be same instance
         
         // Create a VM through jclouds
-        JcloudsSshMachineLocation machine = obtainMachine(ImmutableMap.of("imageId", EUWEST_IMAGE_ID, "imageOwner", IMAGE_OWNER));
+        JcloudsSshMachineLocation machine = obtainMachine(ImmutableMap.of("imageId", EUWEST_IMAGE_ID));
         assertTrue(machine.isSshable());
         LOG.info("obtained "+machine);
 
@@ -79,9 +79,11 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
         
         // Create a new jclouds location, and re-bind the existing VM to that
         JcloudsLocation loc2 = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
-        SshMachineLocation machine2 = loc2.rebindMachine(ImmutableMap.of("id", id, "hostname", hostname, "user", user));
-        
-        LOG.info("rebinded to "+machine2);
+        MachineLocation machineLocation = loc2.registerMachine(ImmutableMap.of("id", id, "hostname", hostname, "user", user));
+        assertTrue(machineLocation instanceof SshMachineLocation);
+        SshMachineLocation machine2 = (SshMachineLocation) machineLocation;
+
+        LOG.info("Registered " + machine2);
         
         // Confirm the re-bound machine is wired up
         assertTrue(machine2.isSshable());
@@ -94,11 +96,11 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
     }
     
     @Test(groups = { "Live" })
-    public void testRebindVmDeprecated() throws Exception {
-        // FIXME See comments in testRebindVm
+    public void testRegisterVmDeprecated() throws Exception {
+        // FIXME See comments in testRegisterVm
 
         // Create a VM through jclouds
-        JcloudsSshMachineLocation machine = obtainMachine(ImmutableMap.of("imageId", EUWEST_IMAGE_ID, "imageOwner", IMAGE_OWNER));
+        JcloudsSshMachineLocation machine = obtainMachine(ImmutableMap.of("imageId", EUWEST_IMAGE_ID));
         assertTrue(machine.isSshable());
 
         String id = machine.getJcloudsId();
@@ -109,8 +111,10 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
         // Create a new jclouds location, and re-bind the existing VM to that
         JcloudsLocation loc2 = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
         // pass deprecated userName
-        SshMachineLocation machine2 = loc2.rebindMachine(ImmutableMap.of("id", id, "hostname", hostname, "userName", username));
-        
+        MachineLocation machineLocation = loc2.registerMachine(ImmutableMap.of("id", id, "hostname", hostname, "userName", username));
+        assertTrue(machineLocation instanceof SshMachineLocation);
+        SshMachineLocation machine2 = (SshMachineLocation) machineLocation;
+
         // Confirm the re-bound machine is wired up
         assertTrue(machine2.isSshable());
         assertEquals(ImmutableSet.copyOf(loc2.getChildren()), ImmutableSet.of(machine2));
@@ -123,14 +127,16 @@ public class JcloudsLocationRebindMachineLiveTest extends AbstractJcloudsLiveTes
 
     // Useful for debugging; accesss a hard-coded existing instance so don't need to wait for provisioning a new one
     @Test(enabled=false, groups = { "Live" })
-    public void testRebindVmToHardcodedInstance() throws Exception {
+    public void testRegisterVmToHardcodedInstance() throws Exception {
         String id = "eu-west-1/i-5504f21d";
         InetAddress address = InetAddress.getByName("ec2-176-34-93-58.eu-west-1.compute.amazonaws.com");
         String hostname = address.getHostName();
         String username = "root";
         
-        SshMachineLocation machine = jcloudsLocation.rebindMachine(ImmutableMap.of("id", id, "hostname", hostname, "userName", username));
-        
+        MachineLocation machineLocation = jcloudsLocation.registerMachine(ImmutableMap.of("id", id, "hostname", hostname, "userName", username));
+        assertTrue(machineLocation instanceof SshMachineLocation);
+        SshMachineLocation machine = (SshMachineLocation) machineLocation;
+
         // Confirm the re-bound machine is wired up
         assertTrue(machine.isSshable());
         assertEquals(ImmutableSet.copyOf(jcloudsLocation.getChildren()), ImmutableSet.of(machine));

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationSuspendResumeMachineLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationSuspendResumeMachineLiveTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.api.location.MachineLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class JcloudsLocationSuspendResumeMachineLiveTest extends AbstractJcloudsLiveTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JcloudsLocationSuspendResumeMachineLiveTest.class);
+
+    private static final String EUWEST_IMAGE_ID = AWS_EC2_EUWEST_REGION_NAME + "/" + "ami-ce7b6fba";
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry()
+                .resolve(AWS_EC2_PROVIDER + ":" + AWS_EC2_EUWEST_REGION_NAME);
+    }
+
+    @Test(groups = "Live")
+    public void testObtainThenSuspendThenResumeMachine() throws Exception {
+        MachineLocation machine = obtainMachine(ImmutableMap.of(
+                "imageId", EUWEST_IMAGE_ID));
+        JcloudsSshMachineLocation sshMachine = (JcloudsSshMachineLocation) machine;
+        assertTrue(sshMachine.isSshable(), "Cannot SSH to " + sshMachine);
+
+        suspendMachine(machine);
+        assertFalse(sshMachine.isSshable(), "Should not be able to SSH to suspended machine");
+
+        MachineLocation machine2 = resumeMachine(ImmutableMap.of("id", sshMachine.getJcloudsId()));
+        assertTrue(machine2 instanceof JcloudsSshMachineLocation);
+        assertTrue(((JcloudsSshMachineLocation) machine2).isSshable(), "Cannot SSH to " + machine2);
+    }
+
+}

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/resources/LocationResource.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/resources/LocationResource.java
@@ -153,18 +153,19 @@ public class LocationResource extends AbstractBrooklynRestResource implements Lo
                 "",
                 "brooklyn.locations:",
                 "- type: "+locationSpec.getSpec());
-          if (locationSpec.getConfig().size() > 0) {
-              yaml.add("  brooklyn.config:");
-              for (Map.Entry<String, ?> entry : locationSpec.getConfig().entrySet()) {
-                  yaml.add("    "+entry.getKey()+": "+entry.getValue());
-              }
-          }
+        if (locationSpec.getConfig().size() > 0) {
+            yaml.add("  brooklyn.config:");
+            for (Map.Entry<String, ?> entry : locationSpec.getConfig().entrySet()) {
+                yaml.add("    " + entry.getKey() + ": " + entry.getValue());
+            }
+        }
 
-          brooklyn().getCatalog().addItems(Joiner.on("\n").join(yaml.build()));
-          LocationDefinition l = brooklyn().getLocationRegistry().getDefinedLocationByName(name);
-          return Response.created(URI.create(name))
-                  .entity(LocationTransformer.newInstance(mgmt(), l, LocationDetailLevel.LOCAL_EXCLUDING_SECRET))
-                  .build();
+        String locationBlueprint = Joiner.on("\n").join(yaml.build());
+        brooklyn().getCatalog().addItems(locationBlueprint);
+        LocationDefinition l = brooklyn().getLocationRegistry().getDefinedLocationByName(name);
+        return Response.created(URI.create(name))
+                .entity(LocationTransformer.newInstance(mgmt(), l, LocationDetailLevel.LOCAL_EXCLUDING_SECRET))
+                .build();
     }
 
     @Override


### PR DESCRIPTION
* `JcloudsLocation` implements `SuspendResumeLocation` (rather than just `SuspendsLocations`).
* The various `rebindMachine` methods in `JcloudsLocation` are deprecated in favour of `registerMachine`, which returns a `MachineLocation` rather than a `JcloudsSshMachineLocation`. This means that it can also be used to register Windows-based systems.