### PR TITLE
Windows script files

### DIFF
--- a/brooklyn-server/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
+++ b/brooklyn-server/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
@@ -88,7 +88,7 @@ public class Windows7zipBlueprintLiveTest extends AbstractBlueprintTest {
                 String password = Strings.getFirstWordAfter(winRMAddress, ":");
                 
                 WinRmTool winRmTool = WinRmTool.connect(ipPort, user, password);
-                WinRmToolResponse winRmResponse = winRmTool.executePs(ImmutableList.of("(Get-Item \"C:\\\\Program Files\\\\7-Zip\\\\7z.exe\").name"));
+                WinRmToolResponse winRmResponse = winRmTool.executePs("(Get-Item \"C:\\\\Program Files\\\\7-Zip\\\\7z.exe\").name");
                 
                 LOG.info("winRmResponse: code="+winRmResponse.getStatusCode()+"; out="+winRmResponse.getStdOut()+"; err="+winRmResponse.getStdErr());
                 return "7z.exe\r\n".equals(winRmResponse.getStdOut());

--- a/brooklyn-server/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/brooklyn-server/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -862,7 +862,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                         String scriptContent = ResourceUtils.create(this).getResourceAsString(setupScriptItem);
                         String script = TemplateProcessor.processTemplateContents(scriptContent, getManagementContext(), substitutions);
                         if (windows) {
-                            ((WinRmMachineLocation)machineLocation).executeCommand(ImmutableList.copyOf((script.replace("\r", "").split("\n"))));
+                            ((WinRmMachineLocation)machineLocation).executeCommand(script);
                         } else {
                             ((SshMachineLocation)machineLocation).execCommands("Customizing node " + this, ImmutableList.of(script));
                         }

--- a/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
+++ b/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskQueueingContext;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.location.winrm.NaiveWindowsScriptRunner;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
 import org.apache.brooklyn.util.core.task.Tasks;
@@ -51,7 +52,7 @@ public class WinRmExecuteHelper {
 
     private Task<Integer> task;
 
-    protected final NativeWindowsScriptRunner runner;
+    protected final NaiveWindowsScriptRunner runner;
     public final String summary;
 
     private String command;
@@ -62,7 +63,7 @@ public class WinRmExecuteHelper {
     protected Predicate<? super Integer> resultCodeCheck = Predicates.alwaysTrue();
     protected ByteArrayOutputStream stdout, stderr, stdin;
 
-    public WinRmExecuteHelper(NativeWindowsScriptRunner runner, String summary) {
+    public WinRmExecuteHelper(NaiveWindowsScriptRunner runner, String summary) {
         this.runner = runner;
         this.summary = summary;
     }

--- a/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
+++ b/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,6 +146,23 @@ public class VanillaWindowsProcessWinrmExitStatusLiveTest {
         LOG.info("stopping entity");
         EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
         EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+    }
+
+    @Test(groups = "Live", expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Execution failed, invalid result 1.*")
+    public void testExecPsWithExitCodesWithMultiLineCommands() throws Throwable {
+        try {
+            VanillaWindowsProcess entity = app.createAndManageChild(EntitySpec.create(VanillaWindowsProcess.class)
+                    .configure(
+                            VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND,
+                        "exit 1")
+                    .configure(VanillaWindowsProcess.LAUNCH_POWERSHELL_COMMAND, "Write-Host launch")
+                    .configure(VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND, "Write-Host checkrunning")
+                    .configure(VanillaWindowsProcess.STOP_POWERSHELL_COMMAND, "Write-Host stop"));
+
+            app.start(ImmutableList.of(machine));
+        } catch (Exception e) {
+            throw Exceptions.getFirstInteresting(e);
+        }
     }
 
     @Test(groups = "Live")

--- a/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/WindowsScriptsWinrmExitStatusLiveTest.java
+++ b/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/WindowsScriptsWinrmExitStatusLiveTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class WindowsScriptsWinrmExitStatusLiveTest {
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsScriptsWinrmExitStatusLiveTest.class);
+
+    private static final String INVALID_CMD = "thisCommandDoesNotExistAEFafiee3d";
+    
+    protected ManagementContextInternal mgmt;
+    protected MachineProvisioningLocation<WinRmMachineLocation> location;
+    protected WinRmMachineLocation machine;
+    protected VanillaWindowsProcess vanillaWindowsProcessEntity;
+    protected AbstractSoftwareProcessWinRmDriver winRmDriver;
+
+    @BeforeClass(alwaysRun=true)
+    public void setUpClass() throws Exception {
+        mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+
+        location = WindowsTestFixture.setUpWindowsLocation(mgmt);
+        machine = location.obtain(ImmutableMap.of());
+
+        vanillaWindowsProcessEntity = mgmt.getEntityManager().createEntity(EntitySpec.create(VanillaWindowsProcess.class));
+
+        winRmDriver = new VanillaWindowsProcessWinRmDriver((EntityLocal)vanillaWindowsProcessEntity, machine);
+    }
+
+    @AfterClass(alwaysRun=true)
+    public void tearDownClass() throws Exception {
+        try {
+            try {
+                if (location != null) location.release(machine);
+            } finally {
+                if (mgmt != null) Entities.destroyAll(mgmt);
+            }
+        } catch (Throwable t) {
+            LOG.error("Caught exception in tearDownClass method", t);
+        } finally {
+            mgmt = null;
+        }
+    }
+
+    @Test(groups = "Live")
+    public void testExecWithZeroExitCodes() {
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(MutableMap.of(), ImmutableList.of("echo HiWorld"), null, "working-script", false), 0, "an echo script should return zero");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(MutableMap.of(), ImmutableList.of(INVALID_CMD), null, "working-script", false), 1, "an echo script should return zero");
+    }
+
+    @Test(groups = "Live")
+    public void testExecWithNonZeroExitCodes() {
+        List<String> simpleScript = ImmutableList.of(INVALID_CMD, "exit /b %ERRORLEVEL%");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(MutableMap.of(), simpleScript, null, "non-working-script", false), 9009, "an echo script should return one (invalid command)");
+
+        List<String> simpleScript2 = ImmutableList.of("echo hi", "exit /b 333");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(MutableMap.of(), simpleScript2, null, "non-working-script", false), 333, "an echo script should return one (invalid command)");
+    }
+
+    //// https://social.technet.microsoft.com/forums/en-US/6f414857-8288-4b11-b8b0-c6fa2339ed7c/run-net-script-powershell-exit-and-published-data
+    @Test(groups = "Live")
+    public void testPsExecWithNonZeroExitCodes() {
+        List<String> simpleScript = ImmutableList.of(INVALID_CMD, "exit 444");
+
+        // in the current winrm implementation we use a cmd call to implement powershell commands
+        // If a native powershell call is made in winrm then the exit code is 1
+        // NOTE: exit code is 1 on a native powershell implementation
+        Assert.assertEquals(machine.executePsScript(simpleScript).getStatusCode(), 444, "an echo script should return one (invalid command)");
+    }
+
+    //// https://technet.microsoft.com/en-us/library/hh847796.aspx
+    @Test(groups = "Live")
+    public void testPsExecWithErrorActionPreferenceExitCodes() {
+        Map<String, Object> flags = MutableMap.of("scriptFilename", null);
+
+        List<String> simpleScript = ImmutableList.of(
+                "$ErrorActionPreference = \"Stop\"",
+                "Write-Error \"writing error\"",
+                "Write-Host goodbye");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(flags, null, simpleScript, "non-working-script", false), 1, "simple script should return 1");
+        String scriptFilename1 = (String) flags.get("scriptFilename");
+
+        Assert.assertEquals(machine.executeCommand(ImmutableMap.of(WinRmTool.PROP_EXEC_TRIES, 1), ImmutableList.of("powershell -File %TEMP%\\" + scriptFilename1)).getStatusCode(), 0, "consecutive failing commands script should return 444");
+    }
+
+    @Test(groups = "Live")
+    public void testPsExecWithConsecutiveNonZeroExitCodes() {
+        Map<String, Object> flags = MutableMap.of("scriptFilename", null);
+
+        List<String> simpleScript = ImmutableList.of(
+                "Write-Host hi",
+                "exit 111");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(flags, null, simpleScript, "non-working-script", false), 1, "simple script should return 1");
+        String scriptFilename1 = (String)flags.get("scriptFilename");
+
+        Assert.assertEquals(winRmDriver.executeCommandNoRetry("powershell -File %TEMP%\\" + scriptFilename1), 111, "consecutive failing commands script should return 111");
+
+        ////
+
+        List<String> consecutiveFailingScript = MutableList.of(
+                "Write-Host hi",
+                "& $env:temp\\" + scriptFilename1,
+                "Write-Host bye",
+                "exit 222");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(flags, null, consecutiveFailingScript, "non-working-script", false), 1, "consecutive failing commands script should return 1");
+        String scriptFilename2 = (String)flags.get("scriptFilename");
+
+        Assert.assertEquals(winRmDriver.executeCommandNoRetry("powershell -File %TEMP%\\" + scriptFilename2), 222, "consecutive failing commands script should return 222");
+
+        ////
+
+        List<String> complicatedPsScript = MutableList.of(
+                "Write-Host hi",
+                "& $env:temp\\" + scriptFilename1,
+                "If ($lastexitcode -ne 0) {",
+                "exit $lastexitcode",
+                "}",
+                "Write-Host bye",
+                "exit 333");
+        Assert.assertEquals(winRmDriver.executeNativeOrPsScript(flags, null, complicatedPsScript, "non-working-script", false), 1, "Again returns 1, but this time because it failed before bye command");
+        String scriptFilename3 = (String)flags.get("scriptFilename");
+
+        Assert.assertEquals(winRmDriver.executeCommandNoRetry("powershell -File %TEMP%\\" + scriptFilename3), 111, "consecutive failing commands script should return 444");
+    }
+}

