### PR TITLE
Remove invalid characters from brooklyn.properties

### DIFF
--- a/docs/guide/start/brooklyn.properties
+++ b/docs/guide/start/brooklyn.properties
@@ -178,7 +178,7 @@ brooklyn.location.named.aws-tokyo = jclouds:aws-ec2:ap-northeast-1
 # brooklyn.location.jclouds.hpcloud-compute.credential = password
 ## where username and password are the same as logging in to the web console, and
 ## projectname can be found here: https://account.hpcloud.com/projects
-#�brooklyn.location.named.HP\ Cloud\ Arizona-1 = jclouds:hpcloud-compute:az-1.region-a.geo-1
+# brooklyn.location.named.HP\ Cloud\ Arizona-1 = jclouds:hpcloud-compute:az-1.region-a.geo-1
 # brooklyn.location.named.HP\ Cloud\ Arizona-1.imageId = az-1.region-a.geo-1/75845
 # brooklyn.location.named.HP\ Cloud\ Arizona-1.user = ubuntu
 


### PR DESCRIPTION
There were some random characters in a commented line in the file.