### PR TITLE
Winrm commands stdin, stdout, stderr; Commands Live tests

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/byon/ByonLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/ByonLocationResolver.java
@@ -70,7 +70,7 @@ public class ByonLocationResolver extends AbstractLocationResolver {
     
     public static final String BYON = "byon";
 
-    public static final ConfigKey<String> OS_FAMILY = ConfigKeys.newStringConfigKey("osfamily", "OS Family of the machine, either windows or linux", "linux");
+    public static final ConfigKey<String> OS_FAMILY = ConfigKeys.newStringConfigKey("osFamily", "OS Family of the machine, either windows or linux", "linux");
 
     public static final Map<String, Class<? extends MachineLocation>> OS_TO_MACHINE_LOCATION_TYPE = ImmutableMap.<String, Class<? extends MachineLocation>>of(
             "windows", WinRmMachineLocation.class,
@@ -147,7 +147,7 @@ public class ByonLocationResolver extends AbstractLocationResolver {
         Map<String, Object> valSanitized = Sanitizer.sanitize(vals);
         Map<String, Object> machineConfig = MutableMap.copyOf(vals);
         
-        String osfamily = (String) machineConfig.remove(OS_FAMILY.getName());
+        String osFamily = (String) machineConfig.remove(OS_FAMILY.getName());
         String ssh = (String) machineConfig.remove("ssh");
         String winrm = (String) machineConfig.remove("winrm");
         Map<Integer, String> tcpPortMappings = (Map<Integer, String>) machineConfig.get("tcpPortMappings");
@@ -199,8 +199,8 @@ public class ByonLocationResolver extends AbstractLocationResolver {
         }
         
         Class<? extends MachineLocation> locationClassHere = locationClass;
-        if (osfamily != null) {
-            locationClassHere = getLocationClass(osfamily);
+        if (osFamily != null) {
+            locationClassHere = getLocationClass(osFamily);
         }
 
         return LocationSpec.create(locationClassHere).configure(machineConfig);

--- a/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
@@ -345,7 +345,7 @@ public class ByonLocationResolverTest {
         String spec = "byon";
         Map<String, ?> flags = ImmutableMap.of(
                 "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),
-                "osfamily", osFamily
+                "osFamily", osFamily
         );
         MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
         WinRmMachineLocation location = (WinRmMachineLocation) provisioner.obtain(ImmutableMap.of());
@@ -360,7 +360,7 @@ public class ByonLocationResolverTest {
         String spec = "byon";
         Map<String, ?> flags = ImmutableMap.of(
                 "hosts", ImmutableList.of("1.1.1.1", "2.2.2.2"),
-                "osfamily", "linux"
+                "osFamily", "linux"
         );
         MachineProvisioningLocation<MachineLocation> provisioner = resolve(spec, flags);
         MachineLocation location = provisioner.obtain(ImmutableMap.of());

--- a/docs/guide/ops/locations/index.md
+++ b/docs/guide/ops/locations/index.md
@@ -418,7 +418,7 @@ location:
       privateAddresses: [10.0.0.2]
       password: mypassword
       user: myuser
-      osfamily: windows
+      osFamily: windows
 {% endhighlight %}
 
 The BYON location also supports a machine chooser, using the config key `byon.machineChooser`. 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -116,11 +116,9 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 preInstall();
             }});
 
-            if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.PRE_INSTALL_COMMAND))) {
-                DynamicTasks.queue("pre-install-command", new Runnable() { public void run() {
-                    runPreInstallCommand(entity.getConfig(BrooklynConfigKeys.PRE_INSTALL_COMMAND));
-                }});
-            };
+            DynamicTasks.queue("pre-install-command", new Runnable() { public void run() {
+                runPreInstallCommand();
+            }});
 
             Optional<Boolean> locationInstalled = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
             Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
@@ -142,11 +140,9 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 }});
             }
 
-            if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND))) {
-                DynamicTasks.queue("post-install-command", new Runnable() { public void run() {
-                    runPostInstallCommand(entity.getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND));
-                }});
-            }
+            DynamicTasks.queue("post-install-command", new Runnable() { public void run() {
+                runPostInstallCommand();
+            }});
 
             DynamicTasks.queue("customize", new Runnable() { public void run() {
                 waitForConfigKey(BrooklynConfigKeys.CUSTOMIZE_LATCH);
@@ -158,22 +154,18 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 copyRuntimeResources();
             }});
 
-            if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.PRE_LAUNCH_COMMAND))) {
-                DynamicTasks.queue("pre-launch-command", new Runnable() { public void run() {
-                    runPreLaunchCommand(entity.getConfig(BrooklynConfigKeys.PRE_LAUNCH_COMMAND));
-                }});
-            };
+            DynamicTasks.queue("pre-launch-command", new Runnable() { public void run() {
+                runPreLaunchCommand();
+            }});
 
             DynamicTasks.queue("launch", new Runnable() { public void run() {
                 waitForConfigKey(BrooklynConfigKeys.LAUNCH_LATCH);
                 launch();
             }});
 
