### PR TITLE
Extend brooklynnode.classpath config options

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNode.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNode.java
@@ -218,7 +218,7 @@ public interface BrooklynNode extends SoftwareProcess, UsesJava {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @SetFromFlag("classpath")
-    public static final BasicAttributeSensorAndConfigKey<List<String>> CLASSPATH = new BasicAttributeSensorAndConfigKey(
+    public static final BasicAttributeSensorAndConfigKey<List> CLASSPATH = new BasicAttributeSensorAndConfigKey(
             List.class, "brooklynnode.classpath", "classpath to use, as list of URL entries", Lists.newArrayList());
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -432,18 +432,18 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
         }
     }
 
-    public List<String> getClasspath() {
-        List<String> classpath = getConfig(CLASSPATH);
+    public List getClasspath() {
+        List classpath = getConfig(CLASSPATH);
         if (classpath == null || classpath.isEmpty()) {
             classpath = getManagementContext().getConfig().getConfig(CLASSPATH);
         }
         return classpath;
     }
-    
+
     protected List<String> getEnabledHttpProtocols() {
         return getAttribute(ENABLED_HTTP_PROTOCOLS);
     }
-    
+
     protected boolean isHttpProtocolEnabled(String protocol) {
         List<String> protocols = getAttribute(ENABLED_HTTP_PROTOCOLS);
         for (String contender : protocols) {
@@ -457,7 +457,7 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
     @Override
     protected void connectSensors() {
         super.connectSensors();
-        
+
         // TODO what sensors should we poll?
         ConfigToAttributes.apply(this);
 
@@ -512,7 +512,7 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
             connectServiceUpIsRunning();
         }
     }
-    
+
     @Override
     protected void disconnectSensors() {
         super.disconnectSensors();


### PR DESCRIPTION
classpath can be a list of
- URLs or file names or directory names as before,
- maps specifying a URL and a filename,
   e.g. { "url": "http://...", "filename": "myfile.jar" }

This feature is needed to fix incorrect filename deduction in
situations where the URL does not contain an explicit jar name

Finally, the destination directory has been changed from ./lib to
./lib/dropins