### PR TITLE
Amend text in creating-yaml.md

### DIFF
--- a/docs/guide/yaml/creating-yaml.md
+++ b/docs/guide/yaml/creating-yaml.md
@@ -31,10 +31,10 @@ Here's a very simple YAML blueprint plan, to explain the structure:
 * The `services` block takes a list of the typed services we want to deploy.
   This is the meat of the blueprint plan, as you'll see below.
 
-Finally, that clipboard in the corner lets you easily copy-and-paste into the web-console:
+Finally, the clipboard in the top-right corner of the example plan box above (hover your cursor over the box)  lets you easily copy-and-paste into the web-console:
 simply [download and launch]({{ site.path.guide }}/start/running.html) Brooklyn,
-then in the "Add Application" dialog at the web console
-(usually [http://127.0.0.1:8081/](http://127.0.0.1:8081/). 
+then in the "Create Application" dialog at the web console
+(usually [http://127.0.0.1:8081/](http://127.0.0.1:8081/), paste the copied YAML into the "Yaml" tab of the dialog and press "Finish". 
 There are several other ways to deploy, including `curl` and via the command-line,
 and you can configure users, https, persistence, and more, 
 as described [in the ops guide](../ops/).


### PR DESCRIPTION
Amended paragraph in section "The Basic Structure" to clarify reference to the copy icon and to add some apparently missing text.