-            if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.POST_LAUNCH_COMMAND))) {
-                DynamicTasks.queue("post-launch-command", new Runnable() { public void run() {
-                    runPostLaunchCommand(entity.getConfig(BrooklynConfigKeys.POST_LAUNCH_COMMAND));
-                }});
-            };
+            DynamicTasks.queue("post-launch-command", new Runnable() { public void run() {
+                runPostLaunchCommand();
+            }});
         }
 
         DynamicTasks.queue("post-launch", new Runnable() { public void run() {
@@ -189,14 +181,14 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
      */
     public void preInstall() {}
 
-    public abstract void runPreInstallCommand(String command);
+    public abstract void runPreInstallCommand();
     public abstract void setup();
     public abstract void install();
-    public abstract void runPostInstallCommand(String command);
+    public abstract void runPostInstallCommand();
     public abstract void customize();
-    public abstract void runPreLaunchCommand(String command);
+    public abstract void runPreLaunchCommand();
     public abstract void launch();
-    public abstract void runPostLaunchCommand(String command);
+    public abstract void runPostLaunchCommand();
 
     @Override
     public void kill() {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.core.BrooklynLogging;
 import org.apache.brooklyn.core.effector.EffectorTasks;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
@@ -295,23 +296,31 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     }
 
     @Override
-    public void runPreInstallCommand(String command) {
-        execute(ImmutableList.of(command), "running pre-install commands");
+    public void runPreInstallCommand() {
+        if(Strings.isNonBlank(getEntity().getConfig(VanillaSoftwareProcess.PRE_INSTALL_COMMAND))) {
+            execute(getEntity().getConfig(VanillaSoftwareProcess.PRE_INSTALL_COMMAND), "running pre-install commands");
+        }
     }
 
     @Override
-    public void runPostInstallCommand(String command) {
-        execute(ImmutableList.of(command), "running post-install commands");
+    public void runPostInstallCommand() {
+        if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND))) {
+            execute(ImmutableList.of(entity.getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND)), "running post-install commands");
+        }
     }
 
     @Override
-    public void runPreLaunchCommand(String command) {
-        execute(ImmutableList.of(command), "running pre-launch commands");
+    public void runPreLaunchCommand() {
+        if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.PRE_LAUNCH_COMMAND))) {
+            execute(ImmutableList.of(entity.getConfig(BrooklynConfigKeys.PRE_LAUNCH_COMMAND)), "running pre-launch commands");
+        }
     }
 
     @Override
