### PR TITLE
WinRM commands

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
@@ -228,7 +228,7 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
         @Override
         public T call() throws Exception {
             WinRmMachineLocation machine = EffectorTasks.getWinRmMachine(entity);
-            WinRmToolResponse response = machine.executePsScript(command);
+            WinRmToolResponse response = machine.executePsCommand(command);
             return (T)response;
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/winrm/NativeWindowsScriptRunner.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/winrm/NativeWindowsScriptRunner.java
@@ -16,14 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.entity.software.base.lifecycle;
+package org.apache.brooklyn.util.core.internal.winrm;
 
 import java.util.Map;
 
 public interface NativeWindowsScriptRunner {
 
     /** Runs a command and returns the result code */
-    int executeNativeCommand(Map flags, String windowsCommand, String summaryForLogging);
-    int executePsCommand(Map flags, String powerShellCommand, String summaryForLogging);
-    Integer executeNativeOrPsCommand(Map flags, String regularCommand, String powershellCommand, String phase, Boolean allowNoOp);
+    Integer executeNativeOrPsCommand(Map flags, String regularCommand, String powershellCommand, String summaryForLogging, Boolean allowNoOp);
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -852,7 +852,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                         String scriptContent = ResourceUtils.create(this).getResourceAsString(setupScriptItem);
                         String script = TemplateProcessor.processTemplateContents(scriptContent, getManagementContext(), substitutions);
                         if (windows) {
-                            ((WinRmMachineLocation)machineLocation).executeScript(ImmutableList.copyOf((script.replace("\r", "").split("\n"))));
+                            ((WinRmMachineLocation)machineLocation).executeCmdCommand(script);
                         } else {
                             ((SshMachineLocation)machineLocation).execCommands("Customizing node " + this, ImmutableList.of(script));
                         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -151,7 +151,7 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <maxmind.version>0.8.1</maxmind.version>
         <jna.version>4.0.0</jna.version>
-        <winrm4j.version>0.1.0</winrm4j.version>
+        <winrm4j.version>0.2.0-SNAPSHOT</winrm4j.version>
         <coverage.target>${working.dir}</coverage.target>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskQueueingContext;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.util.core.internal.winrm.NativeWindowsScriptRunner;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
 import org.apache.brooklyn.util.core.task.Tasks;

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,6 +146,23 @@ public class VanillaWindowsProcessWinrmExitStatusLiveTest {
         LOG.info("stopping entity");
         EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
         EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+    }
+
+    @Test(groups = "Live")//, expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Execution failed, invalid result 1")
+    public void testExecPsWithExitCodesWithMultiLineCommands() throws Throwable {
+        try {
+            VanillaWindowsProcess entity = app.createAndManageChild(EntitySpec.create(VanillaWindowsProcess.class)
+                    .configure(
+                            VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND,
+                        "exit 1")
+                    .configure(VanillaWindowsProcess.LAUNCH_POWERSHELL_COMMAND, "Write-Host launch")
+                    .configure(VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND, "Write-Host checkrunning")
+                    .configure(VanillaWindowsProcess.STOP_POWERSHELL_COMMAND, "Write-Host stop"));
+
+            app.start(ImmutableList.of(machine));
+        } catch (Exception e) {
+            throw Exceptions.getFirstInteresting(e);
+        }
     }
 
     @Test(groups = "Live")


### PR DESCRIPTION
Use executePsCommand and executeCmdCommand instead of executeScript

It is a small refactoring which cleans up the too simple executeScript functionality. 

The PR is dependent on https://github.com/cloudsoft/winrm4j/pull/2