### PR TITLE
Config constraints

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/Entity.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/Entity.java
@@ -265,7 +265,7 @@ public interface Entity extends BrooklynObject {
      * @deprecated since 0.9.0; see {@link PolicySupport#add(PolicySpec)}
      */
     @Deprecated
-    <T extends Policy> T addPolicy(PolicySpec<T> enricher);
+    <T extends Policy> T addPolicy(PolicySpec<T> policy);
     
     /**
      * Removes the given policy from this entity. 

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -112,6 +112,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         public Builder<T> inheritance(ConfigInheritance val) {
             this.inheritance = val; return this;
         }
+        @Beta
         public Builder<T> constraint(Predicate<? super T> constraint) {
             this.constraint = checkNotNull(constraint, "constraint"); return this;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.config;
+
+import java.util.List;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+public class ConfigConstraints {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ConfigConstraints.class);
+    private final Entity entity;
+
+    public ConfigConstraints(Entity e) {
+        this.entity = e;
+    }
+
+    /**
+     * Checks all constraints of all config keys available to an entity.
+     */
+    public static void assertValid(Entity e) {
+        Iterable<ConfigKey<?>> violations = new ConfigConstraints(e).getViolations();
+        if (!Iterables.isEmpty(violations)) {
+            throw new AssertionError("ConfigKeys violate constraints: " + violations);
+        }
+    }
+
+    public boolean isValid() {
+        return Iterables.isEmpty(getViolations());
+    }
+
+    public Iterable<ConfigKey<?>> getViolations() {
+        return validateAll();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterable<ConfigKey<?>> validateAll() {
+        EntityInternal ei = (EntityInternal) entity;
+        List<ConfigKey<?>> violating = Lists.newArrayList();
+
+        for (ConfigKey<?> configKey : getEntityConfigKeys(entity)) {
+            // getRaw returns null if explicitly set and absent if config key was unset.
+            Object value = ei.config().getRaw(configKey).or(configKey.getDefaultValue());
+
+            if (value == null || value.getClass().isAssignableFrom(configKey.getType())) {
+                // Cast should be safe because the author of the constraint on the config key had to
+                // keep its type to Predicte<? super T>, where T is ConfigKey<T>.
+                try {
+                    Predicate<Object> po = (Predicate<Object>) configKey.getConstraint();
+                    if (!po.apply(value)) {
+                        violating.add(configKey);
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Error checking constraint on {} {} ", configKey.getName(), e);
+                }
+            }
+        }
+        return violating;
+    }
+
+    private static Iterable<ConfigKey<?>> getEntityConfigKeys(Entity entity) {
+        return entity.getEntityType().getConfigKeys();
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConstraintViolationException.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConstraintViolationException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.config;
+
+/**
+ * A {@link ConstraintViolationException} indicates one or more problems applying
+ * values for {@link org.apache.brooklyn.config.ConfigKey ConfigKeys} when creating
+ * a {@link org.apache.brooklyn.api.objs.BrooklynObject}.
+ */
+public class ConstraintViolationException extends RuntimeException {
+    private static final long serialVersionUID = -6719912119648996815L;
+
+    public ConstraintViolationException(String message) {
+        super(message);
+    }
+
+    public ConstraintViolationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1214,7 +1214,11 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
             
             getManagementSupport().getEntityChangeListener().onConfigChanged(key);
             return result;
+        }
 
+        @Override
+        protected ExecutionContext getContext() {
+            return AbstractEntity.this.getExecutionContext();
         }
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1551,8 +1551,6 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
      */
     protected ToStringHelper toStringHelper() {
         return Objects.toStringHelper(this).omitNullValues().add("id", getId());
-//            make output more concise by suppressing display name
-//            .add("name", getDisplayName());
     }
     
     // -------- INITIALIZATION --------------

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -987,7 +987,7 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
 
     /**
      * Direct use of this class is strongly discouraged. It will become private in a future release,
-     * once {@link #sensors()} is reverted to return {@link SensorsSupport} instead of
+     * once {@link #sensors()} is reverted to return {@link SensorSupport} instead of
      * {@link BasicSensorSupport}.
      */
     @Beta

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -58,6 +58,7 @@ import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.BrooklynLogging;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.internal.EntityConfigMap;
@@ -1144,6 +1145,7 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
 
         @Override
         public <T> T set(ConfigKey<T> key, T val) {
+            ConfigConstraints.assertValid(AbstractEntity.this, key, val);
             return setConfigInternal(key, val);
         }
 

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -77,6 +77,7 @@ import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.internal.SubscriptionTracker;
 import org.apache.brooklyn.core.mgmt.rebind.BasicEntityRebindSupport;
 import org.apache.brooklyn.core.objs.AbstractBrooklynObject;
+import org.apache.brooklyn.core.objs.AbstractConfigurationSupportInternal;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct.AdjunctTagSupport;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
@@ -1134,16 +1135,11 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
      */
     @Beta
     // TODO revert to private when config() is reverted to return ConfigurationSupportInternal
-    public class BasicConfigurationSupport implements ConfigurationSupportInternal {
+    public class BasicConfigurationSupport extends AbstractConfigurationSupportInternal {
 
         @Override
         public <T> T get(ConfigKey<T> key) {
             return configsInternal.getConfig(key);
-        }
-
-        @Override
-        public <T> T get(HasConfigKey<T> key) {
-            return get(key.getConfigKey());
         }
 
         @Override
@@ -1152,18 +1148,8 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         }
 
         @Override
-        public <T> T set(HasConfigKey<T> key, T val) {
-            return set(key.getConfigKey(), val);
-        }
-
-        @Override
         public <T> T set(ConfigKey<T> key, Task<T> val) {
             return setConfigInternal(key, val);
-        }
-
-        @Override
-        public <T> T set(HasConfigKey<T> key, Task<T> val) {
-            return set(key.getConfigKey(), val);
         }
 
         @Override
@@ -1182,18 +1168,8 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         }
 
         @Override
-        public Maybe<Object> getRaw(HasConfigKey<?> key) {
-            return getRaw(key.getConfigKey());
-        }
-
-        @Override
         public Maybe<Object> getLocalRaw(ConfigKey<?> key) {
             return configsInternal.getConfigRaw(key, false);
-        }
-
-        @Override
-        public Maybe<Object> getLocalRaw(HasConfigKey<?> key) {
-            return getLocalRaw(key.getConfigKey());
         }
 
         @Override

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -472,6 +473,11 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
 
         private ConfigInheritance getDefaultInheritance() {
             return ConfigInheritance.ALWAYS;
+        }
+
+        @Override
+        protected ExecutionContext getContext() {
+            return AbstractLocation.this.getManagementContext().getServerExecutionContext();
         }
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
@@ -59,6 +59,7 @@ import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.internal.SubscriptionTracker;
 import org.apache.brooklyn.core.mgmt.rebind.BasicLocationRebindSupport;
 import org.apache.brooklyn.core.objs.AbstractBrooklynObject;
+import org.apache.brooklyn.core.objs.AbstractConfigurationSupportInternal;
 import org.apache.brooklyn.util.collections.SetFromLiveMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
@@ -379,7 +380,7 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
         return subscriptions;
     }
 
-    private class BasicConfigurationSupport implements ConfigurationSupportInternal {
+    private class BasicConfigurationSupport extends AbstractConfigurationSupportInternal {
 
         @Override
         public <T> T get(ConfigKey<T> key) {
@@ -397,11 +398,6 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
         }
 
         @Override
-        public <T> T get(HasConfigKey<T> key) {
-            return get(key.getConfigKey());
-        }
-
-        @Override
         public <T> T set(ConfigKey<T> key, T val) {
             T result = configBag.put(key, val);
             onChanged();
@@ -409,18 +405,7 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
         }
 
         @Override
-        public <T> T set(HasConfigKey<T> key, T val) {
-            return set(key.getConfigKey(), val);
-        }
-
-        @Override
         public <T> T set(ConfigKey<T> key, Task<T> val) {
-            // TODO Support for locations
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public <T> T set(HasConfigKey<T> key, Task<T> val) {
             // TODO Support for locations
             throw new UnsupportedOperationException();
         }
@@ -446,19 +431,9 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
         }
 
         @Override
-        public Maybe<Object> getRaw(HasConfigKey<?> key) {
-            return getRaw(key.getConfigKey());
-        }
-
-        @Override
         public Maybe<Object> getLocalRaw(ConfigKey<?> key) {
             if (hasConfig(key, false)) return Maybe.of(getLocalBag().getStringKey(key.getName()));
             return Maybe.absent();
-        }
-
-        @Override
-        public Maybe<Object> getLocalRaw(HasConfigKey<?> key) {
-            return getLocalRaw(key.getConfigKey());
         }
 
         @Override

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
@@ -47,6 +47,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.config.BasicConfigKey;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.internal.storage.BrooklynStorage;
 import org.apache.brooklyn.core.internal.storage.Reference;
@@ -400,6 +401,7 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
 
         @Override
         public <T> T set(ConfigKey<T> key, T val) {
+            ConfigConstraints.assertValid(AbstractLocation.this, key, val);
             T result = configBag.put(key, val);
             onChanged();
             return result;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -65,7 +65,7 @@ import com.google.common.base.Stopwatch;
  * <p>
  * on unmanage it hits onManagementStoppingHere() then onManagementStopping().
  * <p>
- * When an entity's management migrates, it invoked onManagementStoppingHere() at the old location,
+ * When an entity's management migrates, it invokes onManagementStoppingHere() at the old location,
  * then onManagementStartingHere() at the new location.
  */
 public class EntityManagementSupport {
@@ -84,9 +84,6 @@ public class EntityManagementSupport {
     protected transient ManagementContext managementContext;
     protected transient SubscriptionContext subscriptionContext;
     protected transient ExecutionContext executionContext;
-    
-    // TODO the application
-    // (elaborate or remove ^^^ ? -AH, Sept 2014)
     
     protected final AtomicBoolean managementContextUsable = new AtomicBoolean(false);
     protected final AtomicBoolean currentlyDeployed = new AtomicBoolean(false);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -44,7 +44,6 @@ import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.core.BrooklynLogging;
-import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -269,8 +268,6 @@ public class LocalEntityManager implements EntityManagerInternal {
                     new Exception("source of duplicate management of "+e));
             return;
         }
-        ConfigConstraints.assertValid(e);
-
         manageRecursive(e, ManagementTransitionMode.guessing(BrooklynObjectManagementMode.NONEXISTENT, BrooklynObjectManagementMode.MANAGED_PRIMARY));
     }
 
@@ -311,7 +308,7 @@ public class LocalEntityManager implements EntityManagerInternal {
     protected void manageRecursive(Entity e, final ManagementTransitionMode initialMode) {
         checkManagementAllowed(e);
 
-        final List<EntityInternal> allEntities =  Lists.newArrayList();
+        final List<EntityInternal> allEntities = Lists.newArrayList();
         Predicate<EntityInternal> manageEntity = new Predicate<EntityInternal>() { public boolean apply(EntityInternal it) {
             ManagementTransitionMode mode = getLastManagementTransitionMode(it.getId());
             if (mode==null) {
@@ -390,7 +387,7 @@ public class LocalEntityManager implements EntityManagerInternal {
             }
         }
     }
-    
+
     @Override
     public void unmanage(final Entity e) {
         unmanage(e, ManagementTransitionMode.guessing(BrooklynObjectManagementMode.MANAGED_PRIMARY, BrooklynObjectManagementMode.NONEXISTENT));
@@ -600,7 +597,7 @@ public class LocalEntityManager implements EntityManagerInternal {
     /**
      * Should ensure that the entity is now known about, but should not be accessible from other entities yet.
      * 
-     * Records that the given entity is about to be managed (used for answering {@link isPreManaged(Entity)}.
+     * Records that the given entity is about to be managed (used for answering {@link #isPreManaged(Entity)}.
      * Note that refs to the given entity are stored in a a weak hashmap so if the subsequent management
      * attempt fails then this reference to the entity will eventually be discarded (if no-one else holds 
      * a reference).
@@ -628,7 +625,6 @@ public class LocalEntityManager implements EntityManagerInternal {
     /**
      * Should ensure that the entity is now managed somewhere, and known about in all the lists.
      * Returns true if the entity has now become managed; false if it was already managed (anything else throws exception)
-     * @param isOrWasReadOnly 
      */
     private synchronized boolean manageNonRecursive(Entity e, ManagementTransitionMode mode) {
         Entity old = entitiesById.get(e.getId());
@@ -641,8 +637,8 @@ public class LocalEntityManager implements EntityManagerInternal {
             }
             return false;
         }
-        
-        BrooklynLogging.log(log, BrooklynLogging.levelDebugOrTraceIfReadOnly(e), 
+
+        BrooklynLogging.log(log, BrooklynLogging.levelDebugOrTraceIfReadOnly(e),
             "{} starting management of entity {}", this, e);
         Entity realE = toRealEntity(e);
         

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.core.BrooklynLogging;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -268,6 +269,8 @@ public class LocalEntityManager implements EntityManagerInternal {
                     new Exception("source of duplicate management of "+e));
             return;
         }
+        ConfigConstraints.assertValid(e);
+
         manageRecursive(e, ManagementTransitionMode.guessing(BrooklynObjectManagementMode.NONEXISTENT, BrooklynObjectManagementMode.MANAGED_PRIMARY));
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -19,9 +19,17 @@
 
 package org.apache.brooklyn.core.objs;
 
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.time.Duration;
 
 public abstract class AbstractConfigurationSupportInternal implements BrooklynObjectInternal.ConfigurationSupportInternal {
 
@@ -41,6 +49,30 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
     }
 
     @Override
+    public <T> Maybe<T> getNonBlocking(HasConfigKey<T> key) {
+        return getNonBlocking(key.getConfigKey());
+    }
+
+    @Override
+    public <T> Maybe<T> getNonBlocking(ConfigKey<T> key) {
+        // getRaw returns Maybe(val) if the key was explicitly set (where val can be null)
+        // or Absent if the config key was unset.
+        Object unresolved = getRaw(key).or(key.getDefaultValue());
+        final Object marker = new Object();
+        // Give tasks a short grace period to resolve.
+        Object resolved = Tasks.resolving(unresolved)
+                .as(Object.class)
+                .defaultValue(marker)
+                .timeout(Duration.of(5, TimeUnit.MILLISECONDS))
+                .context(getContext())
+                .swallowExceptions()
+                .get();
+        return (resolved != marker)
+               ? TypeCoercions.tryCoerce(resolved, key.getTypeToken())
+               : Maybe.<T>absent();
+    }
+
+    @Override
     public <T> T set(HasConfigKey<T> key, Task<T> val) {
         return set(key.getConfigKey(), val);
     }
@@ -50,4 +82,9 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
         return set(key.getConfigKey(), val);
     }
 
+    /**
+     * @return An execution context for use by {@link #getNonBlocking(ConfigKey)}
+     */
+    @Nullable
+    protected abstract ExecutionContext getContext();
 }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.objs;
+
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.util.guava.Maybe;
+
+public abstract class AbstractConfigurationSupportInternal implements BrooklynObjectInternal.ConfigurationSupportInternal {
+
+    @Override
+    public <T> T get(HasConfigKey<T> key) {
+        return get(key.getConfigKey());
+    }
+
+    @Override
+    public Maybe<Object> getLocalRaw(HasConfigKey<?> key) {
+        return getLocalRaw(key.getConfigKey());
+    }
+
+    @Override
+    public Maybe<Object> getRaw(HasConfigKey<?> key) {
+        return getRaw(key.getConfigKey());
+    }
+
+    @Override
+    public <T> T set(HasConfigKey<T> key, Task<T> val) {
+        return set(key.getConfigKey(), val);
+    }
+
+    @Override
+    public <T> T set(HasConfigKey<T> key, T val) {
+        return set(key.getConfigKey(), val);
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -426,7 +426,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
     
     protected abstract void onChanged();
     
-    protected AdjunctType getAdjunctType() {
+    public AdjunctType getAdjunctType() {
         return adjunctType;
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigMap;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.Entities;
@@ -298,6 +299,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         @SuppressWarnings("unchecked")
         @Override
         public <T> T set(ConfigKey<T> key, T val) {
+            ConfigConstraints.assertValid(entity, key, val);
             if (entity != null && isRunning()) {
                 doReconfigureConfig(key, val);
             }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -41,7 +41,6 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.config.ConfigMap;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
@@ -289,16 +288,11 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         }
     }
     
-    private class BasicConfigurationSupport implements ConfigurationSupportInternal {
+    private class BasicConfigurationSupport extends AbstractConfigurationSupportInternal {
 
         @Override
         public <T> T get(ConfigKey<T> key) {
             return configsInternal.getConfig(key);
-        }
-
-        @Override
-        public <T> T get(HasConfigKey<T> key) {
-            return get(key.getConfigKey());
         }
 
         @SuppressWarnings("unchecked")
@@ -312,11 +306,6 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
             return result;
         }
 
-        @Override
-        public <T> T set(HasConfigKey<T> key, T val) {
-            return setConfig(key.getConfigKey(), val);
-        }
-
         @SuppressWarnings("unchecked")
         @Override
         public <T> T set(ConfigKey<T> key, Task<T> val) {
@@ -327,11 +316,6 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
             T result = (T) configsInternal.setConfig(key, val);
             onChanged();
             return result;
-        }
-
-        @Override
-        public <T> T set(HasConfigKey<T> key, Task<T> val) {
-            return set(key.getConfigKey(), val);
         }
 
         @Override
@@ -350,18 +334,8 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         }
 
         @Override
-        public Maybe<Object> getRaw(HasConfigKey<?> key) {
-            return getRaw(key.getConfigKey());
-        }
-
-        @Override
         public Maybe<Object> getLocalRaw(ConfigKey<?> key) {
             return configsInternal.getConfigRaw(key, false);
-        }
-
-        @Override
-        public Maybe<Object> getLocalRaw(HasConfigKey<?> key) {
-            return getLocalRaw(key.getConfigKey());
         }
 
         @Override

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -357,6 +357,11 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         public void refreshInheritedConfigOfChildren() {
             // no-op for location
         }
+
+        @Override
+        protected ExecutionContext getContext() {
+            return AbstractEntityAdjunct.this.execution;
+        }
     }
 
     public <T> T getConfig(ConfigKey<T> key) {

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
@@ -74,7 +74,7 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
         Maybe<Object> getRaw(ConfigKey<?> key);
 
         /**
-         * @see {@link #getConfigRaw(ConfigKey)}
+         * @see {@link #getRaw(ConfigKey)}
          */
         @Beta
         Maybe<Object> getRaw(HasConfigKey<?> key);
@@ -87,7 +87,7 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
         Maybe<Object> getLocalRaw(ConfigKey<?> key);
 
         /**
-         * @see {@link #getLocalConfigRaw(ConfigKey)}
+         * @see {@link #getLocalRaw(ConfigKey)}
          */
         @Beta
         Maybe<Object> getLocalRaw(HasConfigKey<?> key);

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
@@ -46,11 +46,11 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
 
     @Beta
     public interface ConfigurationSupportInternal extends Configurable.ConfigurationSupport {
-        
+
         /**
-         * Returns a read-only view of all the config key/value pairs on this entity, backed by a string-based map, 
+         * Returns a read-only view of all the config key/value pairs on this entity, backed by a string-based map,
          * including config names that did not match anything on this entity.
-         * 
+         *
          * TODO This method gives no information about which config is inherited versus local;
          * this means {@link ConfigKey#getInheritance()} cannot be respected. This is an unsolvable problem
          * for "config names that did not match anything on this entity". Therefore consider using
@@ -58,14 +58,14 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
          */
         @Beta
         ConfigBag getBag();
-        
+
         /**
-         * Returns a read-only view of the local (i.e. not inherited) config key/value pairs on this entity, 
+         * Returns a read-only view of the local (i.e. not inherited) config key/value pairs on this entity,
          * backed by a string-based map, including config names that did not match anything on this entity.
          */
         @Beta
         ConfigBag getLocalBag();
-        
+
         /**
          * Returns the uncoerced value for this config key, if available, not taking any default.
          * If there is no local value and there is an explicit inherited value, will return the inherited.
@@ -92,6 +92,20 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
         @Beta
         Maybe<Object> getLocalRaw(HasConfigKey<?> key);
 
+        /**
+         * Attempts to coerce the value for this config key, if available,
+         * taking a default and {@link Maybe#absent absent} if the uncoerced
+         * cannot be resolved within a short timeframe.
+         */
+        @Beta
+        <T> Maybe<T> getNonBlocking(ConfigKey<T> key);
+
+        /**
+         * @see {@link #getNonBlocking(ConfigKey)}
+         */
+        @Beta
+        <T> Maybe<T> getNonBlocking(HasConfigKey<T> key);
+
         @Beta
         void addToLocalBag(Map<String, ?> vals);
 
@@ -100,7 +114,7 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
 
         @Beta
         void refreshInheritedConfig();
-        
+
         @Beta
         void refreshInheritedConfigOfChildren();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectPredicate.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectPredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.objs;
+
+import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.util.guava.PredicateWithContext;
+
+/**
+ * A marker interface for predicates that can use a {@link BrooklynObject} in their {@link #apply} method.
+ */
+public interface BrooklynObjectPredicate<P> extends PredicateWithContext<P, BrooklynObject> {
+
+    @Override
+    boolean apply(P input, BrooklynObject context);
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalPolicyFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalPolicyFactory.java
@@ -20,13 +20,17 @@ package org.apache.brooklyn.core.objs.proxy;
 
 import java.util.Map;
 
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
@@ -98,15 +102,15 @@ public class InternalPolicyFactory extends InternalFactory {
         if (spec.getFlags().containsKey("parent")) {
             throw new IllegalArgumentException("Spec's flags must not contain parent; use spec.parent() instead for "+spec);
         }
-        
+
         try {
             Class<? extends T> clazz = spec.getType();
-            
+
             T pol = construct(clazz, spec.getFlags());
 
-            if (spec.getDisplayName()!=null)
+            if (spec.getDisplayName()!=null) {
                 ((AbstractPolicy)pol).setDisplayName(spec.getDisplayName());
-            
+            }
             if (spec.getCatalogItemId()!=null) {
                 ((AbstractPolicy)pol).setCatalogItemId(spec.getCatalogItemId());
             }
@@ -125,6 +129,7 @@ public class InternalPolicyFactory extends InternalFactory {
             for (Map.Entry<ConfigKey<?>, Object> entry : spec.getConfig().entrySet()) {
                 pol.config().set((ConfigKey)entry.getKey(), entry.getValue());
             }
+            ConfigConstraints.assertValid(pol);
             ((AbstractPolicy)pol).init();
             
             return pol;
@@ -166,6 +171,7 @@ public class InternalPolicyFactory extends InternalFactory {
             for (Map.Entry<ConfigKey<?>, Object> entry : spec.getConfig().entrySet()) {
                 enricher.config().set((ConfigKey)entry.getKey(), entry.getValue());
             }
+            ConfigConstraints.assertValid(enricher);
             ((AbstractEnricher)enricher).init();
             
             return enricher;
@@ -174,7 +180,7 @@ public class InternalPolicyFactory extends InternalFactory {
             throw Exceptions.propagate(e);
         }
     }
-    
+
     /**
      * Constructs a new-style policy (fails if no no-arg constructor).
      */

--- a/core/src/main/java/org/apache/brooklyn/util/core/ResourcePredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/ResourcePredicates.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.util.core;
+
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.core.objs.BrooklynObjectPredicate;
+import org.apache.brooklyn.util.text.Strings;
+
+import com.google.common.base.Predicate;
+
+public class ResourcePredicates {
+
+    private ResourcePredicates() {}
+
+    /**
+     * @return A predicate that tests whether its input is a resource readable by Brooklyn.
+     * @see ResourceUtils#doesUrlExist(String)
+     */
+    public static Predicate<String> urlExists() {
+        return new ResourceExistsPredicate();
+    }
+
+    private static class ResourceExistsPredicate implements BrooklynObjectPredicate<String> {
+
+        @Override
+        public boolean apply(@Nullable String resource) {
+            return apply(resource, null);
+        }
+
+        @Override
+        public boolean apply(@Nullable String resource, @Nullable BrooklynObject context) {
+            return !Strings.isBlank(resource) && new ResourceUtils(context).doesUrlExist(resource);
+        }
+
+        @Override
+        public String toString() {
+            return "ResourcePredicates.exists()";
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/util/core/ResourceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/ResourceUtils.java
@@ -478,26 +478,37 @@ public class ResourceUtils {
         }
     }
 
-    /** allows failing-fast if URL cannot be read */
+    /** @see #checkUrlExists(String, String) */
     public String checkUrlExists(String url) {
         return checkUrlExists(url, null);
     }
-    
+
+    /**
+     * Throws if the given URL cannot be read.
+     * @param url The URL to test
+     * @param message An optional message to use for the exception thrown.
+     * @return The URL argument
+     * @see #getResourceFromUrl(String)
+     */
     public String checkUrlExists(String url, String message) {
         if (url==null) throw new NullPointerException("URL "+(message!=null ? message+" " : "")+"must not be null");
-        InputStream s;
+        InputStream s = null;
         try {
             s = getResourceFromUrl(url);
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
             throw new IllegalArgumentException("Unable to access URL "+(message!=null ? message : "")+": "+url, e);
+        } finally {
+            Streams.closeQuietly(s);
         }
-        Streams.closeQuietly(s); 
         return url;
     }
 
-    /** tests whether the url exists, returning true or false */
-    public boolean doesUrlExist(String url) {
+    /**
+     * @return True if the given URL can be read, false otherwise.
+     * @see #getResourceFromUrl(String)
+     */
+     public boolean doesUrlExist(String url) {
         InputStream s = null;
         try {
             s = getResourceFromUrl(url);

--- a/core/src/test/java/org/apache/brooklyn/core/config/ConfigKeyConstraintTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/ConfigKeyConstraintTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.config;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.test.entity.TestEntityImpl;
+import org.apache.brooklyn.core.test.policy.TestPolicy;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+
+public class ConfigKeyConstraintTest extends BrooklynAppUnitTestSupport {
+
+    @ImplementedBy(EntityWithNonNullConstraintImpl.class)
+    public static interface EntityWithNonNullConstraint extends TestEntity {
+        ConfigKey<Object> NON_NULL_CONFIG = ConfigKeys.builder(Object.class)
+                .name("test.conf.non-null.without-default")
+                .description("Configuration key that must not be null")
+                .constraint(Predicates.notNull())
+                .build();
+
+    }
+
+    @ImplementedBy(EntityWithNonNullConstraintWithNonNullDefaultImpl.class)
+    public static interface EntityWithNonNullConstraintWithNonNullDefault extends TestEntity {
+        ConfigKey<Object> NON_NULL_WITH_DEFAULT = ConfigKeys.builder(Object.class)
+                .name("test.conf.non-null.with-default")
+                .description("Configuration key that must not be null")
+                .defaultValue(new Object())
+                .constraint(Predicates.notNull())
+                .build();
+    }
+
+    @ImplementedBy(EntityRequiringConfigKeyInRangeImpl.class)
+    public static interface EntityRequiringConfigKeyInRange extends TestEntity {
+        ConfigKey<Integer> RANGE = ConfigKeys.builder(Integer.class)
+                .name("test.conf.range")
+                .description("Configuration key that must not be between zero and nine")
+                .defaultValue(0)
+                .constraint(Range.closed(0, 9))
+                .build();
+    }
+
+    @ImplementedBy(EntityProvidingDefaultValueForConfigKeyInRangeImpl.class)
+    public static interface EntityProvidingDefaultValueForConfigKeyInRange extends EntityRequiringConfigKeyInRange {
+        ConfigKey<Integer> REVISED_RANGE = ConfigKeys.newConfigKeyWithDefault(RANGE, -1);
+    }
+
+    public static class EntityWithNonNullConstraintImpl extends TestEntityImpl implements EntityWithNonNullConstraint {
+    }
+
+    public static class EntityWithNonNullConstraintWithNonNullDefaultImpl extends TestEntityImpl implements EntityWithNonNullConstraintWithNonNullDefault {
+    }
+
+    public static class EntityRequiringConfigKeyInRangeImpl extends TestEntityImpl implements EntityRequiringConfigKeyInRange {
+    }
+
+    public static class EntityProvidingDefaultValueForConfigKeyInRangeImpl extends TestEntityImpl implements EntityProvidingDefaultValueForConfigKeyInRange {
+    }
+
+    @Test
+    public void testExceptionWhenEntityHasNullConfig() {
+        try {
+            app.createAndManageChild(EntitySpec.create(EntityWithNonNullConstraint.class));
+            fail("Expected exception when managing entity with missing config");
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstThrowableOfType(e, AssertionError.class);
+            assertNotNull(t);
+        }
+    }
+
+    @Test
+    public void testNoExceptionWhenEntityHasValueForRequiredConfig() {
+        app.createAndManageChild(EntitySpec.create(EntityWithNonNullConstraint.class)
+                .configure(EntityWithNonNullConstraint.NON_NULL_CONFIG, new Object()));
+    }
+
+    @Test
+    public void testNoExceptionWhenDefaultValueIsValid() {
+        app.createAndManageChild(EntitySpec.create(EntityRequiringConfigKeyInRange.class));
+    }
+
+    @Test
+    public void testExceptionWhenSubclassSetsInvalidDefaultValue() {
+        try {
+            app.createAndManageChild(EntitySpec.create(EntityProvidingDefaultValueForConfigKeyInRange.class));
+            fail("Expected exception when managing entity setting invalid default value");
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstThrowableOfType(e, AssertionError.class);
+            assertNotNull(t);
+        }
+    }
+
+    @Test
+    public void testExceptionIsThrownWhenUserSetsNullValueToConfigWithNonNullDefault() {
+        try {
+            app.createAndManageChild(EntitySpec.create(EntityWithNonNullConstraintWithNonNullDefault.class)
+                    .configure(EntityWithNonNullConstraintWithNonNullDefault.NON_NULL_WITH_DEFAULT, (Object) null));
+            fail("Expected exception when config key set to null");
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstThrowableOfType(e, AssertionError.class);
+            assertNotNull(t);
+        }
+    }
+
+    @Test(enabled = false)
+    public void testExceptionWhenPolicyHasNullConfig() {
+        app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .policy(PolicySpec.create(TestPolicy.class)
+                        .configure(EntityWithNonNullConstraint.NON_NULL_CONFIG, (Object) null)));
+        try {
+            app.start(ImmutableList.of(app.newSimulatedLocation()));
+            fail("Expected exception when starting entity with policy with missing config");
+        } catch (Exception e) {
+            Throwable t = Exceptions.getFirstThrowableOfType(e, AssertionError.class);
+            assertNotNull(t);
+        }
+    }
+
+}

--- a/docs/guide/concepts/configuration-sensor-effectors.md
+++ b/docs/guide/concepts/configuration-sensor-effectors.md
@@ -15,7 +15,7 @@ Configuration is propagated when an application "goes live" (i.e. it becomes "ma
 Configuration values can be specified in a configuration file (``~/.brooklyn/brooklyn.properties``)
 to apply universally, and/or programmatically to a specific entity and its descendants 
 by calling `.configure(KEY, VALUE)` in the entity spec when creating it.
-There is also an ``entity.setConfig(KEY, VALUE)`` method.
+There is also an ``entity.config().set(KEY, VALUE)`` method.
 
 Additionally, many common configuration parameters are available as "flags" which can be supplied as Strings when constructing
 then entity, in the form
@@ -35,6 +35,6 @@ Sensors can be updated by the entity or associated tasks, and sensors from an en
 Effectors can be invoked by an entity's parent remotely, and the invoker is able to track the execution of that effector. Effectors can be invoked by other entities, but use this functionality with care to prevent too many managers!
 
 An entity consists of a Java interface (used when interacting with the entity) and a Java class. For resilience. it is recommended to store 
-the entity's state in attributes (see `getAttribute(AttributeKey)``). If internal fields can be used then the data will be lost on brooklyn 
+the entity's state in attributes (see ``getAttribute(AttributeKey)``). If internal fields can be used then the data will be lost on brooklyn
 restart, and may cause problems if the entity is to be moved to a different brooklyn management node.
 

--- a/docs/guide/java/entities.md
+++ b/docs/guide/java/entities.md
@@ -50,8 +50,21 @@ TODO: why to use config?
   Syntax is as described in the PortRange interface. For example, "8080-8099,8800+" will try port 8080, try sequentially through 8099, then try from 8800 until all ports are exhausted.
   
   This is particularly useful on a contended machine (localhost!). Like ordinary configuration, the config is done by the user, and the actual port used is reported back as a sensor on the entity.
- 
- 
+
+- Validation of config values can be applied by supplying a ``Predicate`` to the ``constraint`` of a ConfigKey builder.
+  Constraints are tested after an entity is initialised and before an entity managed.
+  Useful predicates include:
+  - ``StringPredicates.isNonBlank``: require that a String key is neither null nor empty.
+  - ``ResourcePredicates.urlExists``: require that a URL that is loadable by Brooklyn. Use this to
+    confirm that necessary resources are available to the entity.
+  - ``Predicates.in``: require one of a fixed set of values.
+  - ``Predicates.containsPattern``: require that a value match a regular expression pattern.
+
+  An important caveat is that only constraints on config keys that are on an entity's type hierarchy can be
+  tested automatically. Brooklyn has no knowledge of the true type of other keys until they are retrieved with a
+  ``config().get(key)``.
+
+
 Implementing Sensors
 --------------------
 

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
@@ -126,7 +126,7 @@ public abstract class AbstractBrooklynRestResource implements ManagementContextI
         public RestValueResolver renderAs(Object rendererHintSource) { this.rendererHintSource = rendererHintSource; return this; }
 
         public Object resolve() {
-            Object valueResult = getImmediateValue(valueToResolve, entity);
+            Object valueResult = getImmediateValue(valueToResolve, entity, timeout);
             if (valueResult==UNRESOLVED) valueResult = valueToResolve;
             if (rendererHintSource!=null && Boolean.FALSE.equals(raw)) {
                 valueResult = RendererHints.applyDisplayValueHintUnchecked(rendererHintSource, valueResult);
@@ -136,8 +136,14 @@ public abstract class AbstractBrooklynRestResource implements ManagementContextI
         
         private static Object UNRESOLVED = "UNRESOLVED".toCharArray();
         
-        private static Object getImmediateValue(Object value, @Nullable Entity context) {
-            return Tasks.resolving(value).as(Object.class).defaultValue(UNRESOLVED).timeout(Duration.ZERO).context(context).swallowExceptions().get();
+        private static Object getImmediateValue(Object value, @Nullable Entity context, @Nullable Duration timeout) {
+            return Tasks.resolving(value)
+                    .as(Object.class)
+                    .defaultValue(UNRESOLVED)
+                    .timeout(timeout)
+                    .context(context)
+                    .swallowExceptions()
+                    .get();
         }
 
     }

--- a/utils/common/src/main/java/org/apache/brooklyn/config/ConfigKey.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/config/ConfigKey.java
@@ -55,8 +55,8 @@ public interface ConfigKey<T> {
      * <p> 
      * This returns a "super" of T only in the case where T is generified, 
      * and in such cases it returns the Class instance for the unadorned T ---
-     * i.e. for List<String> this returns Class<List> ---
-     * this is of course because there is no actual Class<List<String>> instance.
+     * i.e. for List&lt;String&gt; this returns Class&lt;List&gt; ---
+     * this is of course because there is no actual Class&lt;List&lt;String&gt;&gt; instance.
      */
     Class<? super T> getType();
 

--- a/utils/common/src/main/java/org/apache/brooklyn/config/ConfigKey.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/config/ConfigKey.java
@@ -20,8 +20,11 @@ package org.apache.brooklyn.config;
 
 import java.util.Collection;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.Beta;
+import com.google.common.base.Predicate;
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -79,11 +82,18 @@ public interface ConfigKey<T> {
      * @return True if the configuration can be changed at runtime.
      */
     boolean isReconfigurable();
-    
+
     /**
      * @return The inheritance model, or <code>null</code> for the default in any context.
      */
     @Nullable ConfigInheritance getInheritance();
+
+    /**
+     * @return the predicate constraining the key's value.
+     */
+    @Beta
+    @Nonnull
+    Predicate<? super T> getConstraint();
 
     /** Interface for elements which want to be treated as a config key without actually being one
      * (e.g. config attribute sensors).

--- a/utils/common/src/main/java/org/apache/brooklyn/config/ConfigKey.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/config/ConfigKey.java
@@ -89,11 +89,18 @@ public interface ConfigKey<T> {
     @Nullable ConfigInheritance getInheritance();
 
     /**
-     * @return the predicate constraining the key's value.
+     * @return The predicate constraining the key's value.
      */
     @Beta
     @Nonnull
     Predicate<? super T> getConstraint();
+
+    /**
+     * @param value The value to test
+     * @return True if the given value is acceptable per the {@link #getConstraint constraints} on this key.
+     */
+    @Beta
+    boolean isValueValid(T value);
 
     /** Interface for elements which want to be treated as a config key without actually being one
      * (e.g. config attribute sensors).

--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/PredicateWithContext.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/PredicateWithContext.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.util.guava;
+
+import com.google.common.base.Predicate;
+
+/**
+ * A marker interface for predicates that may take a context object into account.
+ * <p>
+ * Such predicates should handle absent contexts sensibly.
+ */
+public interface PredicateWithContext<P, T> extends Predicate<P> {
+
+    boolean apply(P input, T context);
+
+}


### PR DESCRIPTION
Allows constraints to be specified on config keys. 

Constraints are eagerly enforced when entities are first managed and when policies and enrichers are created. At other times they are not enforced. Constraints can only be checked on ConfigKeys that are declared on the object's type hierarchy.

A constraint is a `Predicate<T>`, where `T` is the type of the `ConfigKey` in question. Guava's predicates provide almost all of the obvious use cases. I've written `ResourcePredicates.urlExists()` to use with config keys that represent things like files Brooklyn will load and run through Freemarker. I've verified that this works with resources in bundles. Adding this required a couple of adjustments to `NonDeploymentManagementContext`.

See the tests in `ConfigKeyConstraintTest` for most scenarios considered.

Here's what you see if you give an invalid value for a config key using the `urlExists` predicate:
![hello](https://cloud.githubusercontent.com/assets/837527/9824224/4e328df8-58c3-11e5-98d0-e4efd368b2d4.png)
