### PR TITLE
Fix jboss service not up

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
@@ -87,11 +87,30 @@ public class UpdatingMap<S,TKey,TVal> extends AbstractEnricher implements Sensor
 
     public UpdatingMap(Map<Object, Object> flags) {
         super(flags);
-        // this always suppresses duplicates, but it updates the same map *in place* so the usual suppress duplicates logic should not be applied
-        // TODO clean up so that we have synchronization guarantees and can inspect the item to see whether it has changed
-        suppressDuplicates = false;
     }
 
+    @Override
+    public void init() {
+        super.init();
+        
+        // this always suppresses duplicates, but it updates the same map *in place* so the usual suppress duplicates logic should not be applied
+        // TODO clean up so that we have synchronization guarantees and can inspect the item to see whether it has changed
+        if (Boolean.TRUE.equals(getConfig(SUPPRESS_DUPLICATES))) {
+            LOG.warn("suppress-duplicates must not be set on "+this+" because map is updated in-place; unsetting config; will always implicitly suppress duplicates");
+            config().set(SUPPRESS_DUPLICATES, (Boolean)null);
+        }
+    }
+    
+    @Override
+    protected <T> void doReconfigureConfig(ConfigKey<T> key, T val) {
+        if (key.getName().equals(SUPPRESS_DUPLICATES.getName())) {
+            if (Boolean.TRUE.equals(val)) {
+                throw new UnsupportedOperationException("suppress-duplicates must not be set on "+this+" because map is updated in-place; will always implicitly suppress duplicates");
+            }
+        }
+        super.doReconfigureConfig(key, val);
+    }
+    
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public void setEntity(EntityLocal entity) {

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
@@ -126,10 +126,11 @@ public class JBoss7ServerImpl extends JavaWebAppSoftwareProcessImpl implements J
     }
     
     protected void connectServiceUp() {
+        connectServiceUpIsRunning();
+        
         addEnricher(Enrichers.builder().updatingMap(Attributes.SERVICE_NOT_UP_INDICATORS)
             .from(MANAGEMENT_URL_UP)
             .computing(Functionals.ifNotEquals(true).value("Management URL not reachable") )
-            .suppressDuplicates(true)
             .build());
     }
     


### PR DESCRIPTION
Previously, serviceUp was never set to true, for two reasons:
    
    1. because connectServiceUpIsRunning was not called, nothing was
       unsetting the service-not-up-indicator for SERVICE_PROCESS_IS_RUNNING
    
    2. because the service-not-up-indicator for MANAGEMENT_URL_UP said
       suppressDuplicates=true, then it checked if the map was equal to
       the “old” map before publishing. But the map was the same object,
       and that object had been modified in-place. So the object was
       always equal to itself. It therefore never did an emit(), so the
       enricher that listened to it to set serviceUp never fired.

Also fix UpdatingMap for if suppressDuplicates=true:
    
- log.warn to say it should not be set.
- reset config to suppressDuplicates=false

