### PR TITLE
Adding timestamp to the template options' name

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
@@ -41,9 +41,15 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
         StringShortener shortener = Strings.shortener().separator("-");
         shortener.append("system", "brooklyn");
         
-        // randId often not necessary, as an 8-char hex identifier is added later (in jclouds? can we override?)
-        // however it can be useful to have this early in the string, to prevent collisions in places where it is abbreviated 
-        shortener.append("randId", Identifiers.makeRandomId(4));
+        /* timeStamp replaces the previously used randId. 
+         * 
+         * timeStamp uses the standard unix timestamp represented as a 8-char hex string.
+         * 
+         * It represents the moment in time when the name is constructed. 
+         * It gives the possibility to search easily for instances, security groups, keypairs, etc
+         * based on timestamp without complicated enumeration        
+         */ 
+        shortener.append("timeStamp", Long.toString(System.currentTimeMillis() / 1000L, 16));
         
         String user = System.getProperty("user.name");
         if (!"brooklyn".equals(user))
@@ -79,7 +85,7 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
                 .canTruncate("user", 4)
                 .canRemove("entity")
                 .canTruncate("context", 4)
-                .canTruncate("randId", 2)
+                .canTruncate("timeStamp", 8)
                 .canRemove("user")
                 .canTruncate("appId", 2)
                 .canRemove("appId");

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
@@ -22,7 +22,6 @@ import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.text.StringShortener;
 import org.apache.brooklyn.util.text.Strings;
 
@@ -49,7 +48,7 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
          * It gives the possibility to search easily for instances, security groups, keypairs, etc
          * based on timestamp without complicated enumeration        
          */ 
-        shortener.append("timeStamp", Long.toString(System.currentTimeMillis() / 1000L, 16));
+        shortener.append("timeStamp", Long.toString(System.currentTimeMillis() / 1000L, Character.MAX_RADIX));
         
         String user = System.getProperty("user.name");
         if (!"brooklyn".equals(user))
@@ -85,7 +84,7 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
                 .canTruncate("user", 4)
                 .canRemove("entity")
                 .canTruncate("context", 4)
-                .canTruncate("timeStamp", 8)
+                .canTruncate("timeStamp", 6)
                 .canRemove("user")
                 .canTruncate("appId", 2)
                 .canRemove("appId");

--- a/core/src/test/java/org/apache/brooklyn/core/location/cloud/CloudMachineNamerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/cloud/CloudMachineNamerTest.java
@@ -113,9 +113,13 @@ public class CloudMachineNamerTest {
         ConfigBag cfg = new ConfigBag()
             .configure(CloudLocationConfig.CALLER_CONTEXT, child);
         BasicCloudMachineNamer namer = new BasicCloudMachineNamer();
-        namer.setDefaultMachineNameMaxLength(10);
+        // name max length is set to 9, because the constructed name will look like "br-ntsb50"
+        // br - 2 chars
+        // dash (-) - 1 char
+        // timeStamp - 6 chars
+        namer.setDefaultMachineNameMaxLength(2 + 1 + 6);
         String result = namer.generateNewMachineUniqueName(cfg);
-        Assert.assertEquals(result.length(), 10);
+        Assert.assertEquals(result.length(), 2 + 1 + 6);
     }
     
     @Test

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamerTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamerTest.java
@@ -42,9 +42,14 @@ public class JcloudsMachineNamerTest {
         // br-<code>-<user>-myco-1234
         Assert.assertTrue(result.length() <= 24-4-1, "result: "+result);
         
-        String user = Strings.maxlen(System.getProperty("user.name"), 2).toLowerCase();
-        // (length 2 will happen if user is brooklyn, to avoid brooklyn-brooklyn at start!)
-        Assert.assertTrue(result.indexOf(user) >= 0);
+        String user = System.getProperty("user.name");
+        String userExt = Strings.maxlen(user, 2).toLowerCase();
+        
+        // Username can be omitted if it is longer than the rules defined in BasicCloudMachineNamer()
+        if (user.length() <= 4) { 
+            // (length 2 will happen if user is brooklyn, to avoid brooklyn-brooklyn at start!)
+            Assert.assertTrue(result.indexOf(userExt) >= 0);
+        }
         Assert.assertTrue(result.indexOf("-myc") >= 0);
     }
     


### PR DESCRIPTION
- timeStamp replaces the previously used randId. 
- timeStamp uses the standard unix timestamp represented
  as a 8-char hex string.
- It represents the moment in time when the name is constructed. 
- It gives the possibility to search easily for instances, security
  groups, keypairs, etc based on timestamp without complicated
  enumeration