-    public void runPostLaunchCommand(String command) {
-        execute(ImmutableList.of(command), "running post-launch commands");
+    public void runPostLaunchCommand() {
+        if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.POST_LAUNCH_COMMAND))) {
+            execute(ImmutableList.of(entity.getConfig(BrooklynConfigKeys.POST_LAUNCH_COMMAND)), "running post-launch commands");
+        }
     }
 
     /**

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -18,29 +18,35 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
+import com.google.common.collect.ImmutableList;
+import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.ReferenceWithError;
+import org.apache.brooklyn.util.repeat.Repeater;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+import org.python.core.PyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
-import org.apache.brooklyn.api.sensor.AttributeSensor;
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.sensor.Sensors;
-import org.python.core.PyException;
-import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
-import org.apache.brooklyn.util.exceptions.ReferenceWithError;
-import org.apache.brooklyn.util.repeat.Repeater;
-import org.apache.brooklyn.util.time.Duration;
-
-import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
-
-import com.google.api.client.util.Strings;
-import com.google.common.collect.ImmutableList;
-
 public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwareProcessDriver {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSoftwareProcessDriver.class);
 
     AttributeSensor<String> WINDOWS_USERNAME = Sensors.newStringSensor("windows.username",
             "Default Windows username to be used when connecting to the Entity's VM");
@@ -119,20 +125,53 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     protected WinRmToolResponse executeCommand(ConfigKey<String> regularCommandKey, ConfigKey<String> powershellCommandKey, boolean allowNoOp) {
         String regularCommand = getEntity().getConfig(regularCommandKey);
         String powershellCommand = getEntity().getConfig(powershellCommandKey);
-        if (Strings.isNullOrEmpty(regularCommand) && Strings.isNullOrEmpty(powershellCommand)) {
+        if (Strings.isBlank(regularCommand) && Strings.isBlank(powershellCommand)) {
             if (allowNoOp) {
                 return new WinRmToolResponse("", "", 0);
             } else {
                 throw new IllegalStateException(String.format("Exactly one of %s or %s must be set", regularCommandKey.getName(), powershellCommandKey.getName()));
             }
-        } else if (!Strings.isNullOrEmpty(regularCommand) && !Strings.isNullOrEmpty(powershellCommand)) {
+        } else if (!Strings.isBlank(regularCommand) && !Strings.isBlank(powershellCommand)) {
             throw new IllegalStateException(String.format("%s and %s cannot both be set", regularCommandKey.getName(), powershellCommandKey.getName()));
         }
 
-        if (Strings.isNullOrEmpty(regularCommand)) {
-            return getLocation().executePsScript(ImmutableList.of(powershellCommand));
+        ByteArrayOutputStream stdIn = new ByteArrayOutputStream();
+        ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+        ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+
+        Task<?> currentTask = Tasks.current();
+        if (currentTask != null) {
+            writeToStream(stdIn, Strings.isBlank(regularCommand) ? powershellCommand : regularCommand);
+            Tasks.addTagDynamically(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDIN, stdIn));
+
+            if (BrooklynTaskTags.stream(currentTask, BrooklynTaskTags.STREAM_STDOUT)==null) {
+                Tasks.addTagDynamically(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDOUT, stdOut));
+                Tasks.addTagDynamically(BrooklynTaskTags.tagForStreamSoft(BrooklynTaskTags.STREAM_STDERR, stdErr));
+            }
+        }
+
+        WinRmToolResponse response;
+        if (Strings.isBlank(regularCommand)) {
+            response = getLocation().executePsScript(ImmutableList.of(powershellCommand));
         } else {
-            return getLocation().executeScript(ImmutableList.of(regularCommand));
+            response = getLocation().executeScript(ImmutableList.of(regularCommand));
+        }
+
+        if (currentTask != null) {
+            if (BrooklynTaskTags.stream(currentTask, BrooklynTaskTags.STREAM_STDOUT)==null) {
+                writeToStream(stdOut, response.getStdOut());
+                writeToStream(stdErr, response.getStdErr());
+            }
+        }
+
+        return response;
+    }
+
+    private void writeToStream(ByteArrayOutputStream stream, String string)  {
+        try {
+            stream.write(string.getBytes());
+        } catch (IOException e) {
+            LOG.warn("Problem populating one of the std streams for task of entity " + getEntity(), e);
         }
     }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -24,6 +24,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
@@ -60,8 +61,13 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     }
 
     @Override
-    public void runPreInstallCommand(String command) {
-        execute(ImmutableList.of(command));
+    public void runPreInstallCommand() {
+        if (Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.PRE_INSTALL_COMMAND)) || Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.PRE_INSTALL_POWERSHELL_COMMAND))) {
+            executeCommand(VanillaWindowsProcess.PRE_INSTALL_COMMAND, VanillaWindowsProcess.PRE_INSTALL_POWERSHELL_COMMAND, true);
+        }
+        if (entity.getConfig(VanillaWindowsProcess.PRE_INSTALL_REBOOT_REQUIRED)) {
+            rebootAndWait();
+        }
     }
 
     @Override
@@ -70,18 +76,24 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     }
 
     @Override
-    public void runPostInstallCommand(String command) {
-        execute(ImmutableList.of(command));
+    public void runPostInstallCommand() {
+        if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND)) || Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.POST_INSTALL_POWERSHELL_COMMAND))) {
+            executeCommand(BrooklynConfigKeys.POST_INSTALL_COMMAND, VanillaWindowsProcess.POST_INSTALL_POWERSHELL_COMMAND, true);
+        }
     }
 
     @Override
-    public void runPreLaunchCommand(String command) {
-        execute(ImmutableList.of(command));
+    public void runPreLaunchCommand() {
+        if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.PRE_LAUNCH_COMMAND)) || Strings.isNonBlank(entity.getConfig(VanillaWindowsProcess.PRE_LAUNCH_POWERSHELL_COMMAND))) {
+            executeCommand(BrooklynConfigKeys.PRE_LAUNCH_COMMAND, VanillaWindowsProcess.PRE_LAUNCH_POWERSHELL_COMMAND, true);
+        }
     }
 
     @Override
-    public void runPostLaunchCommand(String command) {
-        execute(ImmutableList.of(command));
+    public void runPostLaunchCommand() {
+        if (Strings.isNonBlank(entity.getConfig(BrooklynConfigKeys.POST_LAUNCH_COMMAND)) || Strings.isNonBlank(entity.getConfig(VanillaWindowsProcess.POST_LAUNCH_POWERSHELL_COMMAND))) {
+            executeCommand(BrooklynConfigKeys.POST_LAUNCH_COMMAND, VanillaWindowsProcess.POST_LAUNCH_POWERSHELL_COMMAND, true);
+        }
     }
 
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -46,7 +46,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwareProcessDriver {
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractSoftwareProcessDriver.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSoftwareProcessWinRmDriver.class);
 
     AttributeSensor<String> WINDOWS_USERNAME = Sensors.newStringSensor("windows.username",
             "Default Windows username to be used when connecting to the Entity's VM");

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
@@ -37,6 +37,12 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
             ImmutableSet.of(5985, 3389));
     ConfigKey<String> PRE_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.powershell.command",
             "powershell command to run during the pre-install phase");
+    ConfigKey<String> POST_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("post.install.powershell.command",
+            "powershell command to run during the post-install phase");
+    ConfigKey<String> PRE_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.launch.powershell.command",
+            "powershell command to run during the pre-launch phase");
+    ConfigKey<String> POST_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("post.launch.powershell.command",
+            "powershell command to run during the post-launch phase");
     ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",
             "indicates that a reboot should be performed after the pre-install command is run", false);
     ConfigKey<Boolean> INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("install.reboot.required",

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinRmDriver.java
@@ -23,6 +23,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.net.UserAndHostAndPort;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,19 +42,13 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
 
         super.start();
     }
-    
-    @Override
-    public void runPreInstallCommand(String preInstallCommand) {
-        executeCommand(VanillaWindowsProcess.PRE_INSTALL_COMMAND, VanillaWindowsProcess.PRE_INSTALL_POWERSHELL_COMMAND, true);
-        if (entity.getConfig(VanillaWindowsProcess.PRE_INSTALL_REBOOT_REQUIRED)) {
-            rebootAndWait();
-        }
-    }
 
     @Override
     public void install() {
         // TODO: Follow install path of VanillaSoftwareProcessSshDriver
-        executeCommand(VanillaWindowsProcess.INSTALL_COMMAND, VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND, true);
+        if(Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.INSTALL_COMMAND)) || Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND))) {
+            executeCommand(VanillaWindowsProcess.INSTALL_COMMAND, VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND, true);
+        }
         if (entity.getConfig(VanillaWindowsProcess.INSTALL_REBOOT_REQUIRED)) {
             rebootAndWait();
         }
@@ -62,7 +57,9 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
     @Override
     public void customize() {
         // TODO: Follow customize path of VanillaSoftwareProcessSshDriver
-        executeCommand(VanillaWindowsProcess.CUSTOMIZE_COMMAND, VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND, true);
+        if(Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.CUSTOMIZE_COMMAND)) || Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND))) {
+            executeCommand(VanillaWindowsProcess.CUSTOMIZE_COMMAND, VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND, true);
+        }
         if (entity.getConfig(VanillaWindowsProcess.CUSTOMIZE_REBOOT_REQUIRED)) {
             rebootAndWait();
         }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessStreamsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessStreamsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.mgmt.HasTaskChildren;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.util.core.task.TaskPredicates;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.brooklyn.util.text.StringPredicates;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.testng.Assert.assertTrue;
+
+public abstract class AbstractSoftwareProcessStreamsTest extends BrooklynAppLiveTestSupport {
+    private static final Logger log = LoggerFactory.getLogger(AbstractSoftwareProcessStreamsTest.class);
+
+    public abstract void testGetsStreams();
+
+    protected abstract Map<String, String> getCommands();
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        if (mgmt!=null) {
+            app = ApplicationBuilder.newManagedApp(TestApplication.class, mgmt);
+        } else {
+            mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+            EntitySpec<TestApplication> appSpec = EntitySpec.create(TestApplication.class)
+                    .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true);
+            app = ApplicationBuilder.newManagedApp(appSpec, mgmt);
+        }
+    }
+
+    protected String getStreamOrFail(Task<?> task, String streamType) {
+        String msg = "task="+task+"; stream="+streamType;
+        BrooklynTaskTags.WrappedStream stream = checkNotNull(BrooklynTaskTags.stream(task, BrooklynTaskTags.STREAM_STDIN), "Stream null: " + msg);
+        return checkNotNull(stream.streamContents.get(), "Contents null: "+msg);
+    }
+
+    protected Optional<Task<?>> findTaskOrSubTask(Iterable<? extends Task<?>> tasks, Predicate<? super Task<?>> matcher) {
+        List<String> taskNames = Lists.newArrayList();
+        Optional<Task<?>> result = findTaskOrSubTaskImpl(tasks, matcher, taskNames);
+        if (!result.isPresent() && log.isDebugEnabled()) {
+            log.debug("Task not found matching "+matcher+"; contender names were "+taskNames);
+        }
+        return result;
+    }
+
+    protected Optional<Task<?>> findTaskOrSubTaskImpl(Iterable<? extends Task<?>> tasks, Predicate<? super Task<?>> matcher, List<String> taskNames) {
+        for (Task<?> task : tasks) {
+            if (matcher.apply(task)) return Optional.<Task<?>>of(task);
+
+            if (!(task instanceof HasTaskChildren)) {
+                return Optional.absent();
+            } else {
+                Optional<Task<?>> subResult = findTaskOrSubTask(((HasTaskChildren) task).getChildren(), matcher);
+                if (subResult.isPresent()) return subResult;
+            }
+        }
+
+        return Optional.<Task<?>>absent();
+    }
+
+    protected <T extends SoftwareProcess> void assertStreams(T softwareProcessEntity) {
+        Set<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(mgmt.getExecutionManager(), softwareProcessEntity);
+
+        for (Map.Entry<String, String> entry : getCommands().entrySet()) {
+            String taskNameRegex = entry.getKey();
+            String echoed = entry.getValue();
+
+            Task<?> subTask = findTaskOrSubTask(tasks, TaskPredicates.displayNameMatches(StringPredicates.matchesRegex(taskNameRegex))).get();
+
+            String stdin = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDIN);
+            String stdout = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDOUT);
+            String stderr = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDERR);
+            String env = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_ENV);
+            String msg = "stdin="+stdin+"; stdout="+stdout+"; stderr="+stderr+"; env="+env;
+
+            assertTrue(stdin.contains("echo "+echoed), msg);
+            assertTrue(stdout.contains(echoed), msg);
+        }
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessStreamsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessStreamsTest.java
@@ -32,15 +32,14 @@ import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.util.core.task.TaskPredicates;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.testng.Assert.assertTrue;

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
@@ -705,16 +705,16 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         }
 
         @Override
-        public void runPreInstallCommand(String command) { }
+        public void runPreInstallCommand() { }
 
         @Override
-        public void runPostInstallCommand(String command) { }
+        public void runPostInstallCommand() { }
 
         @Override
-        public void runPreLaunchCommand(String command) { }
+        public void runPreLaunchCommand() { }
 
         @Override
-        public void runPostLaunchCommand(String command) { }
+        public void runPostLaunchCommand() { }
 
         @Override
         protected String getInstallLabelExtraSalt() {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessAndChildrenIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessAndChildrenIntegrationTest.java
@@ -26,8 +26,6 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.software.base.SoftwareProcess;
-import org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.ChildStartableMode;
 import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.ResourceUtils;

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
@@ -108,8 +108,8 @@ public class VanillaSoftwareProcessStreamsIntegrationTest extends BrooklynAppUni
     protected Optional<Task<?>> findTaskOrSubTask(Iterable<? extends Task<?>> tasks, Predicate<? super Task<?>> matcher) {
         List<String> taskNames = Lists.newArrayList();
         Optional<Task<?>> result = findTaskOrSubTaskImpl(tasks, matcher, taskNames);
-        if (!result.isPresent()) {
-            log.info("Task not found matching "+matcher+"; contender names were "+taskNames);
+        if (!result.isPresent() && log.isDebugEnabled()) {
+            log.debug("Task not found matching "+matcher+"; contender names were "+taskNames);
         }
         return result;
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
@@ -81,19 +81,19 @@ public class VanillaSoftwareProcessStreamsIntegrationTest extends BrooklynAppUni
         app.start(ImmutableList.of(localhost));
 
         Set<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(mgmt.getExecutionManager(), entity);
-        
+
         for (Map.Entry<String, String> entry : cmds.entrySet()) {
             String taskNameRegex = entry.getKey();
             String echoed = entry.getValue();
-            
+
             Task<?> subTask = findTaskOrSubTask(tasks, TaskPredicates.displayNameMatches(StringPredicates.matchesRegex(taskNameRegex))).get();
-            
+
             String stdin = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDIN);
             String stdout = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDOUT);
             String stderr = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDERR);
             String env = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_ENV);
             String msg = "stdin="+stdin+"; stdout="+stdout+"; stderr="+stderr+"; env="+env;
-            
+
             assertTrue(stdin.contains("echo "+echoed), msg);
             assertTrue(stdout.contains(echoed), msg);
         }
@@ -109,15 +109,15 @@ public class VanillaSoftwareProcessStreamsIntegrationTest extends BrooklynAppUni
         List<String> taskNames = Lists.newArrayList();
         Optional<Task<?>> result = findTaskOrSubTaskImpl(tasks, matcher, taskNames);
         if (!result.isPresent() && log.isDebugEnabled()) {
-            log.debug("Task not found matching "+matcher+"; contender names were "+taskNames);
+            log.debug("Task not found matching " + matcher + "; contender names were " + taskNames);
         }
         return result;
     }
-    
+
     protected Optional<Task<?>> findTaskOrSubTaskImpl(Iterable<? extends Task<?>> tasks, Predicate<? super Task<?>> matcher, List<String> taskNames) {
         for (Task<?> task : tasks) {
             if (matcher.apply(task)) return Optional.<Task<?>>of(task);
-        
+
             if (!(task instanceof HasTaskChildren)) {
                 return Optional.absent();
             } else {
@@ -125,7 +125,7 @@ public class VanillaSoftwareProcessStreamsIntegrationTest extends BrooklynAppUni
                 if (subResult.isPresent()) return subResult;
             }
         }
-        
+
         return Optional.<Task<?>>absent();
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmStreamsLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmStreamsLiveTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.util.core.task.TaskPredicates;
+import org.apache.brooklyn.util.text.StringPredicates;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertTrue;
+
+public class VanillaWindowsProcessWinrmStreamsLiveTest extends VanillaSoftwareProcessStreamsIntegrationTest {
+    private Location machine;
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+/*
+        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-2", ImmutableMap.of(
+                "inboundPorts", ImmutableList.of(5985, 3389),
+                "displayName", "AWS Oregon (Windows)",
+                "imageNameRegex", ".*Windows.*2012.*",
+                "hardwareId", "m3.medium",
+                "useJcloudsSshInit", false));
+        machine = (WinRmMachineLocation) loc.obtain();
+                */
+        // ImmutableMap.of supports at most 5 key pairs
+        Map<String, String> config = new HashMap<>();
+        config.put("hosts", "52.13.85.118:5985");
+        config.put("osFamily", "windows");
+        config.put("winrm", "52.13.85.118:5985");
+        config.put("user", "Administrator");
+        config.put("password", "q$p5g3(JSWs");
+        config.put("useJcloudsSshInit", "false");
+        config.put("byonIdentity", "dev12");
+        machine = mgmt.getLocationRegistry().resolve("byon", config);
+    }
+
+    @Test(groups = "Live")
+    public void testGetsStreams() {
+        Map<String, String> cmds = ImmutableMap.<String, String>builder()
+                .put("pre-install-command", "myPreInstall")
+                .put("ssh: installing.*", "myInstall")
+                .put("post-install-command", "myPostInstall")
+                .put("ssh: customizing.*", "myCustomizing")
+                .put("pre-launch-command", "myPreLaunch")
+                .put("ssh: launching.*", "myLaunch")
+                .put("post-launch-command", "myPostLaunch")
+                .build();
+        VanillaWindowsProcess entity = app.createAndManageChild(EntitySpec.create(VanillaWindowsProcess.class)
+                .configure("id", "dev12")
+                .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo " + cmds.get("pre-install-command"))
+                .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo " + cmds.get("ssh: installing.*"))
+                .configure(VanillaSoftwareProcess.POST_INSTALL_COMMAND, "echo " + cmds.get("post-install-command"))
+                .configure(VanillaSoftwareProcess.CUSTOMIZE_COMMAND, "echo " + cmds.get("ssh: customizing.*"))
+                .configure(VanillaSoftwareProcess.PRE_LAUNCH_COMMAND, "echo " + cmds.get("pre-launch-command"))
+                .configure(VanillaSoftwareProcess.LAUNCH_COMMAND, "echo " + cmds.get("ssh: launching.*"))
+                .configure(VanillaSoftwareProcess.POST_LAUNCH_COMMAND, "echo " + cmds.get("post-launch-command"))
+                .configure(VanillaSoftwareProcess.CHECK_RUNNING_COMMAND, "true"));
+//        app.start(ImmutableList.of(machine));
+
+        Set<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(mgmt.getExecutionManager(), entity);
+
+        for (Map.Entry<String, String> entry : cmds.entrySet()) {
+            String taskNameRegex = entry.getKey();
+            String echoed = entry.getValue();
+
+            Task<?> subTask = findTaskOrSubTask(tasks, TaskPredicates.displayNameMatches(StringPredicates.matchesRegex(taskNameRegex))).get();
+
+            String stdin = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDIN);
+            String stdout = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDOUT);
+            String stderr = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDERR);
+            String env = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_ENV);
+            String msg = "stdin="+stdin+"; stdout="+stdout+"; stderr="+stderr+"; env="+env;
+
+            assertTrue(stdin.contains("echo "+echoed), msg);
+            assertTrue(stdout.contains(echoed), msg);
+        }
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmStreamsLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmStreamsLiveTest.java
@@ -46,7 +46,7 @@ public class VanillaWindowsProcessWinrmStreamsLiveTest extends AbstractSoftwareP
                 .put("checkRunning.command", "echo true")
                 .put("useJcloudsSshInit", false)
                 .build();
