### PR TITLE
Fix add-app-wizard for enums (WIP)

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/required-config-entry.html
+++ b/usage/jsgui/src/main/webapp/assets/tpl/app-add-wizard/required-config-entry.html
@@ -34,7 +34,7 @@ under the License.
             element = null;
         for (var i = 0; i < length; i++) {
           element = data.possibleValues[i]; %>
-        <option value="<%= element.value %>"><% if (data.defaultValue == element.value) { %> selected="selected"<% } %>><%= element.description %></option>
+        <option value="<%= element.value %>"<% if (data.defaultValue == element.value) { %> selected="selected"<% } %>><%= element.description %></option>
         <% } %>
       </select>
     <% } else { %>


### PR DESCRIPTION
Attempting to fix:

![screen shot 2015-10-07 at 22 53 55](https://cloud.githubusercontent.com/assets/593113/10352437/f7f3739c-6d46-11e5-9302-4171b4fdd0e5.png)

The enum drop-downs are not supposed to start with ">", and should say "Virtualization" rather than the selected= stuff.

My change reverts a change that sneaked in as part of the commit "[BROOKLYN-162] package rename to org.apache.brooklyn: software/webapp"!

However, when I just ran with it in a downstream project, it seemed not to alter the behaviour at all.

Maybe my javascript was cached or maybe the downstream build actually downloaded the latest snapshot Brooklyn (rather than taking my local build)?!