### PR TITLE
Add description for configuring passwordless sudo to localhost location.

### DIFF
--- a/docs/guide/ops/locations/index.md
+++ b/docs/guide/ops/locations/index.md
@@ -357,6 +357,18 @@ brooklyn.location.localhost.privateKeyPassphrase=s3cr3tPASSPHRASE
 
 If you encounter issues or for more information, see [SSH Keys Localhost Setup](ssh-keys.html#localhost-setup). 
 
+If you are normally prompted for a password when executing `sudo` commands, passwordless `sudo` must also be enabled.  To enable passwordless `sudo` for your account, a line must be added to the system `/etc/sudoers` file.  To edit the file, use the `visudo` command:
+{% highlight bash %}
+sudo visudo
+{% endhighlight %}
+Add this line at the bottom of the file, replacing `username` with your own user:
+{% highlight bash %}
+username ALL=(ALL) NOPASSWD: ALL
+{% endhighlight %}
+If executing the following command does not ask for your password, then `sudo` should be setup correctly:
+{% highlight bash %}
+sudo ls
+{% endhighlight %}
 
 
 ### BYON


### PR DESCRIPTION
The current Locations page provides information on setting up passwordless SSH
and says that passwordless sudo is required, but does not tell the user how to setup.