### PR TITLE
Usage goodies

### DIFF
--- a/usage/cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/usage/cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -194,7 +194,7 @@ public class Main extends AbstractMain {
     }
     
     @Command(name = "launch", description = "Starts a server, optionally with applications")
-    public static class LaunchCommand extends BrooklynCommandCollectingArgs {
+    public static class LaunchCommand extends BrooklynCommandWithSystemDefines {
 
         @Option(name = { "--localBrooklynProperties" }, title = "local brooklyn.properties file",
                 description = "Load the given properties file, specific to this launch (appending to and overriding global properties)")
@@ -381,6 +381,8 @@ public class Main extends AbstractMain {
         
         @Override
         public Void call() throws Exception {
+            super.call();
+            
             // Configure launcher
             BrooklynLauncher launcher;
             AppShutdownHandler shutdownHandler = new AppShutdownHandler();

--- a/usage/cli/src/test/java/org/apache/brooklyn/cli/CliTest.java
+++ b/usage/cli/src/test/java/org/apache/brooklyn/cli/CliTest.java
@@ -47,6 +47,7 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.cli.AbstractMain.BrooklynCommand;
 import org.apache.brooklyn.cli.AbstractMain.BrooklynCommandCollectingArgs;
+import org.apache.brooklyn.cli.AbstractMain.DefaultInfoCommand;
 import org.apache.brooklyn.cli.AbstractMain.HelpCommand;
 import org.apache.brooklyn.cli.Main.AppShutdownHandler;
 import org.apache.brooklyn.cli.Main.GeneratePasswordCommand;
@@ -300,12 +301,39 @@ public class CliTest {
         cli.parse("launch", "blah", "my.App");
     }
     
+    @Test
     public void testHelpCommand() {
         Cli<BrooklynCommand> cli = buildCli();
         BrooklynCommand command = cli.parse("help");
-        assertTrue(command instanceof HelpCommand);
-        command = cli.parse();
-        assertTrue(command instanceof HelpCommand);
+        assertTrue(command instanceof HelpCommand, "Command is: "+command);
+    }
+    
+    @Test
+    public void testDefaultInfoCommand() {
+        Cli<BrooklynCommand> cli = buildCli();
+        BrooklynCommand command = cli.parse("");
+        assertTrue(command instanceof DefaultInfoCommand, "Command is: "+command);
+    }
+
+    @Test
+    public void testCliSystemPropertyDefines() {
+        Cli<BrooklynCommand> cli = buildCli();
+        BrooklynCommand command0 = cli.parse(
+            "-Dorg.apache.brooklyn.cli.CliTest.sample1=foo",
+            "-Dorg.apache.brooklyn.cli.CliTest.sample2=bar",
+            "launch", 
+            "-Dorg.apache.brooklyn.cli.CliTest.sample3=baz"
+            );
+        assertTrue(command0 instanceof LaunchCommand);
+        LaunchCommand command = (LaunchCommand) command0;
+        assertEquals(command.getDefines().size(), 3, 
+            "Command is: "+command);
+        assertTrue(command.getDefines().get(0).equals("org.apache.brooklyn.cli.CliTest.sample1=foo"),  
+            "Command is: "+command);
+        assertTrue(command.getDefines().get(2).equals("org.apache.brooklyn.cli.CliTest.sample3=baz"), 
+            "Command is: "+command);
+        assertEquals(command.getDefinesAsMap().get("org.apache.brooklyn.cli.CliTest.sample3"), "baz",
+            "Command is: "+command);
     }
 
     @Test

--- a/usage/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/usage/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -39,6 +39,7 @@ import javax.servlet.DispatcherType;
 
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
 import org.eclipse.jetty.server.ssl.SslSelectChannelConnector;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -588,6 +589,11 @@ public class BrooklynWebServer {
         boolean isRoot = cleanPathSpec.isEmpty();
 
         WebAppContext context = new WebAppContext();
+        // use a unique session ID to prevent interference with other web apps on same server (esp for localhost);
+        // it might be better to make this brooklyn-only or base on the management-plane ID;
+        // but i think it actually *is* per-server instance, since we don't cache sessions server-side,
+        // so i think this is write. [Alex 2015-09] 
+        context.setInitParameter(SessionManager.__SessionCookieProperty, SessionManager.__DefaultSessionCookie+"_"+"BROOKLYN"+Identifiers.makeRandomId(6));
         context.setAttribute(BrooklynServiceAttributes.BROOKLYN_MANAGEMENT_CONTEXT, managementContext);
         for (Map.Entry<String, Object> attributeEntry : attributes.entrySet()) {
             context.setAttribute(attributeEntry.getKey(), attributeEntry.getValue());


### PR DESCRIPTION
* CLI accepts `-Da=b -Dc=d ...`
* JS GUI uses a custom cookie ID so as not to conflict with multiple brooklyn sessions or other services (e.g. alien4cloud) coming from the same server