### PR TITLE
Skip Maven deploy for the OSGi test bundles

### DIFF
--- a/utils/test-bundles/entities/pom.xml
+++ b/utils/test-bundles/entities/pom.xml
@@ -41,6 +41,7 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/utils/test-bundles/more-entities-v1/pom.xml
+++ b/utils/test-bundles/more-entities-v1/pom.xml
@@ -58,6 +58,7 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <build>

--- a/utils/test-bundles/more-entities-v2-evil-twin/pom.xml
+++ b/utils/test-bundles/more-entities-v2-evil-twin/pom.xml
@@ -41,6 +41,7 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/utils/test-bundles/more-entities-v2/pom.xml
+++ b/utils/test-bundles/more-entities-v2/pom.xml
@@ -41,6 +41,7 @@
 
     <properties>
         <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Like #851, but uses a different property (that one didn't work).

These cannot be installed into a repository and uploaded to Nexus as they do not use the same version number as Brooklyn. They have been breaking our Jenkins CI builds as Nexus refuses to accept non-SNAPSHOT-versioned artifacts into the snapshot repository. We would also likely encounter versioning conflicts for release, too.

This change sets `maven.deploy.skip` on the affected modules so they are not installed into the local repository, therefore Jenkins will not attempt to deploy them into the remote repository.