### PR TITLE
Fix service-not-up-diagnostics, add subscription.notifyOfInitialValue, etc

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntityLocal.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntityLocal.java
@@ -115,7 +115,18 @@ public interface EntityLocal extends Entity {
     // FIXME remove from interface?
     @Beta
     <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);
- 
+
+    /**
+     * Allow us to subscribe to data from a {@link Sensor} on another entity.
+     * 
+     * @return a subscription id which can be used to unsubscribe
+     *
+     * @see SubscriptionManager#subscribe(Map, Entity, Sensor, SensorEventListener)
+     */
+    // FIXME remove from interface?
+    @Beta
+    <T> SubscriptionHandle subscribe(Map<String, ?> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);
+
     /** @see SubscriptionManager#subscribeToChildren(Map, Entity, Sensor, SensorEventListener) */
     // FIXME remove from interface?
     @Beta

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/SubscriptionContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/SubscriptionContext.java
@@ -34,7 +34,7 @@ public interface SubscriptionContext {
     /**
      * As {@link SubscriptionManager#subscribe(Map, Entity, Sensor, SensorEventListener)} with default subscription parameters for this context
      */
-    <T> SubscriptionHandle subscribe(Map<String, Object> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);
+    <T> SubscriptionHandle subscribe(Map<String, ?> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);
  
     /** @see #subscribe(Map, Entity, Sensor, SensorEventListener) */
     <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1337,6 +1337,13 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         return getSubscriptionTracker().subscribe(producer, sensor, listener);
     }
 
+    /** @see EntityLocal#subscribe */
+    @Override
+    @Beta
+    public <T> SubscriptionHandle subscribe(Map<String, ?> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        return getSubscriptionTracker().subscribe(flags, producer, sensor, listener);
+    }
+
     /** @see EntityLocal#subscribeToChildren */
     @Override
     public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicSubscriptionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicSubscriptionContext.java
@@ -70,7 +70,7 @@ public class BasicSubscriptionContext implements SubscriptionContext {
     }
     
     @SuppressWarnings("rawtypes")
