### PR TITLE
Ignore Groovy plugin in Eclipse build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -265,5 +265,34 @@
                 </dependencies>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <versionRange>[3.3,)</versionRange>
+                                        <goals>
+                                            <goal>testCompile</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -255,12 +255,12 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>2.9.0-01</version>
+                        <version>2.9.1-01</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>2.3.4-01</version>
+                        <version>2.4.3-01</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/docs/guide/dev/env/ide/eclipse.include.md
+++ b/docs/guide/dev/env/ide/eclipse.include.md
@@ -1,13 +1,6 @@
-
-- Maven Plugin: m2e from [download.eclipse.org/technology/m2e/releases](http://download.eclipse.org/technology/m2e/releases), or for kepler [http://download.eclipse.org/releases/kepler](http://download.eclipse.org/releases/kepler)
-  (typically bundled with Eclipse or available in the default update site set)
-
-- Git Plugin: egit from [download.eclipse.org/egit/updates](http://download.eclipse.org/egit/updates)
-  (typically bundled with Eclipse or available in the default update site set)
-
-- Groovy Plugin: GRECLIPSE from 
-  [dist.springsource.org/release/GRECLIPSE/e4.3/](http://dist.springsource.org/release/GRECLIPSE/e4.3/);
-  Be sure to include Groovy 2.3.4 compiler support and Maven-Eclipse (m2e) support. 
+- Groovy Plugin: GRECLIPSE from
+  [dist.springsource.org/snapshot/GRECLIPSE/e4.5/](http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/);
+  Be sure to include Groovy 2.3 compiler support and Maven-Eclipse (m2e) support.
   More details including download sites for other versions can be found at the [Groovy Eclipse Plugin site](http://groovy.codehaus.org/Eclipse+Plugin).
 
 - TestNG Plugin: beust TestNG from [beust.com/eclipse](http://beust.com/eclipse)

--- a/docs/guide/dev/env/ide/index.md
+++ b/docs/guide/dev/env/ide/index.md
@@ -4,7 +4,7 @@ title: IDE Setup
 toc: /guide/toc.json
 ---
 
-Gone are the days when IDE integration always just works...  Maven and Eclipse fight, 
+Gone are the days when IDE integration always just works...  Maven and Eclipse fight,
 neither quite gets along perfectly with Groovy,
 git branch switches (sooo nice) can be slow, etc etc.
 
@@ -13,40 +13,39 @@ making it much easier to run tests and debug.
 
 As a general tip, don't always trust the IDE to build correctly; if you hit a snag,
 do a command-line ``mvn clean install`` (optionally with ``-DskipTests``)
-then refresh the project. 
+then refresh the project.
 
 See instructions below for specific IDEs.
 
 
 ## Eclipse
 
-If you're an Eclipse user, you'll probably want the Maven (m2e) plugin
-and the Groovy Eclipse plugin (used for testing and examples primarily).
-You may also want Git and TestNG plugins.
+The default Eclipse downloads already include all of the plugins needed for
+working with the Brooklyn project. Optionally you can install the
+Groovy and TestNG plugins, but they are not required for building the project.
 You can install these using Help -> Install New Software, or from the Eclipse Marketplace:
 
 {% readj eclipse.include.md %}
 
-As of this writing, Eclipse 4.2 and Eclipse 4.3 are commonly used, 
-and the codebase can be imported (Import -> Existing Maven Projects) 
+As of this writing, Eclipse 4.5 and Eclipse 4.4 are commonly used,
+and the codebase can be imported (Import -> Existing Maven Projects)
 and successfully built and run inside an IDE.
 However there are quirks, and mileage may vary.
 
 If you encounter issues, the following hints may be helpful:
 
-* If you attempt to import projects before the plugins are installed, you may encounter errors such as 
-  '``No marketplace entries found to handle maven-compiler-plugin:2.3.2:compile in Eclipse``',
-  and the projects will not be recognized as java projects. If you do, simply cancel the import 
-  (or delete the imported projects if they have been imported) and install the plugins as described above.
-  If you have installed plugins from alternative locations, remove them and re-install them from the locations
-  specified above.
+* If m2e reports import problems, it is usually okay (even good) to mark all to "Resolve All Later".
+  The build-helper connector is useful if you're prompted for it, but
+  do *not* install the Tycho OSGi configurator (this causes show-stopping IAE's, and we don't need Eclipse to make bundles anyway).
+  You can manually mark as permanently ignored certain errors;
+  this updates the pom.xml (and should be current).
 
 * A quick command-line build (`mvn clean install -DskipTests`) followed by a workspace refresh
   can be useful to re-populate files which need to be copied to `target/`
- 
+
 * m2e likes to put `excluding="**"` on `resources` directories; if you're seeing funny missing files
   (things like not resolving jclouds/aws-ec2 locations or missing WARs), try building clean install
-  from the command-line then doing Maven -> Update Project (clean uses a maven-replacer-plugin to fix 
+  from the command-line then doing Maven -> Update Project (clean uses a maven-replacer-plugin to fix
   `.classpath`s).
   Alternatively you can go through and remove these manually in Eclipse (Build Path -> Configure)
   or the filesystem, or use
@@ -56,12 +55,6 @@ If you encounter issues, the following hints may be helpful:
 % find . -name .classpath -exec sed -i.bak 's/[ ]*..cluding="[\*\/]*\(\.java\)*"//g' {} \;
 {% endhighlight %}
 
-* If m2e reports import problems, it is usually okay (even good) to mark all to "Resolve All Later".
-  The build-helper connector is useful if you're prompted for it, but
-  do *not* install the Tycho OSGi configurator (this causes show-stopping IAE's, and we don't need Eclipse to make bundles anyway).
-  You can manually mark as permanently ignored certain errors;
-  this updates the pom.xml (and should be current).
-
 * You may need to ensure ``src/main/{java,resources}`` is created in each project dir,
   if (older versions) complain about missing directories,
   and the same for ``src/test/{java,resources}`` *if* there are tests (``src/test`` exists):
@@ -70,13 +63,8 @@ If you encounter issues, the following hints may be helpful:
 find . \( -path "*/src/main" -or -path "*/src/test" \) -exec echo {} \; -exec mkdir -p {}/{java,resources} \;
 {% endhighlight %}
 
-* You may need to add the groovy nature (or even java nature) to projects;
-  with some maven-eclipse plugins this works fine, 
-  but for others (older ones) you may need to handcraft these 
-  (either right-click the project in the Package Explorer and choose Configure,
-  or edit the ``.project`` manually adding it to the project properties).
-
-If the pain starts to be too much, come find us on IRC #brooklyncentral or [elsewhere]({{site.path.website}}/community/) and we can hopefully share our pearls.
+If the pain starts to be too much, come find us on IRC #brooklyncentral or
+[elsewhere]({{site.path.website}}/community/) and we can hopefully share our pearls.
 (And if you have a tip we haven't mentioned please let us know that too!)
 
 
@@ -84,7 +72,7 @@ If the pain starts to be too much, come find us on IRC #brooklyncentral or [else
 ## IntelliJ IDEA
 
 To develop or debug Brooklyn in IntelliJ, you will need to ensure that the Groovy and TestNG plugins are installed
-via the IntelliJ IDEA | Preferences | Plugins menu. Once installed, you can open Brooklyn from the root folder, 
+via the IntelliJ IDEA | Preferences | Plugins menu. Once installed, you can open Brooklyn from the root folder,
 (e.g. ``~/myfiles/brooklyn``) which will automatically open the subprojects.
 
 Brooklyn has informally standardized on arranging `import` statements as per Eclipse's default configuration.
@@ -115,5 +103,5 @@ to the Maven Runner by clicking on the Maven Settings icon in the Maven Projects
 When running at the command line you can enable remote connections so that one can attach a debugger to the Java process:
     Run Java with the following on the command line or in JAVA_OPTS: ``-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005``
 
-To debug a brooklyn instance that has been run with the above JAVA_OPTS, create a remote build configuration (IntelliJ - 
+To debug a brooklyn instance that has been run with the above JAVA_OPTS, create a remote build configuration (IntelliJ -
 Run | Edit Configurations | + | Remote) with the default options, ensuring the port matches the address specified in JAVA_OPTS.

--- a/docs/guide/dev/env/ide/index.md
+++ b/docs/guide/dev/env/ide/index.md
@@ -30,7 +30,8 @@ You can install these using Help -> Install New Software, or from the Eclipse Ma
 As of this writing, Eclipse 4.5 and Eclipse 4.4 are commonly used,
 and the codebase can be imported (Import -> Existing Maven Projects)
 and successfully built and run inside an IDE.
-However there are quirks, and mileage may vary.
+However there are quirks, and mileage may vary. Disable ``Build Automatically``
+from the ``Project`` menu if the IDE is slow to respond.
 
 If you encounter issues, the following hints may be helpful:
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,7 +82,7 @@
         <jersey.version>1.18.1</jersey.version>
         <httpclient.version>4.4.1</httpclient.version>
         <commons-lang3.version>3.1</commons-lang3.version>
-        <groovy.version>2.3.4</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.0-Release-Notes -->
+        <groovy.version>2.3.7</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes -->
         <jsr305.version>2.0.1</jsr305.version>
         <snakeyaml.version>1.11</snakeyaml.version>
 

--- a/usage/downstream-parent/pom.xml
+++ b/usage/downstream-parent/pom.xml
@@ -62,6 +62,7 @@
     <jersey.version>1.18.1</jersey.version>
     <httpclient.version>4.4.1</httpclient.version>
     <commons-lang3.version>3.1</commons-lang3.version>
+    <groovy.version>2.3.4</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.0-Release-Notes -->
     <jsr305.version>2.0.1</jsr305.version>
     <snakeyaml.version>1.11</snakeyaml.version>
   </properties>

--- a/usage/downstream-parent/pom.xml
+++ b/usage/downstream-parent/pom.xml
@@ -62,7 +62,7 @@
     <jersey.version>1.18.1</jersey.version>
     <httpclient.version>4.4.1</httpclient.version>
     <commons-lang3.version>3.1</commons-lang3.version>
-    <groovy.version>2.3.4</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.0-Release-Notes -->
+    <groovy.version>2.3.7</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes -->
     <jsr305.version>2.0.1</jsr305.version>
     <snakeyaml.version>1.11</snakeyaml.version>
   </properties>


### PR DESCRIPTION
The changes allow the project to be imported in vanilla "Eclipse for Java Developers" install without using additional plugins.

Also upgrades the groovy related dependencies to latest release.