### PR TITLE
Update ‘xml-apis’ dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -110,6 +110,10 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
 
@@ -130,10 +134,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -140,7 +140,6 @@
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <jetty-orbit-javax-servlet.version>3.0.0.v201112011016</jetty-orbit-javax-servlet.version>
         <jcommander.version>1.27</jcommander.version>
-        <xml-apis.version>1.3.04</xml-apis.version>
         <jsr250-api.version>1.0</jsr250-api.version>
         <guice.version>3.0</guice.version>
         <javax-inject.version>1</javax-inject.version>
@@ -344,11 +343,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>${httpclient.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>${xml-apis.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.annotation</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -140,7 +140,7 @@
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <jetty-orbit-javax-servlet.version>3.0.0.v201112011016</jetty-orbit-javax-servlet.version>
         <jcommander.version>1.27</jcommander.version>
-        <xml-apis.version>1.0.b2</xml-apis.version>
+        <xml-apis.version>1.3.04</xml-apis.version>
         <jsr250-api.version>1.0</jsr250-api.version>
         <guice.version>3.0</guice.version>
         <javax-inject.version>1</javax-inject.version>

--- a/software/webapp/pom.xml
+++ b/software/webapp/pom.xml
@@ -117,10 +117,6 @@
             <artifactId>groovy-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>


### PR DESCRIPTION
Resolves Eclipse build errors in `XmlPlanToSpecTransformer`. Command-line Maven build was happy, possibly due to later version accidentally getting picked up via transitive dependency.