### PR TITLE
Fix bug preventing ExternalConfigSupplier instantiation

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
@@ -103,7 +103,7 @@ public class BasicExternalConfigSupplierRegistry implements ExternalConfigSuppli
             try {
                 Class<? extends ExternalConfigSupplier> providerClass = (Class<? extends ExternalConfigSupplier>) classloader.loadClass(providerClassname);
                 Constructor<? extends ExternalConfigSupplier> constructor = providerClass.getConstructor(ManagementContext.class, String.class, Map.class);
-                ExternalConfigSupplier configSupplier = constructor.newInstance(this, name, config);
+                ExternalConfigSupplier configSupplier = constructor.newInstance(mgmt, name, config);
                 addProvider(name, configSupplier);
 
             } catch (Exception e) {


### PR DESCRIPTION
ExternalConfigSupplierRegistry was passing a wrong parameter when reflectively invoking the supplier's constructor. "My kingdon for a unit test!"