-        location = ((JcloudsLocation)mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:eu-west-1", config)).obtain();
+        location = ((JcloudsLocation)mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-1", config)).obtain();
     }
 
     @Test(groups = "Live")
@@ -55,9 +55,27 @@ public class VanillaWindowsProcessWinrmStreamsLiveTest extends AbstractSoftwareP
         VanillaWindowsProcess entity = app.createAndManageChild(EntitySpec.create(VanillaWindowsProcess.class)
                 .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo " + getCommands().get("pre-install-command"))
                 .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo " + getCommands().get("^install$"))
+                .configure(VanillaSoftwareProcess.POST_INSTALL_COMMAND, "echo " + getCommands().get("post-install-command"))
                 .configure(VanillaSoftwareProcess.CUSTOMIZE_COMMAND, "echo " + getCommands().get("^customize$"))
+                .configure(VanillaSoftwareProcess.PRE_LAUNCH_COMMAND, "echo " + getCommands().get("pre-launch-command"))
                 .configure(VanillaSoftwareProcess.LAUNCH_COMMAND, "echo " + getCommands().get("^launch$"))
+                .configure(VanillaSoftwareProcess.POST_LAUNCH_COMMAND, "echo " + getCommands().get("post-launch-command"))
                 .configure(VanillaSoftwareProcess.CHECK_RUNNING_COMMAND, "echo true"));
+        app.start(ImmutableList.of(location));
+        assertStreams(entity);
+    }
+
+    @Test(groups = "Live")
+    public void testGetsStreamsPowerShell() {
+        VanillaWindowsProcess entity = app.createAndManageChild(EntitySpec.create(VanillaWindowsProcess.class)
+                .configure(VanillaWindowsProcess.PRE_INSTALL_POWERSHELL_COMMAND, "echo " + getCommands().get("pre-install-command"))
+                .configure(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND, "echo " + getCommands().get("^install$"))
+                .configure(VanillaWindowsProcess.POST_INSTALL_POWERSHELL_COMMAND, "echo " + getCommands().get("post-install-command"))
+                .configure(VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND, "echo " + getCommands().get("^customize$"))
+                .configure(VanillaWindowsProcess.PRE_LAUNCH_POWERSHELL_COMMAND, "echo " + getCommands().get("pre-launch-command"))
+                .configure(VanillaWindowsProcess.LAUNCH_POWERSHELL_COMMAND, "echo " + getCommands().get("^launch$"))
+                .configure(VanillaWindowsProcess.POST_LAUNCH_POWERSHELL_COMMAND, "echo " + getCommands().get("post-launch-command"))
+                .configure(VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND, "echo true"));
         app.start(ImmutableList.of(location));
         assertStreams(entity);
     }
