### PR TITLE
Adds Entity.sensors() to group the sensor methods

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntityLocal.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntityLocal.java
@@ -26,7 +26,6 @@ import org.apache.brooklyn.api.mgmt.SubscriptionManager;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
-import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
@@ -81,31 +80,21 @@ public interface EntityLocal extends Entity {
     <T> T setConfig(HasConfigKey<T> key, Task<T> val);
 
     /**
-     * Sets the {@link AttributeSensor} data for the given attribute to the specified value.
-     * 
-     * This can be used to "enrich" the entity, such as adding aggregated information, 
-     * rolling averages, etc.
-     * 
-     * @return the old value for the attribute (possibly {@code null})
+     * @deprecated since 0.8.0; use {@link SensorSupport#set(AttributeSensor, Object)} via code like {@code sensors().set(attribute, val)}.
      */
     <T> T setAttribute(AttributeSensor<T> attribute, T val);
 
     /**
-     * Atomically modifies the {@link AttributeSensor}, ensuring that only one modification is done
-     * at a time.
-     * 
-     * If the modifier returns {@link Maybe#absent()} then the attribute will be
-     * left unmodified, and the existing value will be returned.
-     * 
-     * For details of the synchronization model used to achieve this, refer to the underlying 
-     * attribute store (e.g. AttributeMap).
-     * 
-     * @return the old value for the attribute (possibly {@code null})
-     * @since 0.7.0-M2
+     * @deprecated since 0.8.0; use {@link SensorSupport#modify(AttributeSensor, Function)} via code like {@code sensors().modify(attribute, modifier)}.
      */
     @Beta
     <T> T modifyAttribute(AttributeSensor<T> attribute, Function<? super T, Maybe<T>> modifier);
 
+    /**
+     * @deprecated since 0.8.0; use {@link SensorSupport#emit(Sensor, Object)} via code like {@code sensors().emit(sensor, val)}.
+     */
+    <T> void emit(Sensor<T> sensor, T value);
+    
     /**
      * @deprecated in 0.5; use {@link #getConfig(ConfigKey)}
      */
@@ -116,14 +105,6 @@ public interface EntityLocal extends Entity {
      */
     <T> T getConfig(HasConfigKey<T> key, T defaultValue);
 
-    /**
-     * Emits a {@link SensorEvent} event on behalf of this entity (as though produced by this entity).
-     * <p>
-     * Note that for attribute sensors it is nearly always recommended to use setAttribute, 
-     * as this method will not update local values.
-     */
-    <T> void emit(Sensor<T> sensor, T value);
-    
     /**
      * Allow us to subscribe to data from a {@link Sensor} on another entity.
      * 

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
@@ -22,7 +22,9 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity.SensorSupport;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -30,13 +32,17 @@ import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
 import org.apache.brooklyn.api.mgmt.rebind.Rebindable;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.EntityMemento;
+import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.entity.internal.EntityConfigMap;
 import org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
+import org.apache.brooklyn.core.objs.BrooklynObjectInternal.ConfigurationSupportInternal;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.annotations.Beta;
 
@@ -54,8 +60,7 @@ public interface EntityInternal extends BrooklynObjectInternal, EntityLocal, Reb
     void clearLocations();
 
     /**
-     * 
-     * Like {@link EntityLocal#setAttribute(AttributeSensor, Object)}, except does not publish an attribute-change event.
+     * @deprecated since 0.8.0; use {@link SensorSupportInternal#setWithoutPublishing(AttributeSensor, Object)} via code like {@code sensors().setWithoutPublishing(attribute, val)}.
      */
     <T> T setAttributeWithoutPublishing(AttributeSensor<T> sensor, T val);
 
@@ -93,9 +98,15 @@ public interface EntityInternal extends BrooklynObjectInternal, EntityLocal, Reb
     @Deprecated
     ConfigBag getLocalConfigBag();
 
+    /**
+     * @deprecated since 0.8.0; use {@link SensorSupportInternal#getAll()} via code like {@code sensors().getAll()}.
+     */
     @Beta
     Map<AttributeSensor, Object> getAllAttributes();
 
+    /**
+     * @deprecated since 0.8.0; use {@link SensorSupportInternal#remove(AttributeSensor)} via code like {@code sensors().remove(attribute)}.
+     */
     @Beta
     void removeAttribute(AttributeSensor<?> attribute);
 
@@ -177,6 +188,25 @@ public interface EntityInternal extends BrooklynObjectInternal, EntityLocal, Reb
      */
     void requestPersist();
     
+    SensorSupportInternal sensors();
+
+    @Beta
+    public interface SensorSupportInternal extends Entity.SensorSupport {
+        /**
+         * 
+         * Like {@link EntityLocal#setAttribute(AttributeSensor, Object)}, except does not publish an attribute-change event.
+         */
+        <T> T setWithoutPublishing(AttributeSensor<T> sensor, T val);
+        
+        @Beta
+        Map<AttributeSensor<?>, Object> getAll();
+
+        @Beta
+        void remove(AttributeSensor<?> attribute);
+
+
+    }
+
     public interface FeedSupport {
         Collection<Feed> getFeeds();
         


### PR DESCRIPTION
- The attribute/sensor methods are all in Entity.sensors().
- Deprecates the previous things in Entity.* and EntityLocal.*,
  except for getAttribute(AttributeSensor) which is left as a convenience.
- In EntityInternal.sensors(), it returns SensorSupportInternal
  which has more methods on it.

There are three big motivations for this:
- Consistency with entity.config()
- Simplification of the Entity class (which has way too many methods)
  by grouping them.
- Exposing the methods of EntityLocal on Entity, so we can 
  deprecate EntityLocal (this commit deals with just the attribute/sensor
  methods of EntityLocal)


Note that I haven't changed any of the uses of the old attribute methods. I wanted to get feedback first as to whether people agreed this was the right thing to do!

Do people agree that `sensors()` is the best name? We could call it `attributes()`?