### PR TITLE
Misc fixes working with plans

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -21,6 +21,8 @@ package org.apache.brooklyn.api.catalog;
 import java.util.Collection;
 import java.util.NoSuchElementException;
 
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
+
 import com.google.common.base.Predicate;
 
 public interface BrooklynCatalog {
@@ -76,7 +78,7 @@ public interface BrooklynCatalog {
 
     /** creates a spec for the given catalog item, throwing exceptions if any problems */
     // TODO this should be cached on the item and renamed getSpec(...), else we re-create it too often (every time catalog is listed)
-    <T,SpecT> SpecT createSpec(CatalogItem<T,SpecT> item);
+    <T, SpecT extends AbstractBrooklynObjectSpec<? extends T, SpecT>> SpecT createSpec(CatalogItem<T, SpecT> item);
     
     /** throws exceptions if any problems 
      * @deprecated since 0.7.0 use {@link #createSpec(CatalogItem)} */

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -208,6 +208,9 @@ public class CatalogInitialization implements ManagementContextInjectable {
                     // once up and running the typical way to add items is via the REST API
                     hasRunFinalInitialization = true;
                 }
+            } catch (Throwable e) {
+                log.warn("Error populating catalog (rethrowing): "+e, e);
+                throw Exceptions.propagate(e);
             } finally {
                 if (!hasRunFinalInitialization) {
                     hasRunTransientOfficialInitialization = true;

--- a/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
@@ -22,8 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
@@ -31,6 +29,8 @@ import org.apache.brooklyn.api.location.LocationResolver;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Given a location spec in the form {@code brooklyn.catalog:<symbolicName>:<version>}, 
@@ -38,7 +38,6 @@ import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
  */
 public class CatalogLocationResolver implements LocationResolver {
 
-    @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(CatalogLocationResolver.class);
 
     public static final String NAME = "brooklyn.catalog";
@@ -61,8 +60,8 @@ public class CatalogLocationResolver implements LocationResolver {
             log.warn("Use of deprecated catalog item "+item.getSymbolicName()+":"+item.getVersion());
         }
         
-        LocationSpec<?> origLocSpec = managementContext.getCatalog().createSpec((CatalogItem<Location, LocationSpec<?>>)item);
-        LocationSpec<?> locSpec = LocationSpec.create(origLocSpec)
+        LocationSpec origLocSpec = (LocationSpec) managementContext.getCatalog().createSpec((CatalogItem)item);
+        LocationSpec locSpec = LocationSpec.create(origLocSpec)
                 .configure(locationFlags);
         return managementContext.getLocationManager().createLocation(locSpec);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -96,12 +96,11 @@ public class EntityManagementUtils {
         }).get();
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static AbstractBrooklynObjectSpec<?, ?> createCatalogSpec(ManagementContext mgmt, final CatalogItem<?, ?> item) {
-        return PlanToSpecFactory.attemptWithLoaders(mgmt, new Function<PlanToSpecTransformer, AbstractBrooklynObjectSpec<?, ?>>() {
+    public static <T,SpecT extends AbstractBrooklynObjectSpec<? extends T, SpecT>> SpecT createCatalogSpec(ManagementContext mgmt, final CatalogItem<T, SpecT> item) {
+        return PlanToSpecFactory.attemptWithLoaders(mgmt, new Function<PlanToSpecTransformer, SpecT>() {
             @Override
-            public AbstractBrooklynObjectSpec<?, ?> apply(PlanToSpecTransformer input) {
-                return input.createCatalogSpec((CatalogItem)item);
+            public SpecT apply(PlanToSpecTransformer input) {
+                return input.createCatalogSpec(item);
             }
         }).get();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/plan/PlanToSpecFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/plan/PlanToSpecFactory.java
@@ -95,11 +95,16 @@ public class PlanToSpecFactory {
         Collection<Exception> otherProblemsFromTransformers = new ArrayList<Exception>();
         for (PlanToSpecTransformer t: transformers) {
             try {
-                return Maybe.of(f.apply(t));
+                T result = f.apply(t);
+                if (result==null) {
+                    transformersWhoDontSupport.add(t.getShortDescription() + " (returned null)");
+                    continue;
+                }
+                return Maybe.of(result);
             } catch (PlanNotRecognizedException e) {
                 transformersWhoDontSupport.add(t.getShortDescription() +
                     (Strings.isNonBlank(e.getMessage()) ? " ("+e.getMessage()+")" : ""));
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 Exceptions.propagateIfFatal(e);
                 otherProblemsFromTransformers.add(new IllegalArgumentException("Transformer for "+t.getShortDescription()+" gave an error creating this plan: "+
                     Exceptions.collapseText(e), e));

--- a/core/src/main/java/org/apache/brooklyn/core/plan/PlanToSpecTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/plan/PlanToSpecTransformer.java
@@ -56,6 +56,6 @@ public interface PlanToSpecTransformer extends ManagementContextInjectable {
      * implementations will typically look at the {@link CatalogItem#getCatalogItemType()} first.
      * <p>
      * should throw {@link PlanNotRecognizedException} if this transformer does not know what to do with the plan. */
-    <T,SpecT extends AbstractBrooklynObjectSpec<T, SpecT>> AbstractBrooklynObjectSpec<T, SpecT> createCatalogSpec(CatalogItem<T, SpecT> item) throws PlanNotRecognizedException;
+    <T,SpecT extends AbstractBrooklynObjectSpec<? extends T, SpecT>> SpecT createCatalogSpec(CatalogItem<T, SpecT> item) throws PlanNotRecognizedException;
     
 }

--- a/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformer.java
+++ b/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformer.java
@@ -72,15 +72,15 @@ public class XmlPlanToSpecTransformer implements PlanToSpecTransformer {
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({ "unchecked" })
     @Override
-    public <T, SpecT extends AbstractBrooklynObjectSpec<T, SpecT>> AbstractBrooklynObjectSpec<T, SpecT> createCatalogSpec(CatalogItem<T, SpecT> item) {
+    public <T, SpecT extends AbstractBrooklynObjectSpec<? extends T, SpecT>> SpecT createCatalogSpec(CatalogItem<T, SpecT> item) {
         if (item.getPlanYaml()==null) throw new PlanNotRecognizedException("Plan is null");
         if (item.getCatalogItemType()==CatalogItemType.ENTITY) {
-            return (EntitySpec)toEntitySpec(parseXml(item.getPlanYaml()), 1);
+            return (SpecT)toEntitySpec(parseXml(item.getPlanYaml()), 1);
         }
         if (item.getCatalogItemType()==CatalogItemType.TEMPLATE) {
-            return (EntitySpec)toEntitySpec(parseXml(item.getPlanYaml()), 0);
+            return (SpecT)toEntitySpec(parseXml(item.getPlanYaml()), 0);
         }
         throw new PlanNotRecognizedException("Type "+item.getCatalogItemType()+" not supported");
     }

--- a/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
+++ b/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
@@ -109,10 +109,10 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
             String policyType = decoLoader.getTypeName().get();
             ManagementContext mgmt = instantiator.loader.getManagementContext();
             BrooklynCatalog catalog = mgmt.getCatalog();
-            CatalogItem<?, ?> item = getPolicyCatalogItem(catalog, policyType);
+            CatalogItem<Policy, PolicySpec<?>> item = getPolicyCatalogItem(catalog, policyType);
             PolicySpec<? extends Policy> spec;
             if (item != null) {
-                spec = (PolicySpec<? extends Policy>) catalog.createSpec(item);
+                spec = (PolicySpec) catalog.createSpec((CatalogItem) item);
                 spec.configure(decoLoader.getConfigMap());
             } else {
                 // this pattern of creating a spec could be simplified with a "Configurable" superinterface on *Spec  
@@ -121,13 +121,14 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
             }
             decorations.add(spec);
         }
-        private CatalogItem<?, ?> getPolicyCatalogItem(BrooklynCatalog catalog, String policyType) {
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        private CatalogItem<Policy, PolicySpec<?>> getPolicyCatalogItem(BrooklynCatalog catalog, String policyType) {
             if (CatalogUtils.looksLikeVersionedId(policyType)) {
                 String id = CatalogUtils.getIdFromVersionedId(policyType);
                 String version = CatalogUtils.getVersionFromVersionedId(policyType);
-                return catalog.getCatalogItem(id, version);
+                return (CatalogItem) catalog.getCatalogItem(id, version);
             } else {
-                return catalog.getCatalogItem(policyType, BrooklynCatalog.DEFAULT_VERSION);
+                return (CatalogItem) catalog.getCatalogItem(policyType, BrooklynCatalog.DEFAULT_VERSION);
             }
         }
     }

--- a/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityMatcher.java
+++ b/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityMatcher.java
@@ -64,6 +64,7 @@ public class BrooklynEntityMatcher implements PdpMatcher {
             Service service = (Service)deploymentPlanItem;
 
             String serviceType = service.getServiceType();
+            if (serviceType==null) throw new NullPointerException("Service must declare a type ("+service+")");
             BrooklynClassLoadingContext loader = BasicBrooklynCatalog.BrooklynLoaderTracker.getLoader();
             if (loader == null) loader = JavaBrooklynClassLoadingContext.create(mgmt);
             if (BrooklynComponentTemplateResolver.Factory.supportsType(loader, serviceType))

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
@@ -238,7 +238,8 @@ public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest {
         BrooklynCatalog catalog = mgmt().getCatalog();
         Iterable<CatalogItem<Object, Object>> items = catalog.getCatalogItems();
         for (CatalogItem<Object, Object> item: items) {
-            Object spec = catalog.createSpec(item);
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Object spec = catalog.createSpec((CatalogItem)item);
             switch (item.getCatalogItemType()) {
                 case TEMPLATE:
                 case ENTITY:

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -525,7 +525,8 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
         addCatalogOSGiEntity(id);
         BrooklynCatalog catalog = mgmt().getCatalog();
         CatalogItem<?, ?> item = catalog.getCatalogItem(id, TEST_VERSION);
-        Object spec = catalog.createSpec(item);
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        Object spec = catalog.createSpec((CatalogItem) item);
         Assert.assertNotNull(spec);
     }
     

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
@@ -105,8 +105,9 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
         assertEquals(Iterables.getOnlyElement(libs).getUrl(), Iterables.getOnlyElement(getOsgiLibraries()));
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void assertAdded(String symbolicName, String expectedJavaType) {
-        CatalogItem<?, ?> item = mgmt().getCatalog().getCatalogItem(symbolicName, TEST_VERSION);
+        CatalogItem item = mgmt().getCatalog().getCatalogItem(symbolicName, TEST_VERSION);
         assertEquals(item.getSymbolicName(), symbolicName);
         assertEquals(countCatalogLocations(), 1);
 
@@ -115,7 +116,7 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
         assertEquals(def.getId(), symbolicName);
         assertEquals(def.getName(), symbolicName);
         
-        LocationSpec<?> spec = (LocationSpec<?>)mgmt().getCatalog().createSpec(item);
+        LocationSpec spec = (LocationSpec) mgmt().getCatalog().createSpec(item);
         assertEquals(spec.getType().getName(), expectedJavaType);
     }
     

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/test/lite/CampYamlLiteTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/test/lite/CampYamlLiteTest.java
@@ -168,7 +168,8 @@ public class CampYamlLiteTest {
         Assert.assertEquals(bundle.getUrl(), OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL);
         Assert.assertEquals(bundle.getVersion(), "0.1.0");
 
-        EntitySpec<?> spec1 = (EntitySpec<?>) mgmt.getCatalog().createSpec(retrievedItem);
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        EntitySpec<?> spec1 = (EntitySpec<?>) mgmt.getCatalog().createSpec((CatalogItem)retrievedItem);
         assertNotNull(spec1);
         Assert.assertEquals(spec1.getConfig().get(TestEntity.CONF_NAME), "sample");
         

--- a/usage/cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/usage/cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -631,7 +631,8 @@ public class Main extends AbstractMain {
                         // and additionally they might contain multiple items in which case
                         // the validation below won't work anyway (you need to go via a deployment plan)
                     } else {
-                        Object spec = catalog.createSpec(item);
+                        @SuppressWarnings({ "unchecked", "rawtypes" })
+                        Object spec = catalog.createSpec((CatalogItem)item);
                         if (spec instanceof EntitySpec) {
                             BrooklynTypes.getDefinedEntityType(((EntitySpec<?>)spec).getType());
                         }

--- a/usage/jsgui/src/main/webapp/assets/css/base.css
+++ b/usage/jsgui/src/main/webapp/assets/css/base.css
@@ -1165,6 +1165,9 @@ tr.app-add-wizard-config-entry {
     padding: 7px;
     border-radius: 3px;
 }
+.catalog-error-message {
+    white-space: pre-wrap;
+}
 
 .float-right {
     float: right;

--- a/usage/jsgui/src/main/webapp/assets/js/model/server-extended-status.js
+++ b/usage/jsgui/src/main/webapp/assets/js/model/server-extended-status.js
@@ -58,7 +58,7 @@ define(["backbone", "brooklyn", "view/viewutils"], function (Backbone, Brooklyn,
             var that = this;
             // to debug:
 //            serverExtendedStatus.onLoad(function() { log("loaded server status:"); log(that.attributes); })
-            ViewUtils.fetchModelRepeatedlyWithDelay(this, { doitnow: true });
+            ViewUtils.fetchModelRepeatedlyWithDelay(this, { doitnow: true, backoffMaxPeriod: 3000 });
         },
 
         isUp: function() { return this.get("up") },

--- a/usage/jsgui/src/main/webapp/assets/js/view/catalog.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/catalog.js
@@ -210,7 +210,7 @@ define([
                         self.$(".catalog-save-error")
                             .removeClass("hide")
                             .find(".catalog-error-message")
-                            .html(Brooklyn.util.extractError(xhr, "Error adding catalog item: " + error));
+                            .html(_.escape(Brooklyn.util.extractError(xhr, "Could not add catalog item:\n'n" + error)));
                     });
             }
         });

--- a/usage/jsgui/src/main/webapp/assets/tpl/catalog/add-location.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/catalog/add-location.html
@@ -30,8 +30,7 @@ under the License.
 
     <p class="catalog-save-error hide">
         <span class="alert-error">
-            <strong>Error:</strong><br/>
-            <span class="catalog-error-message"></span>
+            <span class="catalog-error-message"><strong>Error</strong></span>
         </span>
     </p>
 </form>

--- a/usage/jsgui/src/main/webapp/assets/tpl/catalog/add-yaml.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/catalog/add-yaml.html
@@ -23,8 +23,7 @@ under the License.
     <button class='catalog-submit-button btn' data-loading-text='Saving...'>Submit</button>
     <p class="catalog-save-error hide">
         <span class="alert-error">
-            <strong>Error:</strong><br/>
-            <span class="catalog-error-message"></span>
+            <span class="catalog-error-message"><strong>Error</strong></span>
         </span>
     </p>
 </form>

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -243,7 +243,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        CatalogItem<? extends Entity,EntitySpec<?>> result =
+        CatalogItem<Entity,EntitySpec<?>> result =
                 CatalogUtils.getCatalogItemOptionalVersion(mgmt(), Entity.class, entityId);
 
         if (result==null) {
@@ -263,8 +263,8 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         //TODO These casts are not pretty, we could just provide separate get methods for the different types?
         //Or we could provide asEntity/asPolicy cast methods on the CataloItem doing a safety check internally
         @SuppressWarnings("unchecked")
-        CatalogItem<? extends Entity, EntitySpec<?>> result =
-              (CatalogItem<? extends Entity, EntitySpec<?>>) brooklyn().getCatalog().getCatalogItem(symbolicName, version);
+        CatalogItem<Entity, EntitySpec<?>> result =
+              (CatalogItem<Entity, EntitySpec<?>>) brooklyn().getCatalog().getCatalogItem(symbolicName, version);
 
         if (result==null) {
             throw WebResourceUtils.notFound("Entity with id '%s:%s' not found", symbolicName, version);

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -58,13 +58,13 @@ public class CatalogTransformer {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(CatalogTransformer.class);
     
-    public static CatalogEntitySummary catalogEntitySummary(BrooklynRestResourceUtils b, CatalogItem<? extends Entity,EntitySpec<?>> item) {
+    public static <T extends Entity> CatalogEntitySummary catalogEntitySummary(BrooklynRestResourceUtils b, CatalogItem<T,EntitySpec<? extends T>> item) {
         Set<EntityConfigSummary> config = Sets.newTreeSet(SummaryComparators.nameComparator());
         Set<SensorSummary> sensors = Sets.newTreeSet(SummaryComparators.nameComparator());
         Set<EffectorSummary> effectors = Sets.newTreeSet(SummaryComparators.nameComparator());
 
         try {
-            EntitySpec<?> spec = b.getCatalog().createSpec(item);
+            EntitySpec<?> spec = (EntitySpec<?>) b.getCatalog().createSpec((CatalogItem) item);
             EntityDynamicType typeMap = BrooklynTypes.getDefinedEntityType(spec.getType());
             EntityType type = typeMap.getSnapshot();
 
@@ -94,17 +94,17 @@ public class CatalogTransformer {
             item.isDeprecated(), makeLinks(item));
     }
 
-    @SuppressWarnings("unchecked")
-    public static CatalogItemSummary catalogItemSummary(BrooklynRestResourceUtils b, CatalogItem<?,?> item) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static CatalogItemSummary catalogItemSummary(BrooklynRestResourceUtils b, CatalogItem item) {
         try {
             switch (item.getCatalogItemType()) {
             case TEMPLATE:
             case ENTITY:
-                return catalogEntitySummary(b, (CatalogItem<? extends Entity, EntitySpec<?>>) item);
+                return catalogEntitySummary(b, item);
             case POLICY:
-                return catalogPolicySummary(b, (CatalogItem<? extends Policy, PolicySpec<?>>) item);
+                return catalogPolicySummary(b, item);
             case LOCATION:
-                return catalogLocationSummary(b, (CatalogItem<? extends Location, LocationSpec<?>>) item);
+                return catalogLocationSummary(b, item);
             default:
                 log.warn("Unexpected catalog item type when getting self link (supplying generic item): "+item.getCatalogItemType()+" "+item);
             }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/Exceptions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/Exceptions.java
@@ -64,12 +64,13 @@ public class Exceptions {
     private static List<Class<? extends Throwable>> BORING_PREFIX_THROWABLE_EXACT_TYPES = ImmutableList.<Class<? extends Throwable>>of(
         IllegalStateException.class, RuntimeException.class, CompoundRuntimeException.class);
 
-    /** Returns whether this is throwable either known to be boring or to have an unuseful prefix;
-     * null is *not* boring. */
+    /** Returns whether this is throwable either known to be boring or to have an unhelpful type name (prefix)
+     * which should be suppressed. null is accepted but treated as not boring. */
     public static boolean isPrefixBoring(Throwable t) {
         if (t==null) return false;
         if (isBoring(t))
             return true;
+        if (t instanceof UserFacingException) return true;
         for (Class<? extends Throwable> type: BORING_PREFIX_THROWABLE_EXACT_TYPES)
             if (t.getClass().equals(type)) return true;
         return false;

--- a/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/UserFacingException.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/UserFacingException.java
@@ -19,7 +19,7 @@
 package org.apache.brooklyn.util.exceptions;
 
 /** marker interface, to show that an exception is suitable for pretty-printing to an end-user,
- * without including a stack trace */
+ * without the prefix (type) including a stack trace */
 public class UserFacingException extends RuntimeException {
 
     private static final long serialVersionUID = 2216885527195571323L;

--- a/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
@@ -202,7 +202,8 @@ public class Os {
     }
 
     /** merges paths using forward slash as the "local OS file separator", because it is recognised on windows,
-     * making paths more consistent and avoiding problems with backslashes being escaped */
+     * making paths more consistent and avoiding problems with backslashes being escaped.
+     * empty segments are omitted. */
     public static String mergePaths(String ...items) {
         char separatorChar = '/';
         StringBuilder result = new StringBuilder();

--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.util.text.Strings;
+
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -138,7 +140,7 @@ public class Duration implements Comparable<Duration>, Serializable {
      * also accepts "forever" (and for those who prefer things exceedingly accurate, "practically_forever"). 
      * Also see {@link #of(Object)}. */
     public static Duration parse(String textualDescription) {
-        if (textualDescription==null) return null;
+        if (Strings.isBlank(textualDescription)) return null;
         if ("null".equalsIgnoreCase(textualDescription)) return null;
         
         if ("forever".equalsIgnoreCase(textualDescription)) return Duration.PRACTICALLY_FOREVER;

--- a/utils/common/src/test/java/org/apache/brooklyn/util/time/TimeTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/time/TimeTest.java
@@ -152,7 +152,13 @@ public class TimeTest {
         Assert.assertFalse(Time.hasElapsedSince(aFewSecondsAgo, Duration.TEN_SECONDS));
         Assert.assertTrue(Time.hasElapsedSince(-1, Duration.TEN_SECONDS));
     }
-    
+
+    @Test
+    public void testParseTime() {
+        Assert.assertEquals(Time.parseElapsedTime("1s"), 1000);
+        Assert.assertEquals(Time.parseElapsedTime("never"), -1);
+    }
+
     @Test
     public void testMakeDateString() {
         String in1 = "2015-06-15T12:34:56";


### PR DESCRIPTION
Change CAMP parsing so it can load items which use other transformers.  Previously it assumed referenced types were either java or yaml; now it uses the plan transformer extensions.  Messier than I had thought so please review commits.

Misc other tidies including errors and generics, as described in commits.