### PR TITLE
Update the plexus eclipse compiler to latest stable

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1883,7 +1883,7 @@
                                <dependency>
                                    <groupId>org.codehaus.plexus</groupId>
                                    <artifactId>plexus-compiler-eclipse</artifactId>
-                                   <version>2.4</version>
+                                   <version>2.6</version>
                                </dependency>
                        </dependencies>
                     </plugin>


### PR DESCRIPTION
Fixes failing builds where the compiler is looking for a non existing generated-sources/annotations folder.