### PR TITLE
With Clocker microservice only one security group on AWS for customizer

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
@@ -266,33 +266,33 @@ public class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLocation
         Set<SecurityGroup> groupsOnNode = securityApi.listSecurityGroupsForNode(nodeId);
         SecurityGroup unique;
         if (locationId.equals("aws-ec2")) {
-            if (groupsOnNode.size() != 2) {
-                LOG.warn("Expected to find two security groups on node {} in app {} (one shared, one unique). Found {}: {}",
-                        new Object[]{nodeId, applicationId, groupsOnNode.size(), groupsOnNode});
-                return null;
-            }
-            String expectedSharedName = getNameForSharedSecurityGroup();
-            Iterator<SecurityGroup> it = groupsOnNode.iterator();
-            SecurityGroup shared = it.next();
-            if (shared.getName().endsWith(expectedSharedName)) {
-                unique = it.next();
+            if (groupsOnNode.size() == 2) {
+                String expectedSharedName = getNameForSharedSecurityGroup();
+                Iterator<SecurityGroup> it = groupsOnNode.iterator();
+                SecurityGroup shared = it.next();
+                if (shared.getName().endsWith(expectedSharedName)) {
+                    unique = it.next();
+                } else {
+                    unique = shared;
+                    shared = it.next();
+                }
+                if (!shared.getName().endsWith(expectedSharedName)) {
+                    LOG.warn("Couldn't determine which security group is shared between instances in app {}. Expected={}, found={}",
+                            new Object[]{ applicationId, expectedSharedName, groupsOnNode });
+                    return null;
+                }
+                // Shared entry might be missing if Brooklyn has rebound to an application
+                SecurityGroup old = sharedGroupCache.asMap().putIfAbsent(shared.getLocation(), shared);
+                LOG.info("Loaded unique security group for node {} (in {}): {}",
+                        new Object[]{nodeId, applicationId, unique});
+                if (old == null) {
+                    LOG.info("Proactively set shared group for app {} to: {}", applicationId, shared);
+                }
+                return unique;
             } else {
-                unique = shared;
-                shared = it.next();
+                LOG.warn("Expected to find two security groups on node {} in app {} (one shared, one unique). Found {}: {}",
+                        new Object[]{ nodeId, applicationId, groupsOnNode.size(), groupsOnNode });
             }
-            if (!shared.getName().endsWith(expectedSharedName)) {
-                LOG.warn("Couldn't determine which security group is shared between instances in app {}. Expected={}, found={}",
-                        new Object[]{applicationId, expectedSharedName, groupsOnNode});
-                return null;
-            }
-            // Shared entry might be missing if Brooklyn has rebound to an application
-            SecurityGroup old = sharedGroupCache.asMap().putIfAbsent(shared.getLocation(), shared);
-            LOG.info("Loaded unique security group for node {} (in {}): {}",
-                    new Object[]{nodeId, applicationId, unique});
-            if (old == null) {
-                LOG.info("Proactively set shared group for app {} to: {}", applicationId, shared);
-            }
-            return unique;
         }
         return Iterables.getOnlyElement(groupsOnNode);
     }


### PR DESCRIPTION
Will warn if two AWS security groups not found, but tries to return the single group. Throws `IllegalArgumentException` if zero or more than two.