@@ -67,8 +85,11 @@ public class VanillaWindowsProcessWinrmStreamsLiveTest extends AbstractSoftwareP
         return ImmutableMap.<String, String>builder()
                 .put("pre-install-command", "myPreInstall")
                 .put("^install$", "myInstall")
+                .put("post-install-command", "pre install command output")
                 .put("^customize$", "myCustomizing")
+                .put("pre-launch-command", "pre launch command output")
                 .put("^launch$", "myLaunch")
+                .put("post-launch-command", "post launch command output")
                 .build();
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmStreamsLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmStreamsLiveTest.java
@@ -18,92 +18,57 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.api.mgmt.Task;
-import org.apache.brooklyn.core.internal.BrooklynProperties;
-import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
-import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
-import org.apache.brooklyn.util.core.task.TaskPredicates;
-import org.apache.brooklyn.util.text.StringPredicates;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
-import static org.testng.Assert.assertTrue;
-
-public class VanillaWindowsProcessWinrmStreamsLiveTest extends VanillaSoftwareProcessStreamsIntegrationTest {
-    private Location machine;
+public class VanillaWindowsProcessWinrmStreamsLiveTest extends AbstractSoftwareProcessStreamsTest {
+    private Location location;
 
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
-/*
-        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-2", ImmutableMap.of(
-                "inboundPorts", ImmutableList.of(5985, 3389),
-                "displayName", "AWS Oregon (Windows)",
-                "imageNameRegex", ".*Windows.*2012.*",
-                "hardwareId", "m3.medium",
-                "useJcloudsSshInit", false));
-        machine = (WinRmMachineLocation) loc.obtain();
-                */
-        // ImmutableMap.of supports at most 5 key pairs
-        Map<String, String> config = new HashMap<>();
-        config.put("hosts", "52.13.85.118:5985");
-        config.put("osFamily", "windows");
-        config.put("winrm", "52.13.85.118:5985");
-        config.put("user", "Administrator");
-        config.put("password", "q$p5g3(JSWs");
-        config.put("useJcloudsSshInit", "false");
-        config.put("byonIdentity", "dev12");
-        machine = mgmt.getLocationRegistry().resolve("byon", config);
+
+        Map<String, Object> config = ImmutableMap.<String, Object>builder()
+                .put("inboundPorts", ImmutableList.of(5985, 3389))
+                .put("osFamily", "windows")
+                .put("displayName", "AWS Oregon (Windows)")
+                .put("imageOwner", "801119661308")
+                .put("imageNameRegex", "Windows_Server-2012-R2_RTM-English-64Bit-Base-.*")
+                .put("hardwareId", "m3.medium")
+                .put("checkRunning.command", "echo true")
+                .put("useJcloudsSshInit", false)
+                .build();
+        location = ((JcloudsLocation)mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:eu-west-1", config)).obtain();
     }
 
     @Test(groups = "Live")
+    @Override
     public void testGetsStreams() {
-        Map<String, String> cmds = ImmutableMap.<String, String>builder()
-                .put("pre-install-command", "myPreInstall")
-                .put("ssh: installing.*", "myInstall")
-                .put("post-install-command", "myPostInstall")
-                .put("ssh: customizing.*", "myCustomizing")
-                .put("pre-launch-command", "myPreLaunch")
-                .put("ssh: launching.*", "myLaunch")
-                .put("post-launch-command", "myPostLaunch")
-                .build();
         VanillaWindowsProcess entity = app.createAndManageChild(EntitySpec.create(VanillaWindowsProcess.class)
-                .configure("id", "dev12")
-                .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo " + cmds.get("pre-install-command"))
-                .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo " + cmds.get("ssh: installing.*"))
-                .configure(VanillaSoftwareProcess.POST_INSTALL_COMMAND, "echo " + cmds.get("post-install-command"))
-                .configure(VanillaSoftwareProcess.CUSTOMIZE_COMMAND, "echo " + cmds.get("ssh: customizing.*"))
-                .configure(VanillaSoftwareProcess.PRE_LAUNCH_COMMAND, "echo " + cmds.get("pre-launch-command"))
-                .configure(VanillaSoftwareProcess.LAUNCH_COMMAND, "echo " + cmds.get("ssh: launching.*"))
-                .configure(VanillaSoftwareProcess.POST_LAUNCH_COMMAND, "echo " + cmds.get("post-launch-command"))
-                .configure(VanillaSoftwareProcess.CHECK_RUNNING_COMMAND, "true"));
-//        app.start(ImmutableList.of(machine));
+                .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo " + getCommands().get("pre-install-command"))
+                .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo " + getCommands().get("^install$"))
+                .configure(VanillaSoftwareProcess.CUSTOMIZE_COMMAND, "echo " + getCommands().get("^customize$"))
+                .configure(VanillaSoftwareProcess.LAUNCH_COMMAND, "echo " + getCommands().get("^launch$"))
+                .configure(VanillaSoftwareProcess.CHECK_RUNNING_COMMAND, "echo true"));
+        app.start(ImmutableList.of(location));
+        assertStreams(entity);
+    }
 
-        Set<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(mgmt.getExecutionManager(), entity);
-
-        for (Map.Entry<String, String> entry : cmds.entrySet()) {
-            String taskNameRegex = entry.getKey();
-            String echoed = entry.getValue();
-
-            Task<?> subTask = findTaskOrSubTask(tasks, TaskPredicates.displayNameMatches(StringPredicates.matchesRegex(taskNameRegex))).get();
-
-            String stdin = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDIN);
-            String stdout = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDOUT);
-            String stderr = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_STDERR);
-            String env = getStreamOrFail(subTask, BrooklynTaskTags.STREAM_ENV);
-            String msg = "stdin="+stdin+"; stdout="+stdout+"; stderr="+stderr+"; env="+env;
-
-            assertTrue(stdin.contains("echo "+echoed), msg);
-            assertTrue(stdout.contains(echoed), msg);
-        }
+    @Override
+    protected Map<String, String> getCommands() {
+        return ImmutableMap.<String, String>builder()
+                .put("pre-install-command", "myPreInstall")
+                .put("^install$", "myInstall")
+                .put("^customize$", "myCustomizing")
+                .put("^launch$", "myLaunch")
+                .build();
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
@@ -62,12 +62,14 @@ public class WinRmMachineLocationLiveTest {
     @BeforeClass(alwaysRun=true)
     public void setUpClass() throws Exception {
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
-        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-2", ImmutableMap.of(
-                "inboundPorts", ImmutableList.of(5985, 3389),
-                "displayName", "AWS Oregon (Windows)",
-                "imageId", "us-west-2/ami-8fd3f9bf",
-                "hardwareId", "m3.medium",
-                "useJcloudsSshInit", false));
+        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-2", ImmutableMap.<String, Object>builder()
+                .put("inboundPorts", ImmutableList.of(5985, 3389))
+                .put("displayName", "AWS Oregon (Windows)")
+                .put("imageOwner", "801119661308")
+                .put("imageNameRegex", "Windows_Server-2012-R2_RTM-English-64Bit-Base-.*")
+                .put("hardwareId", "m3.medium")
+                .put("useJcloudsSshInit", false)
+                .build());
         machine = (JcloudsWinRmMachineLocation) loc.obtain();
     }
 

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
@@ -109,7 +109,7 @@ public class ByonLocationsYamlTest extends AbstractYamlTest {
                 "      password: mypassword",
                 "      user: myuser",
                 "      mykey: myval",
-                "      osfamily: windows",
+                "      osFamily: windows",
                 "services:",
                 "- serviceType: org.apache.brooklyn.entity.stock.BasicApplication");
         