-    public <T> SubscriptionHandle subscribe(Map<String, Object> newFlags, Entity producer, Sensor<T> sensor, Closure c) {
+    public <T> SubscriptionHandle subscribe(Map<String, ?> newFlags, Entity producer, Sensor<T> sensor, Closure c) {
         return subscribe(newFlags, producer, sensor, toSensorEventListener(c));        
     }
 
@@ -80,7 +80,7 @@ public class BasicSubscriptionContext implements SubscriptionContext {
     }
     
     @Override
-    public <T> SubscriptionHandle subscribe(Map<String, Object> newFlags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+    public <T> SubscriptionHandle subscribe(Map<String, ?> newFlags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
         Map<String,Object> subscriptionFlags = Maps.newLinkedHashMap(flags);
         if (newFlags != null) subscriptionFlags.putAll(newFlags);
         return manager.subscribe(subscriptionFlags, producer, sensor, listener);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/SubscriptionTracker.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/SubscriptionTracker.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.mgmt.internal;
 
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.Group;
@@ -29,6 +30,7 @@ import org.apache.brooklyn.api.sensor.SensorEventListener;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.SetMultimap;
 
 /**
@@ -57,13 +59,17 @@ public class SubscriptionTracker {
     
     /** @see SubscriptionContext#subscribe(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
-        SubscriptionHandle handle = context.subscribe(producer, sensor, listener);
+        return subscribe(ImmutableMap.<String, Object>of(), producer, sensor, listener);
+    }
+
+    public <T> SubscriptionHandle subscribe(Map<String, ?> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        SubscriptionHandle handle = context.subscribe(flags, producer, sensor, listener);
         synchronized (subscriptions) {
             subscriptions.put(producer, handle);
         }
         return handle;
     }
-    
+
     /** @see SubscriptionContext#subscribeToChildren(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, SensorEventListener<? super T> listener) {
         SubscriptionHandle handle = context.subscribeToChildren(parent, sensor, listener);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/DeserializingClassRenamesProvider.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/DeserializingClassRenamesProvider.java
@@ -38,19 +38,22 @@ public class DeserializingClassRenamesProvider {
 
     public static final String DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH = "classpath://org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties";
     
-    private static Map<String, String> cache = null;
+    private static volatile Map<String, String> cache;
     
     @Beta
     public static Map<String, String> loadDeserializingClassRenames() {
-        if (cache!=null) return cache;
-        synchronized (DeserializingClassRenamesProvider.class) {
-            cache = loadDeserializingClassRenamesCache();
-            return cache;
+        // Double-checked locking - got to use volatile or some such!
+        if (cache == null) {
+            synchronized (DeserializingClassRenamesProvider.class) {
+                if (cache == null) {
+                    cache = loadDeserializingClassRenamesCache();
+                }
+            }
         }
+        return cache;
     }
     
-    private synchronized static Map<String, String> loadDeserializingClassRenamesCache() {
-        if (cache!=null) return cache;
+    private static Map<String, String> loadDeserializingClassRenamesCache() {
         InputStream resource = new ResourceUtils(DeserializingClassRenamesProvider.class).getResourceFromUrl(DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH);
         if (resource != null) {
             try {

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -392,6 +392,14 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
     }
 
     @VisibleForTesting //intended as protected, meant for subclasses
+    @Beta
+    /** @see SubscriptionContext#subscribe(Map, Entity, Sensor, SensorEventListener) */
+    public <T> SubscriptionHandle subscribe(Map<String, ?> flags, Entity producer, Sensor<T> sensor, SensorEventListener<? super T> listener) {
+        if (!checkCanSubscribe()) return null;
+        return getSubscriptionTracker().subscribe(flags, producer, sensor, listener);
+    }
+
+    @VisibleForTesting //intended as protected, meant for subclasses
     /** @see SubscriptionContext#subscribe(Entity, Sensor, SensorEventListener) */
     public <T> SubscriptionHandle subscribeToMembers(Group producerGroup, Sensor<T> sensor, SensorEventListener<? super T> listener) {
         if (!checkCanSubscribe(producerGroup)) return null;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
 
@@ -102,8 +103,7 @@ public class UpdatingMap<S,TKey,TVal> extends AbstractEnricher implements Sensor
         this.computing = (Function) getRequiredConfig(COMPUTING);
         this.removingIfResultIsNull = getConfig(REMOVING_IF_RESULT_IS_NULL);
 
-        subscribe(entity, sourceSensor, this);
-        onUpdated();
+        subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, sourceSensor, this);
     }
     
     @Override

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySubscriptionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySubscriptionTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertEquals;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.BasicSensorEvent;
 import org.apache.brooklyn.core.test.entity.TestApplication;
@@ -81,10 +80,10 @@ public class EntitySubscriptionTest {
         entity.subscribe(observedEntity, TestEntity.NAME, listener);
         entity.subscribe(observedEntity, TestEntity.MY_NOTIF, listener);
         
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        observedEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        observedEntity.setAttribute(TestEntity.NAME, "myname");
-        observedEntity.emit(TestEntity.MY_NOTIF, 456);
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        observedEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        observedEntity.sensors().set(TestEntity.NAME, "myname");
+        observedEntity.sensors().emit(TestEntity.MY_NOTIF, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -99,8 +98,8 @@ public class EntitySubscriptionTest {
     public void testSubscriptionToAllReceivesEvents() {
         entity.subscribe(null, TestEntity.SEQUENCE, listener);
         
-        observedEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 456);
+        observedEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -114,8 +113,8 @@ public class EntitySubscriptionTest {
     public void testSubscribeToChildrenReceivesEvents() {
         entity.subscribeToChildren(observedEntity, TestEntity.SEQUENCE, listener);
         
-        observedChildEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        observedEntity.setAttribute(TestEntity.SEQUENCE, 456);
+        observedChildEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        observedEntity.sensors().set(TestEntity.SEQUENCE, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -129,7 +128,7 @@ public class EntitySubscriptionTest {
         entity.subscribeToChildren(observedEntity, TestEntity.SEQUENCE, listener);
         
         final TestEntity observedChildEntity2 = observedEntity.createAndManageChild(EntitySpec.create(TestEntity.class));
-        observedChildEntity2.setAttribute(TestEntity.SEQUENCE, 123);
+        observedChildEntity2.sensors().set(TestEntity.SEQUENCE, 123);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -142,8 +141,8 @@ public class EntitySubscriptionTest {
     public void testSubscribeToMembersReceivesEvents() {
         entity.subscribeToMembers(observedGroup, TestEntity.SEQUENCE, listener);
         
-        observedMemberEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        ((EntityLocal)observedGroup).setAttribute(TestEntity.SEQUENCE, 456);
+        observedMemberEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        ((EntityLocal)observedGroup).sensors().set(TestEntity.SEQUENCE, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -158,7 +157,7 @@ public class EntitySubscriptionTest {
         
         final TestEntity observedMemberEntity2 = app.createAndManageChild(EntitySpec.create(TestEntity.class));
         observedGroup.addMember(observedMemberEntity2);
-        observedMemberEntity2.setAttribute(TestEntity.SEQUENCE, 123);
+        observedMemberEntity2.sensors().set(TestEntity.SEQUENCE, 123);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -173,7 +172,7 @@ public class EntitySubscriptionTest {
         
         observedGroup.removeMember(observedMemberEntity);
         
-        observedMemberEntity.setAttribute(TestEntity.SEQUENCE, 123);
+        observedMemberEntity.sensors().set(TestEntity.SEQUENCE, 123);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -189,10 +188,10 @@ public class EntitySubscriptionTest {
         entity.subscribe(otherEntity, TestEntity.SEQUENCE, listener);
         entity.unsubscribe(observedEntity);
         
-        observedEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        observedEntity.setAttribute(TestEntity.NAME, "myname");
-        observedEntity.emit(TestEntity.MY_NOTIF, 123);
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 456);
+        observedEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        observedEntity.sensors().set(TestEntity.NAME, "myname");
+        observedEntity.sensors().emit(TestEntity.MY_NOTIF, 123);
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -209,9 +208,9 @@ public class EntitySubscriptionTest {
         
         entity.unsubscribe(observedEntity, handle2);
         
-        observedEntity.setAttribute(TestEntity.SEQUENCE, 123);
-        observedEntity.setAttribute(TestEntity.NAME, "myname");
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 456);
+        observedEntity.sensors().set(TestEntity.SEQUENCE, 123);
+        observedEntity.sensors().set(TestEntity.NAME, "myname");
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -227,7 +226,7 @@ public class EntitySubscriptionTest {
         entity.subscribe(observedEntity, TestEntity.MY_NOTIF, listener);
 
         for (int i = 0; i < NUM_EVENTS; i++) {
-            observedEntity.emit(TestEntity.MY_NOTIF, i);
+            observedEntity.sensors().emit(TestEntity.MY_NOTIF, i);
         }
         
         Asserts.succeedsEventually(new Runnable() {
@@ -238,5 +237,4 @@ public class EntitySubscriptionTest {
                 }
             }});
     }
-
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManagerTest.java
@@ -128,7 +128,7 @@ public class LocalSubscriptionManagerTest extends BrooklynAppUnitTestSupport {
                 events.add(event);
                 latch.countDown();
             }});
-        member.setAttribute(TestEntity.SEQUENCE, 123);
+        member.sensors().set(TestEntity.SEQUENCE, 123);
 
         if (!latch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
             fail("Timeout waiting for Event on parent TestEntity listener");
@@ -168,7 +168,7 @@ public class LocalSubscriptionManagerTest extends BrooklynAppUnitTestSupport {
         try {
             thread.start();
             for (int i = 0; i < 10000; i++) {
-                entity.setAttribute(TestEntity.SEQUENCE, i);
+                entity.sensors().set(TestEntity.SEQUENCE, i);
             }
         } finally {
             thread.interrupt();

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicySubscriptionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicySubscriptionTest.java
@@ -65,10 +65,10 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
         policy.subscribe(entity, TestEntity.NAME, listener);
         policy.subscribe(entity, TestEntity.MY_NOTIF, listener);
         
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 456);
-        entity.setAttribute(TestEntity.SEQUENCE, 123);
-        entity.setAttribute(TestEntity.NAME, "myname");
-        entity.emit(TestEntity.MY_NOTIF, 789);
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 456);
+        entity.sensors().set(TestEntity.SEQUENCE, 123);
+        entity.sensors().set(TestEntity.NAME, "myname");
+        entity.sensors().emit(TestEntity.MY_NOTIF, 789);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
@@ -87,10 +87,10 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
         policy.subscribe(otherEntity, TestEntity.SEQUENCE, listener);
         policy.unsubscribe(entity);
         
-        entity.setAttribute(TestEntity.SEQUENCE, 123);
-        entity.setAttribute(TestEntity.NAME, "myname");
-        entity.emit(TestEntity.MY_NOTIF, 456);
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 789);
+        entity.sensors().set(TestEntity.SEQUENCE, 123);
+        entity.sensors().set(TestEntity.NAME, "myname");
+        entity.sensors().emit(TestEntity.MY_NOTIF, 456);
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 789);
         
         Thread.sleep(SHORT_WAIT_MS);
         Asserts.succeedsEventually(new Runnable() {
@@ -108,9 +108,9 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
         
         policy.unsubscribe(entity, handle2);
         
-        entity.setAttribute(TestEntity.SEQUENCE, 123);
-        entity.setAttribute(TestEntity.NAME, "myname");
-        otherEntity.setAttribute(TestEntity.SEQUENCE, 456);
+        entity.sensors().set(TestEntity.SEQUENCE, 123);
+        entity.sensors().set(TestEntity.NAME, "myname");
+        otherEntity.sensors().set(TestEntity.SEQUENCE, 456);
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {

--- a/core/src/test/java/org/apache/brooklyn/core/test/qa/performance/SubscriptionPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/qa/performance/SubscriptionPerformanceTest.java
@@ -84,7 +84,7 @@ public class SubscriptionPerformanceTest extends AbstractPerformanceTest {
         measureAndAssert("updateAttributeWithManyPublishedOneSubscriber", numIterations, minRatePerSec,
                 new Runnable() {
                     public void run() {
-                        entity.setAttribute(TestEntity.SEQUENCE, (iter.getAndIncrement()));
+                        entity.sensors().set(TestEntity.SEQUENCE, (iter.getAndIncrement()));
                     }
                 },
                 new Runnable() {
@@ -121,7 +121,7 @@ public class SubscriptionPerformanceTest extends AbstractPerformanceTest {
         measureAndAssert("updateAttributeWithManyListeners", numIterations, minRatePerSec,
                 new Runnable() {
                     @Override public void run() {
-                        entity.setAttribute(TestEntity.SEQUENCE, (iter.getAndIncrement()));
+                        entity.sensors().set(TestEntity.SEQUENCE, (iter.getAndIncrement()));
                     }},
                 new Runnable() {
                         public void run() {
@@ -157,7 +157,7 @@ public class SubscriptionPerformanceTest extends AbstractPerformanceTest {
         
         measureAndAssert("updateAttributeWithUnrelatedListeners", numIterations, minRatePerSec, new Runnable() {
             @Override public void run() {
-                entity.setAttribute(TestEntity.SEQUENCE, (iter.incrementAndGet()));
+                entity.sensors().set(TestEntity.SEQUENCE, (iter.incrementAndGet()));
             }});
         
         if (exception.get() != null) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -157,8 +157,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             if (!(entity instanceof SoftwareProcess)) {
                 throw new IllegalArgumentException("Expected SoftwareProcess, but got entity "+entity);
             }
-            subscribe(entity, Attributes.SERVICE_UP, this);
-            onUpdated();
+            subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, Attributes.SERVICE_UP, this);
         }
 
         @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -157,6 +157,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             if (!(entity instanceof SoftwareProcess)) {
                 throw new IllegalArgumentException("Expected SoftwareProcess, but got entity "+entity);
             }
+            subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, Attributes.SERVICE_STATE_ACTUAL, this);
             subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, Attributes.SERVICE_UP, this);
         }
 
@@ -167,8 +168,12 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
 
         protected void onUpdated() {
             Boolean up = entity.getAttribute(SERVICE_UP);
+            Lifecycle state = entity.getAttribute(SERVICE_STATE_ACTUAL);
             if (up == null || up) {
-                entity.setAttribute(ServiceStateLogic.SERVICE_NOT_UP_DIAGNOSTICS, ImmutableMap.<String, Object>of());
+                entity.sensors().set(ServiceStateLogic.SERVICE_NOT_UP_DIAGNOSTICS, ImmutableMap.<String, Object>of());
+            } else if (state == Lifecycle.STOPPING || state == Lifecycle.STOPPED || state == Lifecycle.DESTROYED) {
+                // stopping/stopped, so expect not to be up; get rid of the diagnostics.
+                entity.sensors().set(ServiceStateLogic.SERVICE_NOT_UP_DIAGNOSTICS, ImmutableMap.<String, Object>of());
             } else {
                 ((SoftwareProcess)entity).populateServiceNotUpDiagnostics();
             }

--- a/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -38,6 +38,7 @@ import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
 import org.apache.brooklyn.core.entity.EntityDynamicType;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.apache.brooklyn.core.mgmt.persist.DeserializingClassRenamesProvider;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -47,6 +48,7 @@ import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Reflections;
 import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
 import org.apache.brooklyn.util.text.Strings;
@@ -111,7 +113,9 @@ public class BrooklynDslCommon {
     public static Sensor<?> sensor(String clazzName, String sensorName) {
         try {
             // TODO Should use catalog's classloader, rather than Class.forName; how to get that? Should we return a future?!
-            Class<?> clazz = Class.forName(clazzName);
+            String mappedClazzName = DeserializingClassRenamesProvider.findMappedName(clazzName);
+            Class<?> clazz = Class.forName(mappedClazzName);
+            
             Sensor<?> sensor;
             if (Entity.class.isAssignableFrom(clazz)) {
                 sensor = new EntityDynamicType((Class<? extends Entity>) clazz).getSensor(sensorName);
@@ -150,7 +154,9 @@ public class BrooklynDslCommon {
         Map<String,Object> brooklynConfig = (Map<String, Object>) config.getStringKeyMaybe(BrooklynCampReservedKeys.BROOKLYN_CONFIG).or(MutableMap.of());
         try {
             // TODO Should use catalog's classloader, rather than Class.forName; how to get that? Should we return a future?!
-            Class<?> type = Class.forName(typeName);
+            String mappedTypeName = DeserializingClassRenamesProvider.findMappedName(typeName);
+            Class<?> type = Class.forName(mappedTypeName);
+            
             if (!Reflections.hasNoArgConstructor(type)) {
                 throw new IllegalStateException(String.format("Cannot construct %s bean: No public no-arg constructor available", type));
             }


### PR DESCRIPTION
Various fixes for things encountered (or speculatively encountered for "notifyOfInitialValue"!) when testing upgrade from an old Brooklyn to a new brooklyn.