### PR TITLE
Prevent DynamicCluster NPE when subclasses have not called super.init()

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBReplicaSetImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBReplicaSetImpl.java
@@ -137,6 +137,7 @@ public class MongoDBReplicaSetImpl extends DynamicClusterImpl implements MongoDB
     
     @Override
     public void init() {
+        super.init();
         enrichers().add(Enrichers.builder()
                 .aggregating(MongoDBAuthenticationMixins.ROOT_USERNAME)
                 .publishing(MongoDBAuthenticationMixins.ROOT_USERNAME)


### PR DESCRIPTION
The `NEXT_CLUSTER_MEMBER_ID` attribute was uninitialised, causing an exception in `addNode`.