### PR TITLE
Fix MySqlCluster script init

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlCluster.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlCluster.java
@@ -25,20 +25,27 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
-
-import com.google.common.reflect.TypeToken;
-
+import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.database.DatastoreMixins.HasDatastoreUrl;
 import org.apache.brooklyn.entity.group.DynamicCluster;
+
+import com.google.common.reflect.TypeToken;
 
 @ImplementedBy(MySqlClusterImpl.class)
 @Catalog(name="MySql Master-Slave cluster", description="Sets up a cluster of MySQL nodes using master-slave relation and binary logging", iconUrl="classpath:///mysql-logo-110x57.png")
 public interface MySqlCluster extends DynamicCluster, HasDatastoreUrl {
     interface MySqlMaster {
-        AttributeSensor<String> MASTER_LOG_FILE = Sensors.newStringSensor("mysql.master.log_file", "The binary log file master is writing to");
-        AttributeSensor<Integer> MASTER_LOG_POSITION = Sensors.newIntegerSensor("mysql.master.log_position", "The position in the log file to start replication");
+        AttributeSensor<String> MASTER_LOG_FILE = Sensors.newStringSensor(
+                "mysql.master.log_file", "The binary log file master is writing to");
+        AttributeSensor<Integer> MASTER_LOG_POSITION = Sensors.newIntegerSensor(
+                "mysql.master.log_position", "The position in the log file to start replication");
+
+        ConfigKey<String> MASTER_CREATION_SCRIPT_CONTENTS = ConfigKeys.newStringConfigKey(
+                "datastore.master.creation.script.contents", "Contents of creation script to initialize the master node after initializing replication");
+
+        ConfigKey<String> MASTER_CREATION_SCRIPT_URL = ConfigKeys.newStringConfigKey(
+                "datastore.master.creation.script.url", "URL of creation script to use to initialize the master node after initializing replication (ignored if creationScriptContents is specified)");
     }
     interface MySqlSlave {
         AttributeSensor<Boolean> SLAVE_HEALTHY = Sensors.newBooleanSensor("mysql.slave.healthy", "Indicates that the replication state of the slave is healthy");

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterIntegrationTest.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterIntegrationTest.java
@@ -19,18 +19,20 @@
 package org.apache.brooklyn.entity.database.mysql;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.util.os.Os;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 public class MySqlClusterIntegrationTest extends BrooklynAppLiveTestSupport {
 
     @Test(groups = {"Integration"})
-    public void test_localhost() throws Exception {
+    public void testAllNodesInit() throws Exception {
         try {
-            MySqlClusterTestHelper.test(app, mgmt.getLocationRegistry().resolve("localhost"));
+            MySqlClusterTestHelper.test(app, getLocation());
         } finally {
             for (Entity member : Iterables.getOnlyElement(app.getChildren()).getChildren()) {
                 String runDir = member.getAttribute(MySqlNode.RUN_DIR);
@@ -39,5 +41,23 @@ public class MySqlClusterIntegrationTest extends BrooklynAppLiveTestSupport {
                 }
             }
         }
+    }
+
+    @Test(groups = {"Integration"})
+    public void testMasterInit() throws Exception {
+        try {
+            MySqlClusterTestHelper.testMasterInit(app, getLocation());
+        } finally {
+            for (Entity member : Iterables.getOnlyElement(app.getChildren()).getChildren()) {
+                String runDir = member.getAttribute(MySqlNode.RUN_DIR);
+                if (runDir != null) {
+                    Os.deleteRecursively(runDir);
+                }
+            }
+        }
+    }
+
+    private Location getLocation() {
+        return mgmt.getLocationRegistry().resolve("localhost");
     }
 }

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterTestHelper.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterTestHelper.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import org.apache.brooklyn.entity.database.VogellaExampleAccess;
+import org.apache.brooklyn.entity.database.mysql.MySqlCluster.MySqlMaster;
 
 /**
  * Runs a slightly modified version of the popular Vogella MySQL tutorial,
@@ -72,11 +73,21 @@ public class MySqlClusterTestHelper {
             ));
 
     public static void test(TestApplication app, Location location) throws Exception {
-        MySqlCluster mysql = app.createAndManageChild(EntitySpec.create(MySqlCluster.class)
+        test(app, location, EntitySpec.create(MySqlCluster.class)
                 .configure(MySqlCluster.INITIAL_SIZE, 2)
                 .configure(MySqlNode.CREATION_SCRIPT_CONTENTS, CREATION_SCRIPT)
                 .configure(MySqlNode.MYSQL_SERVER_CONF, MutableMap.<String, Object>of("skip-name-resolve","")));
+    }
 
+    public static void testMasterInit(TestApplication app, Location location) throws Exception {
+        test(app, location, EntitySpec.create(MySqlCluster.class)
+                .configure(MySqlCluster.INITIAL_SIZE, 2)
+                .configure(MySqlMaster.MASTER_CREATION_SCRIPT_CONTENTS, CREATION_SCRIPT)
+                .configure(MySqlNode.MYSQL_SERVER_CONF, MutableMap.<String, Object>of("skip-name-resolve","")));
+    }
+
+    public static void test(TestApplication app, Location location, EntitySpec<MySqlCluster> clusterSpec) throws Exception {
+        MySqlCluster mysql = app.createAndManageChild(clusterSpec);
         app.start(ImmutableList.of(location));
         log.info("MySQL started");
 

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterTestHelper.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterTestHelper.java
@@ -74,12 +74,11 @@ public class MySqlClusterTestHelper {
     public static void test(TestApplication app, Location location) throws Exception {
         MySqlCluster mysql = app.createAndManageChild(EntitySpec.create(MySqlCluster.class)
                 .configure(MySqlCluster.INITIAL_SIZE, 2)
+                .configure(MySqlNode.CREATION_SCRIPT_CONTENTS, CREATION_SCRIPT)
                 .configure(MySqlNode.MYSQL_SERVER_CONF, MutableMap.<String, Object>of("skip-name-resolve","")));
 
         app.start(ImmutableList.of(location));
         log.info("MySQL started");
-        MySqlNode masterEntity = (MySqlNode) mysql.getAttribute(MySqlCluster.FIRST);
-        masterEntity.invoke(MySqlNode.EXECUTE_SCRIPT, ImmutableMap.of("commands", CREATION_SCRIPT)).asTask().getUnchecked();
 
         VogellaExampleAccess masterDb = new VogellaExampleAccess("com.mysql.jdbc.Driver", mysql.getAttribute(MySqlNode.DATASTORE_URL));
         VogellaExampleAccess slaveDb = new VogellaExampleAccess("com.mysql.jdbc.Driver", Iterables.getOnlyElement(mysql.getAttribute(MySqlCluster.SLAVE_DATASTORE_URL_LIST)));


### PR DESCRIPTION
`CREATION_SCRIPT_{URL, CONTENT} `was applied to the master node pre-replication-init so there was no way to initialize the slave nodes. Improved by:
  * Applying `CREATION_SCRIPT_{URL, CONTENT} ` on all nodes, including slaves pre-replication-init
  * Introducing a new `MASTER_CREATION_SCRIPT_{URL, CONTENT} ` config applied on master only post-replication-init