@@ -146,7 +146,7 @@ public class ByonLocationsYamlTest extends AbstractYamlTest {
                 "      password: mypassword",
                 "      user: myuser",
                 "      mykey: myval3",
-                "      osfamily: windows",
+                "      osFamily: windows",
                 "services:",
                 "- serviceType: org.apache.brooklyn.entity.stock.BasicApplication");
         
@@ -194,7 +194,7 @@ public class ByonLocationsYamlTest extends AbstractYamlTest {
                 "      password: mypassword",
                 "      user: myuser",
                 "      mykey: myval2",
-                "      osfamily: windows",
+                "      osFamily: windows",
                 "services:",
                 "- serviceType: org.apache.brooklyn.entity.stock.BasicApplication");
 


### PR DESCRIPTION
This PR provides stdin, stderr and stdout support to the Windows commands.
Look the commits to see the changes

**Not** ready for review.

It has a Live tests for it and there is an example blueprint for windows byon location which I can remove from the PR if you'd like.

I also changed the config key ByonLocationResolver.OS_FAMILY. Here are my comments on these 
So JcloudsLocationConfig.OS_FAMILY config key is osFamily and for ByonLocationResolver.OS_FAMILY it is osfamily without capital F
I was thinking for fixing it by moving this config key to AbstractLocation. Is it possible that we don't want to include this config to all descendants of AbstractLocation?
