### PR TITLE
Fix: SetHostnameCustomizer error handling

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/SetHostnameCustomizerTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/SetHostnameCustomizerTest.java
@@ -19,17 +19,32 @@
 package org.apache.brooklyn.entity.machine;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
 
-import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.location.MachineLocation;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.StringPredicates;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Functions;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -42,7 +57,7 @@ public class SetHostnameCustomizerTest extends BrooklynAppUnitTestSupport {
         super.setUp();
         customizer = new SetHostnameCustomizer(ConfigBag.newInstance());
     }
-    
+
     @Test
     public void testGeneratedHostnameUsesPrivateIp() throws Exception {
         SshMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
@@ -76,12 +91,67 @@ public class SetHostnameCustomizerTest extends BrooklynAppUnitTestSupport {
         
         assertEquals(customizer.generateHostname(machine), "ip-none-"+machine.getId());
     }
+    
+    @Test
+    public void testCustomizerIgnoresNonSshMachines() throws Exception {
+        WinRmMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(WinRmMachineLocation.class)
+                .configure("address", "4.3.2.1"));
+        
+        // Confirm not called (as that would cause error); and visual inspection that logs a nice message.
+        customizer.customize(machine);
+    }
+    
+    @Test
+    public void testCustomizerIgnoresNonMatchingMachine() throws Exception {
+        SshMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocationThrowsException.class)
+                .configure("address", "4.3.2.1"));
+
+        customizer = new SetHostnameCustomizer(ConfigBag.newInstance()
+                .configure(SetHostnameCustomizer.MACHINE_FILTER, Predicates.not(Predicates.<MachineLocation>equalTo(machine))));
+
+        // Confirm not called (as that would cause error); and visual inspection that logs a nice message.
+        customizer.customize(machine);
+    }
+    
+    @Test
+    public void testCustomizerPropagatesException() throws Exception {
+        SshMachineLocation machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocationThrowsException.class)
+                .configure("address", "4.3.2.1"));
+        
+        FixedListMachineProvisioningLocation<?> provisioningLoc = mgmt.getLocationManager().createLocation(LocationSpec.create(FixedListMachineProvisioningLocation.class)
+                .configure("machines", MutableSet.of(machine)));
+
+        MachineEntity entity = app.createAndManageChild(EntitySpec.create(MachineEntity.class)
+                .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true)
+                .configure(MachineEntity.PROVISIONING_PROPERTIES.subKey(JcloudsLocation.MACHINE_LOCATION_CUSTOMIZERS.getName()), ImmutableSet.of(customizer)));
+
+        try {
+            entity.start(ImmutableList.of(provisioningLoc));
+            fail();
+        } catch (RuntimeException e) {
+            if (Exceptions.getFirstThrowableMatching(e, Predicates.compose(StringPredicates.containsLiteral("simulated failure"), Functions.toStringFunction())) == null) {
+                throw e;
+            };
+            assertFalse(Machines.findUniqueMachineLocation(entity.getLocations(), SshMachineLocation.class).isPresent());
+        }
+        
+    }
+    
     public static class SshMachineLocationWithNoPublicIps extends SshMachineLocation {
         public SshMachineLocationWithNoPublicIps() {
         }
         @Override
         public Set<String> getPublicAddresses() {
             return ImmutableSet.<String>of();
+        }
+    }
+    
+    public static class SshMachineLocationThrowsException extends SshMachineLocation {
+        public SshMachineLocationThrowsException() {
+        }
+        @Override
+        public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
+            throw new RuntimeException("simulated failure");
         }
     }
 }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/Exceptions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/Exceptions.java
@@ -124,6 +124,11 @@ public class Exceptions {
         return (T) Iterables.tryFind(getCausalChain(from), instanceOf(clazz)).orNull();
     }
 
+    /** returns the first exception that matches the filter, or null */
+    public static Throwable getFirstThrowableMatching(Throwable from, Predicate<? super Throwable> filter) {
+        return Iterables.tryFind(getCausalChain(from), filter).orNull();
+    }
+
     /** returns the first exception in the call chain which is not of common uninteresting types
      * (ie excluding ExecutionException and PropagatedRuntimeExceptions); 
      * or the original throwable if all are uninteresting 


### PR DESCRIPTION
Adds support for MACHINE_FILTER, so you can tell it not to run against windows machines etc. Default is only to run against `SshMachineLocation` machines.

Also adds some tests for Exceptions (as I added an extra utility method there, to make my test easier to write).