### PR TITLE
Small edits to documentation.

### DIFF
--- a/docs/guide/ops/install-on-server.md
+++ b/docs/guide/ops/install-on-server.md
@@ -1,11 +1,11 @@
 ---
 layout: website-normal
-title: Installing Brooklyn
+title: Installing Apache Brooklyn
 ---
 
 {% include fields.md %}
 
-Here we present two *alternatives* to install Brooklyn:
+Here we present two *alternatives* to install Apache Brooklyn:
 
 - [Running the *installation script*](#script)
 - [Manual installation](#manual)
@@ -20,9 +20,9 @@ The script assumes that the server is a recent *RHEL/CentOS 6.x Linux* or *Ubunt
 
 The script will install Java 7 and other required packages if they are not present. 
 You must have root access over [passwordless SSH]({{ site.path.guide }}/ops/locations/ssh-keys.html) 
-to install brooklyn, but the service runs as an ordinary user once installed. 
+to install Brooklyn, but the service runs as an ordinary user once installed. 
 
-To manage the brooklyn service you must also be able to connect to port 8081 remotely.
+To manage the Brooklyn service you must also be able to connect to port 8081 remotely.
 
 Once the above prerequisites are satisfied, you should be able to run successfully:
 {% highlight bash %}
@@ -35,7 +35,7 @@ $ ./brooklyn-install.sh -s -r <your-server-ip>
 ## <a id="manual"></a> Manual Installation
 
 1. [Set up the prerequisites](#prerequisites)
-1. [Download Brooklyn](#download)
+1. [Download Apache Brooklyn](#download)
 1. [Configuring brooklyn.properties](#configuring-properties)
 1. [Configuring default.catalog.bom](#configuring-catalog)
 1. [Test the installation](#confirm)
@@ -43,9 +43,9 @@ $ ./brooklyn-install.sh -s -r <your-server-ip>
 
 ### <a id="prerequisites"></a>Set up the Prerequisites
 
-Before installing Apache Brooklyn, it is recommented to configure the host as follows. 
+Before installing Brooklyn, it is recommended to configure the host as follows. 
 
-* install Java JRE or SDK (version 6 or later)
+* install Java JRE or JDK (version 7 or later)
 * install an [SSH key]({{ site.path.guide }}/ops/locations/ssh-keys.html), if not available
 * enable [passwordless ssh login]({{ site.path.guide }}/ops/locations/ssh-keys.html)
 * create a `~/.brooklyn` directory on the host with `$ mkdir ~/.brooklyn`
@@ -53,7 +53,7 @@ Before installing Apache Brooklyn, it is recommented to configure the host as fo
 * check that the [linux kernel entropy]({{ site.path.website }}/documentation/increase-entropy.html) is sufficient
 
 
-### <a id="download"></a>Download Brooklyn
+### <a id="download"></a>Download Apache Brooklyn
 
 Download Brooklyn and obtain a binary build as described on [the download page]({{site.path.website}}/download/).
 
@@ -65,20 +65,20 @@ Expand the `tar.gz` archive:
 
 {% if brooklyn_version contains 'SNAPSHOT' %}
 {% highlight bash %}
-$ tar -zxf brooklyn-dist-{{ site.brooklyn-stable-version }}-timestamp-dist.tar.gz
+$ tar -zxf apache-brooklyn-dist-{{ site.brooklyn-stable-version }}-timestamp-dist.tar.gz
 {% endhighlight %}
 {% else %}
 {% highlight bash %}
-$ tar -zxf brooklyn-{{ site.brooklyn-stable-version }}-dist.tar.gz
+$ tar -zxf apache-brooklyn-{{ site.brooklyn-stable-version }}-dist.tar.gz
 {% endhighlight %}
 {% endif %}
 
-This will create a `brooklyn-{{ site.brooklyn-stable-version }}` folder.
+This will create a `apache-brooklyn-{{ site.brooklyn-stable-version }}` folder.
 
 Let's setup some paths for easy commands.
 
 {% highlight bash %}
-$ cd brooklyn-{{ site.brooklyn-stable-version }}
+$ cd apache-brooklyn-{{ site.brooklyn-stable-version }}
 $ BROOKLYN_DIR="$(pwd)"
 $ export PATH=$PATH:$BROOKLYN_DIR/bin/
 {% endhighlight %}

--- a/docs/guide/start/policies.md
+++ b/docs/guide/start/policies.md
@@ -6,7 +6,7 @@ layout: website-normal
 
 ### Exploring and Testing Policies
 
-The Demo Web Cluster with DB application is pre-configured with two polices.
+The Demo Web Cluster with DB application is pre-configured with two policies.
 
 The app server cluster has an `AutoScalerPolicy`, and the loadbalancer has a `targets` policy.
 
@@ -23,7 +23,7 @@ The loadbalancer's `targets` policy ensures that the loadbalancer is updated as 
 
 Sitting idle, this cluster will only contain one server, but you can use a tool like [jmeter](http://jmeter.apache.org/) pointed at the nginx endpoint to create load on the cluster. (Download a [jmeter test plan](https://github.com/apache/incubator-brooklyn/blob/master/examples/simple-web-cluster/resources/jmeter-test-plan.jmx).)
 
-As load is added, Brooklyn requests a new cloud machine, creates a new app server, and adds it to the cluster. As load is removed, servers are removed from the cluster, and the infrastructure is handed back to the cloud.
+As load is added, Apache Brooklyn requests a new cloud machine, creates a new app server, and adds it to the cluster. As load is removed, servers are removed from the cluster, and the infrastructure is handed back to the cloud.
 
 
 ### Under the Covers

--- a/docs/guide/start/running.md
+++ b/docs/guide/start/running.md
@@ -1,17 +1,17 @@
 ---
-title: Running Brooklyn
-title_in_menu: Running Brooklyn
+title: Running Apache Brooklyn
+title_in_menu: Running Apache Brooklyn
 layout: website-normal
 menu_parent: index.md
 ---
 
 This guide will walk you through deploying an example 3-tier web application to a public cloud. 
 
-This tutorial assumes that you are using Linux or Mac OSX.
+This tutorial assumes that you are using Linux or Mac OS X.
 
-## Install Brooklyn
+## Install Apache Brooklyn
 
-Download Brooklyn and obtain a binary build as described on [the download page]({{site.path.website}}/download/).
+Download Apache Brooklyn and obtain a binary build as described on [the download page]({{site.path.website}}/download/).
 
 {% if brooklyn_version contains 'SNAPSHOT' %}
 Expand the `tar.gz` archive (note: as this is a -SNAPSHOT version, your filename will be slightly different):
@@ -21,15 +21,15 @@ Expand the `tar.gz` archive:
 
 {% if brooklyn_version contains 'SNAPSHOT' %}
 {% highlight bash %}
-$ tar -zxf brooklyn-dist-{{ site.brooklyn-version }}-timestamp-dist.tar.gz
+$ tar -zxf apache-brooklyn-dist-{{ site.brooklyn-version }}-timestamp-dist.tar.gz
 {% endhighlight %}
 {% else %}
 {% highlight bash %}
-$ tar -zxf brooklyn-{{ site.brooklyn-version }}-dist.tar.gz
+$ tar -zxf apache-brooklyn-{{ site.brooklyn-version }}-dist.tar.gz
 {% endhighlight %}
 {% endif %}
 
-This will create a `brooklyn-{{ site.brooklyn-version }}` folder.
+This will create a `apache-brooklyn-{{ site.brooklyn-version }}` folder.
 
 **Note**: You'll need a Java JRE or SDK installed (version 1.7 or later), as Brooklyn is Java under the covers.
 
@@ -37,12 +37,12 @@ This will create a `brooklyn-{{ site.brooklyn-version }}` folder.
 to ensure that your Brooklyn can access your machine.
 
 
-## Launch Brooklyn
+## Launch Apache Brooklyn
 
 Now start Brooklyn with the following command:
 
 {% highlight bash %}
-$ cd brooklyn-{{ site.brooklyn.version }}
+$ cd apache-brooklyn-{{ site.brooklyn.version }}
 $ bin/brooklyn launch
 {% endhighlight %}
 


### PR DESCRIPTION
Correct archive name and path for installation. Fix typos.
Bump Java version to 1.7 in install-on-server.md.
Change Brooklyn to Apache Brooklyn in headings and first occurence in the body text.