### PR TITLE
Update archetype command with correct package name

### DIFF
--- a/docs/guide/java/archetype.md
+++ b/docs/guide/java/archetype.md
@@ -23,7 +23,7 @@ if creating a project named "autobrick" for "com.acme":
 
 {% highlight bash %}
 $ mvn archetype:generate \
-	-DarchetypeGroupId=io.brooklyn \
+	-DarchetypeGroupId=org.apache.brooklyn \
 	-DarchetypeArtifactId=brooklyn-archetype-quickstart \
 	-DarchetypeVersion={{ site.brooklyn-version }} \
 	-DgroupId=com.acme -DartifactId=autobrick \


### PR DESCRIPTION
Updates https://brooklyn.incubator.apache.org/v/0.7.0-SNAPSHOT/java/archetype.html with correct package name in command

Tested on: https://github.com/apache/incubator-brooklyn/releases/tag/apache-brooklyn-0.7.0-incubating