### PR TITLE
Add sequential ID number to each DynamicCluster member

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -161,6 +161,10 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
     ConfigKey<Integer> NUM_AVAILABILITY_ZONES = ConfigKeys.newIntegerConfigKey(
             "dynamiccluster.numAvailabilityZones", "number of availability zones to use (will attempt to auto-discover this number)");
 
+    @SetFromFlag("clusterMemberId")
+    ConfigKey<Integer> CLUSTER_MEMBER_ID = ConfigKeys.newIntegerConfigKey(
+            "cluster.member.id", "The unique ID number (sequential) of a member of a cluster");
+
     AttributeSensor<List<Location>> SUB_LOCATIONS = new BasicAttributeSensor<List<Location>>(
             new TypeToken<List<Location>>() {},
             "dynamiccluster.subLocations", "Locations for each availability zone to use");

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -28,16 +28,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.policy.Policy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Entities;
@@ -50,9 +51,8 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.cloud.AvailabilityZoneExtension;
+import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.stock.DelegateEntity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
@@ -67,11 +67,14 @@ import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.javalang.Reflections;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -81,11 +84,16 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 
 /**
  * A cluster of entities that can dynamically increase or decrease the number of entities.
  */
 public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicCluster {
+
+    @SuppressWarnings("serial")
+    private static final AttributeSensor<Supplier<Integer>> NEXT_CLUSTER_MEMBER_ID = Sensors.newSensor(new TypeToken<Supplier<Integer>>() {},
+            "next.cluster.member.id", "Returns the ID number of the next member to be added");
 
     // TODO better mechanism for arbitrary class name to instance type coercion
     static {
@@ -147,12 +155,22 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
         }
     };
 
+    private static class NextClusterMemberIdSupplier implements Supplier<Integer> {
+        private AtomicInteger nextId = new AtomicInteger(0);
+
+        @Override
+        public Integer get() {
+            return nextId.getAndIncrement();
+        }
+    }
+
     public DynamicClusterImpl() {
     }
 
     @Override
     public void init() {
         super.init();
+        sensors().set(NEXT_CLUSTER_MEMBER_ID, new NextClusterMemberIdSupplier());
     }
 
     @Override
@@ -765,6 +783,7 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
         Map<?,?> createFlags = MutableMap.builder()
                 .putAll(getCustomChildFlags())
                 .putAll(extraFlags)
+                .put(CLUSTER_MEMBER_ID, getAttribute(NEXT_CLUSTER_MEMBER_ID).get())
                 .build();
         if (LOG.isDebugEnabled()) {
             LOG.debug("Creating and adding a node to cluster {}({}) with properties {}", new Object[] { this, getId(), createFlags });


### PR DESCRIPTION
Each `DynamicCluster` member entity now has a `cluster.member.id` integer config value representing the order in which it was added to the cluster, starting from 0 and increasing sequentially.