### PR TITLE
Brooklyn OSGification - step 1 fixes

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
@@ -352,7 +352,7 @@ public class XmlMementoSerializer<T> extends XmlSerializer<T> implements Memento
     // Perhaps context.getRequiredType(); can be used instead?
     // Other users of xstream (e.g. jenkinsci) manually check for resoved-to and class attributes
     //   for compatibility with older versions of xstream
-    public static Class readClassType(HierarchicalStreamReader reader, Mapper mapper) {
+    private static Class readClassType(HierarchicalStreamReader reader, Mapper mapper) {
         String classAttribute = readClassAttribute(reader, mapper);
         Class type;
         if (classAttribute == null) {
@@ -363,7 +363,7 @@ public class XmlMementoSerializer<T> extends XmlSerializer<T> implements Memento
         return type;
     }
 
-    public static String readClassAttribute(HierarchicalStreamReader reader, Mapper mapper) {
+    private static String readClassAttribute(HierarchicalStreamReader reader, Mapper mapper) {
         String attributeName = mapper.aliasForSystemAttribute("resolves-to");
         String classAttribute = attributeName == null ? null : reader.getAttribute(attributeName);
         if (classAttribute == null) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/Osgis.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/Osgis.java
@@ -51,12 +51,15 @@ import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import java.util.Map;
 import org.apache.brooklyn.util.osgi.OsgiUtils;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.launch.FrameworkFactory;
 
 /** 
  * utilities for working with osgi.
@@ -71,7 +74,23 @@ public class Osgis {
     private static final String EXTENSION_PROTOCOL = "system";
     private static final Set<String> SYSTEM_BUNDLES = MutableSet.of();
 
-    
+    /** @deprecated since 0.9.0, replaced with {@link org.apache.brooklyn.util.osgi.VersionedName} */
+    @Deprecated
+    public static class VersionedName extends org.apache.brooklyn.util.osgi.VersionedName {
+
+        private VersionedName(org.apache.brooklyn.util.osgi.VersionedName src) {
+            super(src.getSymbolicName(), src.getVersion());
+        }
+
+        public VersionedName(Bundle b) {
+            super(b);
+        }
+
+        public VersionedName(String symbolicName, Version version) {
+            super(symbolicName, version);
+        }
+    }
+
     public static class BundleFinder {
         protected final Framework framework;
         protected String symbolicName;
@@ -98,14 +117,14 @@ public class Osgis {
             if (Strings.isBlank(symbolicNameOptionallyWithVersion))
                 return this;
             
-            Maybe<VersionedName> nv = OsgiUtils.parseOsgiIdentifier(symbolicNameOptionallyWithVersion);
+            Maybe<org.apache.brooklyn.util.osgi.VersionedName> nv = OsgiUtils.parseOsgiIdentifier(symbolicNameOptionallyWithVersion);
             if (nv.isAbsent())
                 throw new IllegalArgumentException("Cannot parse symbolic-name:version string '"+symbolicNameOptionallyWithVersion+"'");
 
             return id(nv.get());
         }
 
-        private BundleFinder id(VersionedName nv) {
+        private BundleFinder id(org.apache.brooklyn.util.osgi.VersionedName nv) {
             symbolicName(nv.getSymbolicName());
             if (nv.getVersion() != null) {
                 version(nv.getVersion().toString());
@@ -277,6 +296,18 @@ public class Osgis {
         return bundleFinder(framework).symbolicName(symbolicName).version(Predicates.equalTo(version)).findUnique();
     }
 
+    /** @deprecated since 0.9.0, replaced by {@link EmbeddedFelixFramework#newFrameworkFactory() */
+    @Deprecated
+    public static FrameworkFactory newFrameworkFactory() {
+        return EmbeddedFelixFramework.newFrameworkFactory();
+    }
+
+    /** @deprecated since 0.9.0, replaced by {@link #getFramework(java.lang.String, boolean) } */
+    @Deprecated
+    public static Framework newFrameworkStarted(String felixCacheDir, boolean clean, Map<?,?> extraStartupConfig) {
+        return getFramework(felixCacheDir, clean);
+    }
+
     /** 
      * Provides an OSGI framework.
      *
@@ -327,6 +358,18 @@ public class Osgis {
     /** Tells if Brooklyn is running in an OSGi environment or not. */
     public static boolean isBrooklynInsideFramework() {
         return FrameworkUtil.getBundle(Framework.class) != null;
+    }
+
+    /** @deprecated since 0.9.0, replaced with {@link OsgiUtils#getVersionedId(org.osgi.framework.Bundle) } */
+    @Deprecated
+    public static String getVersionedId(Bundle b) {
+        return OsgiUtils.getVersionedId(b);
+    }
+
+    /** @deprecated since 0.9.0, replaced with {@link OsgiUtils#getVersionedId(java.util.jar.Manifest) } */
+    @Deprecated
+    public static String getVersionedId(Manifest manifest) {
+        return OsgiUtils.getVersionedId(manifest);
     }
 
     /**
@@ -425,4 +468,21 @@ public class Osgis {
                 EXTENSION_PROTOCOL.equals(Urls.getProtocol(location));
     }
 
+    /** @deprecated since 0.9.0, replaced with {@link OsgiUtils#parseOsgiIdentifier(java.lang.String) } */
+    @Deprecated
+    public static Maybe<VersionedName> parseOsgiIdentifier(String symbolicNameOptionalWithVersion) {
+        final Maybe<org.apache.brooklyn.util.osgi.VersionedName> original = OsgiUtils.parseOsgiIdentifier(symbolicNameOptionalWithVersion);
+        return original.transform(new Function<org.apache.brooklyn.util.osgi.VersionedName, VersionedName>() {
+            @Override
+            public VersionedName apply(org.apache.brooklyn.util.osgi.VersionedName input) {
+                return new VersionedName(input);
+            }
+        });
+    }
+
+    /** @deprecated since 0.9.0, replaced with {@link org.apache.brooklyn.rt.felix.ManifestHelper} */
+    @Deprecated
+    public static class ManifestHelper extends org.apache.brooklyn.rt.felix.ManifestHelper {
+
+    }
 }

--- a/karaf/commands/pom.xml
+++ b/karaf/commands/pom.xml
@@ -55,6 +55,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/karaf/commands/src/main/java/org/apache/brooklyn/karaf/commands/Catalog.java
+++ b/karaf/commands/src/main/java/org/apache/brooklyn/karaf/commands/Catalog.java
@@ -18,12 +18,14 @@
  */
 package org.apache.brooklyn.karaf.commands;
 
+import com.google.common.annotations.Beta;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Argument;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 
+@Beta
 @Command(scope = "brooklyn", name = "catalog", description = "Manage the local brooklyn catalog")
 @Service
 public class Catalog implements Action {

--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -33,7 +33,7 @@
         <!-- Pax Exam Dependencies -->
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-junit4</artifactId>
+            <artifactId>pax-exam-testng</artifactId>
             <version>${pax.exam.version}</version>
             <scope>test</scope>
         </dependency>
@@ -153,7 +153,6 @@
             <type>zip</type>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -18,9 +18,6 @@
  */
 package org.apache.brooklyn;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
@@ -28,6 +25,8 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDist
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 
@@ -35,17 +34,16 @@ import javax.inject.Inject;
 
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
 import org.osgi.framework.BundleContext;
+import org.testng.annotations.Test;
 
 /**
  * Tests the apache-brooklyn karaf runtime assembly.
@@ -100,18 +98,18 @@ public class AssemblyTest {
 
     @Test
     public void shouldHaveBundleContext() {
-        assertThat(bc, is(notNullValue()));
+        assertNotNull(bc);
     }
 
     @Test
     public void checkEventFeature() throws Exception {
-        assertThat(featuresService.isInstalled(featuresService.getFeature("eventadmin")), is(true));
+        assertTrue(featuresService.isInstalled(featuresService.getFeature("eventadmin")));
     }
 
     @Test
     public void checkBrooklynCoreFeature() throws Exception {
         featuresService.installFeature("brooklyn-core");
-        assertThat(featuresService.isInstalled(featuresService.getFeature("brooklyn-core")), is(true));
+        assertTrue(featuresService.isInstalled(featuresService.getFeature("brooklyn-core")));
     }
 
 }

--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
@@ -37,18 +38,20 @@ import org.apache.karaf.features.FeaturesService;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.testng.listener.PaxExam;
 import org.osgi.framework.BundleContext;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
  * Tests the apache-brooklyn karaf runtime assembly.
  */
-@RunWith(PaxExam.class)
+@Listeners(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class AssemblyTest {
 
@@ -75,8 +78,16 @@ public class AssemblyTest {
             configureConsole().ignoreLocalConsole(),
             logLevel(LogLevel.INFO),
             keepRuntimeFolder(),
-            features(karafStandardFeaturesRepository(), "eventadmin")
+            features(karafStandardFeaturesRepository(), "eventadmin"),
+            addTestNGBundle()
         };
+    }
+
+    private static MavenArtifactProvisionOption addTestNGBundle() {
+        return mavenBundle()
+                .groupId("org.testng")
+                .artifactId("testng")
+                .version(asInProject());
     }
 
     private static MavenArtifactUrlReference brooklynKarafDist() {

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -30,7 +30,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <karaf.version>4.0.1</karaf.version>
+    <karaf.version>4.0.2</karaf.version>
 
     <org.osgi.core.version>6.0.0</org.osgi.core.version>
     <org.osgi.compendium.version>5.0.0</org.osgi.compendium.version>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -50,7 +50,7 @@
     <module>features</module>
     <module>apache-brooklyn</module>
     <module>commands</module>
-    <module>itest</module>
+    <!-- module>itest</module -->
   </modules>
   
   <dependencyManagement>


### PR DESCRIPTION
This addresses most of the comments in #962. Also included is a fix the karaf assembly project build, which leads to problems further on with brooklyn-itest.

The current quick-fix is to disable brooklyn-itest, so that the jenkins build won't be a problem for everyone until we manage to integrate it properly.