### PR TITLE
Add support for correct configkey conversion from the app wizard UI

### DIFF
--- a/usage/jsgui/src/main/webapp/assets/js/view/application-add-wizard.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/application-add-wizard.js
@@ -85,6 +85,13 @@ define([
         if (entity.config && _.size(entity.config)) result["brooklyn.config"] = entity.config;
         return result;
     }
+    function getConvertedConfigValue(value) {
+        try {
+            return $.parseJSON(value);
+        } catch (e) {
+            return value;
+        }
+    }
     
     var ModalWizard = Backbone.View.extend({
         tagName:'div',
@@ -510,7 +517,7 @@ define([
         getConfigMap:function (root) {
             var map = {}
             $('.app-add-wizard-config-entry',root).each( function (index,elt) {
-                map[$('#key',elt).val()] = $('#value',elt).val()
+                map[$('#key',elt).val()] = getConvertedConfigValue($('#value',elt).val())
             })
             return map;
         },
@@ -777,21 +784,13 @@ define([
             }
         },
         getConfigMap:function() {
-            var that = this;
             var map = {};
             $('.app-add-wizard-config-entry').each( function (index,elt) {
                 map[$('#key',elt).val()] = 
                     $('#checkboxValue',elt).length ? $('#checkboxValue',elt).is(':checked') :
-                    that.getConvertedConfigValue($('#value',elt).val())
+                    getConvertedConfigValue($('#value',elt).val())
             })
             return map;
-        },
-        getConvertedConfigValue:function (value) {
-            try {
-                return $.parseJSON(value);
-            } catch (e) {
-                return value;
-            }
         },
         selectionVersion:function (event) {
             this.model.spec.set("version", $(event.currentTarget).val())

--- a/usage/jsgui/src/main/webapp/assets/js/view/application-add-wizard.js
+++ b/usage/jsgui/src/main/webapp/assets/js/view/application-add-wizard.js
@@ -777,13 +777,21 @@ define([
             }
         },
         getConfigMap:function() {
-            var map = {}
+            var that = this;
+            var map = {};
             $('.app-add-wizard-config-entry').each( function (index,elt) {
                 map[$('#key',elt).val()] = 
                     $('#checkboxValue',elt).length ? $('#checkboxValue',elt).is(':checked') :
-                    $('#value',elt).val()
+                    that.getConvertedConfigValue($('#value',elt).val())
             })
             return map;
+        },
+        getConvertedConfigValue:function (value) {
+            try {
+                return $.parseJSON(value);
+            } catch (e) {
+                return value;
+            }
         },
         selectionVersion:function (event) {
             this.model.spec.set("version", $(event.currentTarget).val())


### PR DESCRIPTION
Right now, the app wizard modal pass all additional configurations as `String`. If the entities have configkey with different types, an array of integers for example, Brooklyn will fail right after hitting the `Finish` button because it won't be able to convert `"[]"` as an array.

This will correctly convert string value, entered within the app wizard, into their corresponding Javascript type. For instance:
- `[1,2,3,4]` will be converted as a JS `Array` that contains 1, 2, 3 and 4 integers (`Number` type)
- `{"test": true}` will be converted as a JS `Object` containing the field `test` with the boolean value `true`
- `true` will be converted as a `Boolean`
- `0.123456` will be converted as a `Number`

If the conversion fails, it will fallback to the previous implementation which is taking the value as a `String`.