### PR TITLE
Fix Java 8 build error

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterImpl.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlClusterImpl.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.entity.database.mysql;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,7 +121,7 @@ public class MySqlClusterImpl extends DynamicClusterImpl implements MySqlCluster
         enrichers().add(Enrichers.builder()
                 .aggregating(MySqlNode.DATASTORE_URL)
                 .publishing(SLAVE_DATASTORE_URL_LIST)
-                .computing((Function)Functions.identity())
+                .computing((Function<Collection<String>, List<String>>)(Function)Functions.identity())
                 .entityFilter(Predicates.not(MySqlClusterUtils.IS_MASTER))
                 .fromMembers()
                 .build());


### PR DESCRIPTION
The raw cast erases all generics, forcing the return value to the bound which is `AbstractAggregatorBuilder`. Following method calls get resolved against the inaccessible (protected) `AbstractAggregatorBuilder` which leads to compile errors. This is a problem in Java 8. Java 7 and the Eclipse compiler don't need the additional cast.