### PR TITLE
Fix for BROOKLYN-169 - CreateUserPolicy always resets the password

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
@@ -87,6 +87,12 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
             "createuser.vm.user.credentials",
             "The \"<user> : <password> @ <hostname>:<port>\"");
 
+    @SetFromFlag("resetLoginUser")
+    public static final ConfigKey<Boolean> RESET_LOGIN_USER = ConfigKeys.newBooleanConfigKey(
+            "createuser.vm.user.resetLoginUser",
+            "Whether to reset the password used for user login",
+            false);
+
     public void setEntity(EntityLocal entity) {
         super.setEntity(entity);
         subscribe(entity, AbstractEntity.LOCATION_ADDED, this);
@@ -110,6 +116,7 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
     
     protected void addUser(Entity entity, SshMachineLocation machine) {
         boolean grantSudo = getRequiredConfig(GRANT_SUDO);
+        boolean resetPassword = getRequiredConfig(RESET_LOGIN_USER);
         String user = getRequiredConfig(VM_USERNAME);
         String password = Identifiers.makeRandomId(12);
         String hostname = machine.getAddress().getHostName();
@@ -125,7 +132,7 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
                 .adminUsername(user)
                 .adminPassword(password)
                 .grantSudoToAdminUser(false)
-                .resetLoginPassword(true)
+                .resetLoginPassword(resetPassword)
                 .loginPassword(password)
                 .authorizeAdminPublicKey(false)
                 .adminPublicKey("ignored")

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyLiveTest.java
@@ -73,6 +73,7 @@ public class CreateUserPolicyLiveTest extends BrooklynAppLiveTestSupport {
             app.createAndManageChild(EntitySpec.create(TestEntity.class)
                     .policy(PolicySpec.create(CreateUserPolicy.class)
                             .configure(CreateUserPolicy.GRANT_SUDO, true)
+                            .configure(CreateUserPolicy.RESET_LOGIN_USER, true)
                             .configure(CreateUserPolicy.VM_USERNAME, newUsername)));
             TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyLiveTest.java
@@ -73,7 +73,6 @@ public class CreateUserPolicyLiveTest extends BrooklynAppLiveTestSupport {
             app.createAndManageChild(EntitySpec.create(TestEntity.class)
                     .policy(PolicySpec.create(CreateUserPolicy.class)
                             .configure(CreateUserPolicy.GRANT_SUDO, true)
-                            .configure(CreateUserPolicy.RESET_LOGIN_USER, true)
                             .configure(CreateUserPolicy.VM_USERNAME, newUsername)));
             TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyTest.java
@@ -107,6 +107,7 @@ public class CreateUserPolicyTest extends BrooklynAppUnitTestSupport {
         app.createAndManageChild(EntitySpec.create(TestEntity.class)
                 .policy(PolicySpec.create(CreateUserPolicy.class)
                         .configure(CreateUserPolicy.GRANT_SUDO, true)
+                        .configure(CreateUserPolicy.RESET_LOGIN_USER, false)
                         .configure(CreateUserPolicy.VM_USERNAME, newUsername)));
         TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
         app.start(ImmutableList.of(machine));


### PR DESCRIPTION
- Added parameter (BYON_USER_RESET_PASSWORD)
- BYON_USER_RESET_PASSWORD controls when password to be reset
- Whether to reset the password of the BYON login user in case it is
  used to create a new one, e.g. via a custom security policy such as
  org.apache.brooklyn.policy.jclouds.os.CreateUserPolicy"