### PR TITLE
Fix CreateUserPolicy for SuSe Linux

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.policy.jclouds.os;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -150,14 +151,14 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
         String cmd = adminAccess.render(scriptOsFamily);
 
         // Exec command to create the user
-        int result = machine.execScript(ImmutableMap.of(SshTool.PROP_RUN_AS_ROOT.getName(), true), "create-user-"+user, ImmutableList.of(cmd));
+        int result = machine.execScript(ImmutableMap.of(SshTool.PROP_RUN_AS_ROOT.getName(), true), "create-user-"+user, ImmutableList.of(cmd), getEnv());
         if (result != 0) {
             throw new IllegalStateException("Failed to auto-generate user, using command "+cmd);
         }
 
         // Exec command to grant password-access to sshd (which may have been disabled earlier).
         cmd = new SshdConfig(ImmutableMap.of("PasswordAuthentication", "yes")).render(scriptOsFamily);
-        result = machine.execScript(ImmutableMap.of(SshTool.PROP_RUN_AS_ROOT.getName(), true), "create-user-"+user, ImmutableList.of(cmd));
+        result = machine.execScript(ImmutableMap.of(SshTool.PROP_RUN_AS_ROOT.getName(), true), "create-user-"+user, ImmutableList.of(cmd), getEnv());
         if (result != 0) {
             throw new IllegalStateException("Failed to enable ssh-login-with-password, using command "+cmd);
         }
@@ -169,12 +170,18 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
                             user+" ALL = (ALL) NOPASSWD:ALL\n"+
                             "END_OF_JCLOUDS_FILE\n",
                     "chmod 0440 /etc/sudoers");
-            result = machine.execScript(ImmutableMap.of(SshTool.PROP_RUN_AS_ROOT.getName(), true), "add-user-to-sudoers-"+user, cmds);
+            result = machine.execScript(ImmutableMap.of(SshTool.PROP_RUN_AS_ROOT.getName(), true), "add-user-to-sudoers-"+user, cmds, getEnv());
             if (result != 0) {
-                throw new IllegalStateException("Failed to auto-generate user, using command "+cmd);
+                throw new IllegalStateException("Failed to auto-generate user, using command "+cmds);
             }
         }
         
         ((EntityLocal)entity).sensors().set(VM_USER_CREDENTIALS, creds);
+    }
+
+    private Map<String, String> getEnv() {
+        final String SBIN_PATH = "$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+        return ImmutableMap.<String, String>of("PATH", SBIN_PATH);
     }
 }

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeSshDriver.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
 import static org.apache.brooklyn.util.ssh.BashCommands.INSTALL_CURL;
 import static org.apache.brooklyn.util.ssh.BashCommands.INSTALL_TAR;
 import static org.apache.brooklyn.util.ssh.BashCommands.addSbinPathCommand;
+import static org.apache.brooklyn.util.ssh.BashCommands.sbinPath;
 import static org.apache.brooklyn.util.ssh.BashCommands.alternatives;
 import static org.apache.brooklyn.util.ssh.BashCommands.chainGroup;
 import static org.apache.brooklyn.util.ssh.BashCommands.commandToDownloadUrlAs;
@@ -63,7 +64,6 @@ import com.google.common.collect.Lists;
 public class RiakNodeSshDriver extends JavaSoftwareProcessSshDriver implements RiakNodeDriver {
 
     private static final Logger LOG = LoggerFactory.getLogger(RiakNodeSshDriver.class);
-    private static final String sbinPath = "$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
     private static final String INSTALLING_FALLBACK = INSTALLING + "_fallback";
 
     public RiakNodeSshDriver(final RiakNodeImpl entity, final SshMachineLocation machine) {
@@ -170,7 +170,7 @@ public class RiakNodeSshDriver extends JavaSoftwareProcessSshDriver implements R
         }
         String apt = chainGroup(
                 //debian fix
-                "export PATH=" + sbinPath,
+                addSbinPathCommand(),
                 "which apt-get",
                 ok(sudo("apt-get -y --allow-unauthenticated install logrotate libpam0g-dev libssl0.9.8")),
                 "export OS_NAME=" + Strings.toLowerCase(osDetails.getName()),
@@ -602,7 +602,7 @@ public class RiakNodeSshDriver extends JavaSoftwareProcessSshDriver implements R
     }
 
     private void addRiakOnPath(ScriptHelper scriptHelper) {
-        Map<String, String> newPathVariable = ImmutableMap.of("PATH", sbinPath);
+        Map<String, String> newPathVariable = ImmutableMap.of("PATH", sbinPath());
 //        log.warn("riak command not found on PATH. Altering future commands' environment variables from {} to {}", getShellEnvironment(), newPathVariable);
         scriptHelper.environmentVariablesReset(newPathVariable);
     }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
@@ -138,7 +138,11 @@ public class BashCommands {
 //    }
 
     public static String addSbinPathCommand() {
-        return "export PATH=$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+        return "export PATH=" + sbinPath();
+    }
+
+    public static String sbinPath() {
+        return "$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
     }
 
     /** executes a command, then as user tees the output to the given file. 


### PR DESCRIPTION
- Sudo is compiled with --without-secure-path on Suse
- Brooklyn uses sudo with the -E parameter which preserves the
  user environment
- CreateUserPolicy needs commands only available on the secure path
  locations