### PR TITLE
VanillaWindowsProcess CatalogConfig: add priority

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
@@ -38,52 +38,66 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     ConfigKey<Collection<Integer>> REQUIRED_OPEN_LOGIN_PORTS = ConfigKeys.newConfigKeyWithDefault(
             SoftwareProcess.REQUIRED_OPEN_LOGIN_PORTS,
             ImmutableSet.of(5985, 3389));
-    ConfigKey<String> PRE_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.powershell.command",
-            "powershell command to run during the pre-install phase");
-    ConfigKey<String> POST_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("post.install.powershell.command",
-            "powershell command to run during the post-install phase");
-    ConfigKey<String> PRE_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.launch.powershell.command",
-            "powershell command to run during the pre-launch phase");
-    ConfigKey<String> POST_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("post.launch.powershell.command",
-            "powershell command to run during the post-launch phase");
-    ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",
-            "indicates that a reboot should be performed after the pre-install command is run", false);
-    ConfigKey<Boolean> INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("install.reboot.required",
-            "indicates that a reboot should be performed after the install command is run", false);
-    ConfigKey<Boolean> CUSTOMIZE_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("customize.reboot.required",
-            "indicates that a reboot should be performed after the customize command is run", false);
+    
+    @CatalogConfig(label = "Install PowerShell command", priority=5.5)
+    ConfigKey<String> INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("install.powershell.command",
+            "powershell command to run during the install phase");
+    
+    @CatalogConfig(label = "Install Command", priority=5)
+    ConfigKey<String> INSTALL_COMMAND = VanillaSoftwareProcess.INSTALL_COMMAND;
 
-    @CatalogConfig(label = "Launch Command")
-    ConfigKey<String> LAUNCH_COMMAND = VanillaSoftwareProcess.LAUNCH_COMMAND;
-
-    @CatalogConfig(label = "Launch PowerShell command")
+    @CatalogConfig(label = "Customize PowerShell command", priority=4.5)
+    ConfigKey<String> CUSTOMIZE_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("customize.powershell.command",
+            "powershell command to run during the customization phase");
+    
+    @CatalogConfig(label = "Customize command", priority=4)
+    ConfigKey<String> CUSTOMIZE_COMMAND = VanillaSoftwareProcess.CUSTOMIZE_COMMAND;
+    
+    @CatalogConfig(label = "Launch PowerShell command", priority=3.5)
     ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("launch.powershell.command",
             "command to run to launch the process");
 
-    @CatalogConfig(label = "Check Running Command")
-    ConfigKey<String> CHECK_RUNNING_COMMAND = VanillaSoftwareProcess.CHECK_RUNNING_COMMAND;
+    @CatalogConfig(label = "Launch Command", priority=3)
+    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newConfigKeyWithDefault(VanillaSoftwareProcess.LAUNCH_COMMAND, null);
 
-    @CatalogConfig(label = "Check Running PowerShell Command")
+    @CatalogConfig(label = "Check-running PowerShell Command", priority=2.5)
     ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("checkRunning.powershell.command",
             "command to determine whether the process is running");
 
-    @CatalogConfig(label = "Stop PowerShell Command")
-    ConfigKey<String> STOP_COMMAND = VanillaSoftwareProcess.STOP_COMMAND;
+    @CatalogConfig(label = "Check-running Command", priority=2)
+    ConfigKey<String> CHECK_RUNNING_COMMAND = VanillaSoftwareProcess.CHECK_RUNNING_COMMAND;
 
-    @CatalogConfig(label = "Stop Command")
+    @CatalogConfig(label = "Stop PowerShell Command", priority=1.5)
     ConfigKey<String> STOP_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("stop.powershell.command",
             "command to run to stop the process");
-    ConfigKey<String> CUSTOMIZE_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("customize.powershell.command",
-            "powershell command to run during the customization phase");
+    
+    @CatalogConfig(label = "Stop Command", priority=1)
+    ConfigKey<String> STOP_COMMAND = VanillaSoftwareProcess.STOP_COMMAND;
 
-    @CatalogConfig(label = "Install Command")
-    ConfigKey<String> INSTALL_COMMAND = VanillaSoftwareProcess.INSTALL_COMMAND;
+    ConfigKey<String> PRE_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.install.powershell.command",
+            "powershell command to run during the pre-install phase");
+    
+    ConfigKey<String> POST_INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("post.install.powershell.command",
+            "powershell command to run during the post-install phase");
 
-    @CatalogConfig(label = "Install PowerShell command")
-    ConfigKey<String> INSTALL_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("install.powershell.command",
-            "powershell command to run during the install phase");
+    ConfigKey<String> PRE_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("pre.launch.powershell.command",
+            "powershell command to run during the pre-launch phase");
+    
+    ConfigKey<String> POST_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.newStringConfigKey("post.launch.powershell.command",
+            "powershell command to run during the post-launch phase");
+
+    ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",
+            "indicates that a reboot should be performed after the pre-install command is run", false);
+    
+    ConfigKey<Boolean> INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("install.reboot.required",
+            "indicates that a reboot should be performed after the install command is run", false);
+    
+    ConfigKey<Boolean> CUSTOMIZE_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("customize.reboot.required",
+            "indicates that a reboot should be performed after the customize command is run", false);
+
     ConfigKey<Duration> REBOOT_BEGUN_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.begun.timeout",
             "duration to wait whilst waiting for a machine to begin rebooting, and thus become unavailable", Duration.TWO_MINUTES);
+    
     // TODO If automatic updates are enabled and there are updates waiting to be installed, thirty minutes may not be sufficient...
     ConfigKey<Duration> REBOOT_COMPLETED_TIMEOUT = ConfigKeys.newDurationConfigKey("reboot.completed.timeout",
             "duration to wait whilst waiting for a machine to finish rebooting, and thus to become available again", Duration.minutes(30));


### PR DESCRIPTION
Re-orders the config keys into a sensible order, and adds priority
to the CatalogConfig.

Removes the default from LAUNCH_COMMAND.

Addresses the comments in https://github.com/apache/incubator-brooklyn/pull/927