--- a/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
+++ b/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
@@ -146,7 +146,7 @@ public class WinRmMachineLocationLiveTest {
         String remotePath = "C:\\myfile-"+Identifiers.makeRandomId(4)+".txt";
         machine.copyTo(new ByteArrayInputStream(contents.getBytes()), remotePath);
         
-        WinRmToolResponse response = machine.executeCommand("type "+remotePath);
+        WinRmToolResponse response = machine.executeCommand("type " + remotePath);
         String msg = "statusCode="+response.getStatusCode()+"; out="+response.getStdOut()+"; err="+response.getStdErr();
         assertEquals(response.getStatusCode(), 0, msg);
         assertEquals(response.getStdOut().trim(), contents, msg);
@@ -159,7 +159,7 @@ public class WinRmMachineLocationLiveTest {
             String remotePath = "C:\\myfile-"+Identifiers.makeRandomId(4)+".txt";
             machine.copyTo(localFile, remotePath);
             
-            WinRmToolResponse response = machine.executeCommand("type "+remotePath);
+            WinRmToolResponse response = machine.executeCommand("type " + remotePath);
             String msg = "statusCode="+response.getStatusCode()+"; out="+response.getStdOut()+"; err="+response.getStdErr();
             assertEquals(response.getStatusCode(), 0, msg);
             assertEquals(response.getStdOut().trim(), contents, msg);
@@ -182,25 +182,18 @@ public class WinRmMachineLocationLiveTest {
     public void testExecMultiLineScript() throws Exception {
         assertExecSucceeds("echo first" + "\r\n" + "echo second", "first"+"\r\n"+"second", "");
     }
-    
-    @Test(groups={"Live"})
-    public void testExecMultiPartScript() throws Exception {
-        assertExecSucceeds(ImmutableList.of("echo first", "echo second"), "first "+"\r\n"+"second", "");
-    }
-    
+
     @Test(groups="Live")
     public void testExecFailingScript() throws Exception {
         final String INVALID_CMD = "thisCommandDoesNotExistAEFafiee3d";
         
         // Single commands
         assertExecFails(INVALID_CMD);
-        assertExecFails(ImmutableList.of(INVALID_CMD));
     }
 
     @Test(groups="Live")
     public void testExecScriptExit0() throws Exception {
         assertExecSucceeds("exit /B 0", "", "");
-        assertExecSucceeds(ImmutableList.of("exit /B 0"), "", "");
     }
 
     /*
@@ -216,7 +209,6 @@ public class WinRmMachineLocationLiveTest {
     public void testExecScriptExit1() throws Exception {
         // Single commands
         assertExecFails("exit /B 1");
-        assertExecFails(ImmutableList.of("exit /B 1"));
     }
 
     @Test(groups="Live")
@@ -334,7 +326,7 @@ public class WinRmMachineLocationLiveTest {
     
     @Test(groups="Live")
     public void testExecPsMultiPartScript() throws Exception {
-        assertExecPsSucceeds(ImmutableList.of("Write-Host first", "Write-Host second"), "first"+"\n"+"second", "");
+        assertExecPsSucceeds("Write-Host first" + "\r\n" +  "Write-Host second", "first"+"\n"+"second", "");
     }
 
     @Test(groups="Live")
@@ -364,7 +356,7 @@ public class WinRmMachineLocationLiveTest {
         String scriptPath = "C:\\myscript-"+Identifiers.makeRandomId(4)+".bat";
         machine.copyTo(new ByteArrayInputStream(script.getBytes()), scriptPath);
 
-        WinRmToolResponse response = machine.executePsScript("& '"+scriptPath+"'");
+        WinRmToolResponse response = machine.executePsScript("& '" + scriptPath + "'");
         String msg = "statusCode="+response.getStatusCode()+"; out="+response.getStdOut()+"; err="+response.getStdErr();
         assertEquals(response.getStatusCode(), 3, msg);
     }
@@ -456,7 +448,7 @@ public class WinRmMachineLocationLiveTest {
     @Test(groups="Live")
     public void testConfirmUseOfErrorActionPreferenceDoesNotCauseErr() throws Exception {
         // Confirm that ErrorActionPreference=Stop does not itself cause a failure, and still get output on success.
-        assertExecPsSucceeds(ImmutableList.of(PS_ERR_ACTION_PREF_EQ_STOP, "Write-Host myline"), "myline", "");
+        assertExecPsSucceeds(PS_ERR_ACTION_PREF_EQ_STOP + "\r\n" + "Write-Host myline", "myline", "");
     }
 
     /*
@@ -485,11 +477,10 @@ public class WinRmMachineLocationLiveTest {
     public void testExecFailingPsScript() throws Exception {
         // Single commands
         assertExecPsFails(INVALID_CMD);
-        assertExecPsFails(ImmutableList.of(INVALID_CMD));
-        
+
         // Multi-part commands
-        assertExecPsFails(ImmutableList.of(PS_ERR_ACTION_PREF_EQ_STOP, "Write-Host myline", INVALID_CMD));
-        assertExecPsFails(ImmutableList.of(PS_ERR_ACTION_PREF_EQ_STOP, INVALID_CMD, "Write-Host myline"));
+        assertExecPsFails(Joiner.on("\r\n").join(ImmutableList.of(PS_ERR_ACTION_PREF_EQ_STOP, "Write-Host myline", INVALID_CMD)));
+        assertExecPsFails(Joiner.on("\r\n").join(ImmutableList.of(PS_ERR_ACTION_PREF_EQ_STOP, INVALID_CMD, "Write-Host myline")));
     }
 
     @Test(groups={"Live", "Acceptance"})

--- a/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/NaiveWindowsScriptRunner.java
+++ b/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/NaiveWindowsScriptRunner.java
@@ -16,14 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.entity.software.base.lifecycle;
+package org.apache.brooklyn.location.winrm;
 
+import java.io.InputStream;
 import java.util.Map;
 
-public interface NativeWindowsScriptRunner {
+/** Marks something which can run scripts. Called "Naive" because it hides too much of the complexity,
+ * about script execution and other command-related tasks (put, etc).
+ */
+public interface NaiveWindowsScriptRunner {
 
     /** Runs a command and returns the result code */
     int executeNativeCommand(Map flags, String windowsCommand, String summaryForLogging);
     int executePsCommand(Map flags, String powerShellCommand, String summaryForLogging);
-    Integer executeNativeOrPsCommand(Map flags, String regularCommand, String powershellCommand, String phase, Boolean allowNoOp);
+    Integer executeNativeOrPsCommand(Map flags, String regularCommand, String powershellCommand, String summaryForLogging, Boolean allowNoOp);
+
+    int copyTo(InputStream source, String destination);
 }

--- a/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmScriptTool.java
+++ b/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmScriptTool.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.internal.winrm;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.location.winrm.NaiveWindowsScriptRunner;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.internal.ssh.ShellTool;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Identifiers;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Time;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithDefault;
+import static org.apache.brooklyn.util.core.internal.ssh.ShellAbstractTool.getOptionalVal;
+
+/**
+ * Implemented like SshCliTool
+ */
+// TODO Use a general interface for SshTool and WinRmScriptTool with
+public class WinRmScriptTool {
+    public static final ConfigKey<String> PROP_SCRIPT_DIR = newConfigKeyWithDefault(ShellTool.PROP_SCRIPT_DIR, "The directory where the script should be uploaded. It is an env variable.", "temp");
+    public static final ConfigKey<String> PROP_SUMMARY = ShellTool.PROP_SUMMARY;
+
+    private static final String SCRIPT_TEMP_DIR_VARIABLE = "BROOKLYN_TEMP_SCRIPT_DIR";
+
+    private String scriptNameWithoutExtension;
+    private String scriptDir;
+    private String summary;
+    private NaiveWindowsScriptRunner scriptRunner;
+
+    public WinRmScriptTool(Map<String, ?> props, NaiveWindowsScriptRunner scriptRunner) {
+        this.scriptDir = getOptionalVal(props, PROP_SCRIPT_DIR);
+
+        String summary = getOptionalVal(props, PROP_SUMMARY);
+        if (summary != null) {
+            summary = Strings.makeValidFilename(summary);
+            if (summary.length() > 30)
+                summary = summary.substring(0, 30);
+        }
+
+        this.summary = summary;
+        this.scriptNameWithoutExtension = "brooklyn-" +
+                Time.makeDateStampString() + "-" + Identifiers.makeRandomId(4) +
+                (Strings.isBlank(summary) ? "" : "-" + summary);
+
+        this.scriptRunner = scriptRunner;
+    }
+
+    public static String psStringExpressionToBatchVariable(String psString, String batchVariable) {
+        return "for /f \"delims=\" %%i in ('powershell -noprofile \\'Write-Host \""+ psString +"\"\\') do @set "+batchVariable+ "=%i";
+    }
+
+    private String psExtension(String filename) {
+        return filename + ".ps1";
+    }
+
+    private String batchExtension(String filename) {
+        return filename + ".bat";
+    }
+
+    public int execPsScript(List<String> psCommands) {
+        return execPsScript(ImmutableMap.<String, Object>of(), psCommands);
+    }
+
+    public int execPsScript(Map<String, Object> flags, List<String> commands) {
+        byte[] scriptBytes = toScript(commands).getBytes();
+        String scriptFilename = psExtension(scriptNameWithoutExtension);
+        if (flags.containsKey("scriptFilename"))
+            flags.put("scriptFilename", scriptFilename);
+        String scriptPath = Os.mergePathsWin("$env:"+scriptDir, scriptFilename);
+        scriptRunner.copyTo(new ByteArrayInputStream(scriptBytes), scriptPath);
+        return scriptRunner.executeNativeOrPsCommand(MutableMap.of(), null, "& " + scriptPath, summary, false);
+    }
+
+    public int execNativeScript(List<String> commands) {
+        return execNativeScript(ImmutableMap.<String, Object>of(), commands);
+    }
+
+    public int execNativeScript(Map<String, Object> flags, List<String> commands) {
+        byte[] scriptBytes = toScript(commands).getBytes();
+        String scriptFilename = batchExtension(scriptNameWithoutExtension);
+        if (flags.containsKey("scriptFilename"))
+            flags.put("scriptFilename", scriptFilename);
+        scriptRunner.copyTo(new ByteArrayInputStream(scriptBytes), Os.mergePathsWin("$env:"+scriptDir, scriptFilename));
+        String scriptPath = Os.mergePathsWin("%"+scriptDir+"%", scriptFilename);
+        return scriptRunner.executeNativeOrPsCommand(MutableMap.of(), scriptPath, null, summary, false);
+    }
+
+    private String toScript(List<String> commands) {
+        return Joiner.on("\r\n").join(commands);
+    }
+}

--- a/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -67,7 +67,26 @@ public interface WinRmTool {
             1024);
 
     /**
-     * @deprecated since 0.9.0; use {@link #executeCommand(List)} to avoid ambiguity between native command and power shell.
+     * Executes a Native Windows command.
+     * It is creating a new Shell on the destination host each time it is being called.
+     * @param command
+     * @since 0.2
+     */
+    WinRmToolResponse executeCommand(String command);
+
+    /**
+     * Executes a Power Shell command.
+     * It is creating a new Shell on the destination host each time it is being called.
+     * @param psCommand
+     * @since 0.2
+     */
+    WinRmToolResponse executePsCommand(String psCommand);
+
+    /**
+     * Execute a list of Windows Native commands as one command.
+     * The method translates the list of commands to a single String command with a <code>"\r\n"</code> delimiter and a terminating one.
+     * @param commands
+     * @deprecated since 0.2; Use the {@link #executeCommand(String)} instead and transform your commands list explicitly
      */
     @Deprecated
     WinRmToolResponse executeScript(List<String> commands);
@@ -77,6 +96,13 @@ public interface WinRmTool {
      */
     WinRmToolResponse executeCommand(List<String> commands);
 
+    /**
+     * Execute a list of Power Shell commands as one command.
+     * The method translates the list of commands to a single String command with a <code>"\r\n"</code> delimiter and a terminating one.
+     * @param commands
+     * @deprecated since 0.2; Use the {@link #executePsCommand(String)} instead and transform your commands list explicitly
+     */
+    @Deprecated
     WinRmToolResponse executePs(List<String> commands);
     
     WinRmToolResponse copyToServer(InputStream source, String destination);

--- a/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
+++ b/brooklyn-server/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
@@ -82,7 +82,25 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
         execRetryDelay = getRequiredConfig(config, PROP_EXEC_RETRY_DELAY);
         logCredentials = getRequiredConfig(config, LOG_CREDENTIALS);
     }
-    
+
+    @Override
+    public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse executeCommand(final String command) {
+        return exec(new Function<io.cloudsoft.winrm4j.winrm.WinRmTool, io.cloudsoft.winrm4j.winrm.WinRmToolResponse>() {
+            @Override public WinRmToolResponse apply(io.cloudsoft.winrm4j.winrm.WinRmTool tool) {
+                return tool.executeCommand(command);
+            }
+        });
+    }
+
+    @Override
+    public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse executePsCommand(final String psCommand) {
+        return exec(new Function<io.cloudsoft.winrm4j.winrm.WinRmTool, io.cloudsoft.winrm4j.winrm.WinRmToolResponse>() {
+            @Override public WinRmToolResponse apply(io.cloudsoft.winrm4j.winrm.WinRmTool tool) {
+                return tool.executePs(psCommand);
+            }
+        });
+    }
+
     @Override
     public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse executeCommand(final List<String> commands) {
         return exec(new Function<io.cloudsoft.winrm4j.winrm.WinRmTool, io.cloudsoft.winrm4j.winrm.WinRmToolResponse>() {

--- a/brooklyn-server/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
+++ b/brooklyn-server/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
@@ -204,6 +204,17 @@ public class Os {
         return Urls.mergePaths(items);
     }
 
+    public static String mergePathsWin(String... items) {
+        char separatorChar = '\\';
+        StringBuilder result = new StringBuilder();
+        for (String item: items) {
+            if (Strings.isEmpty(item)) continue;
+            if (result.length() > 0 && !isSeparator(result.codePointAt(result.length()-1))) result.append(separatorChar);
+            result.append(item);
+        }
+        return result.toString();
+    }
+
     /** merges paths using forward slash as the "local OS file separator", because it is recognised on windows,
      * making paths more consistent and avoiding problems with backslashes being escaped.
      * empty segments are omitted. */


### PR DESCRIPTION
The PR includes #947 and it is
Dependent on cloudsoft/winrm4j#2

Introduces support for executing multiline commands from a script. This is needed so we can have more control over how commands are executed and catch properly their exit code.
Just like in ssh it uploads multiline commands into a script file on the machine and it is executing it from there.
Multiline commands into scripts is available only in WinRmMachineLocation. If we add it to AbstractSoftwareProcessWinRmDriver it will allow writing more complicated Windows Entities.

The most important part here is that I wrote Live tests for executing scripts so we can advice users better how to write Windows scripts properly.
