### PR TITLE
shortened sensor period in netcat with client yaml example

### DIFF
--- a/docs/guide/yaml/custom-entities.md
+++ b/docs/guide/yaml/custom-entities.md
@@ -97,6 +97,7 @@ so that the `$message` we passed above gets logged and reported back:
       - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
         brooklyn.config:
           name: output.last
+          period: 1s
           command: tail -1 server-input
 
 This is still a simple example, but worth going through carefully.

--- a/docs/guide/yaml/example_yaml/vanilla-bash-netcat-w-client.yaml
+++ b/docs/guide/yaml/example_yaml/vanilla-bash-netcat-w-client.yaml
@@ -32,11 +32,13 @@ services:
   - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
     brooklyn.config:
       name: output.last
+      period: 1s
       command: tail -1 server-input
       
   - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
     brooklyn.config:
       name: output.all
+      period: 1s
       command: cat server-input
 
 # a client to hit netcat


### PR DESCRIPTION
Set the sensor periods to 1 sec, the default 5 minute sensor period is too long for this example. 