### PR TITLE
Hashicorp Vault external config supplier, plus documentation for external config

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultAppIdExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultAppIdExternalConfigSupplier.java
@@ -1,0 +1,71 @@
+package org.apache.brooklyn.core.config.external.vault;
+
+import com.google.api.client.util.Lists;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.List;
+import java.util.Map;
+
+public class VaultAppIdExternalConfigSupplier extends VaultExternalConfigSupplier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VaultAppIdExternalConfigSupplier.class);
+
+    protected VaultAppIdExternalConfigSupplier(ManagementContext managementContext, String name, Map<String, String> config) {
+        super(managementContext, name, config);
+    }
+
+    protected String initAndLogIn(Map<String, String> config) {
+        List<String> errors = Lists.newArrayListWithCapacity(1);
+        String appId = config.get("appId");
+        if (Strings.isBlank(appId)) errors.add("missing configuration 'appId'");
+        if (!errors.isEmpty()) {
+            String message = String.format("Problem configuration Vault external config supplier '%s': %s",
+                    name, Joiner.on(System.lineSeparator()).join(errors));
+            throw new IllegalArgumentException(message);
+        }
+
+        String userId = getUserId(config);
+
+        LOG.info("Config supplier named {} using Vault at {} appID {} userID {} path {}", new Object[] {
+                name, endpoint, appId, userId, path });
+
+        String path = "v1/auth/app-id/login";
+        ImmutableMap<String, String> requestData = ImmutableMap.of("app_id", appId, "user_id", userId);
+        ImmutableMap<String, String> headers = MINIMAL_HEADERS;
+        JsonObject response = apiPost(path, headers, requestData);
+        return response.getAsJsonObject("auth").get("client_token").getAsString();
+    }
+
+    private String getUserId(Map<String, String> config) {
+        String userId = config.get("userId");
+        if (Strings.isBlank(userId))
+            userId = getUserIdFromMacAddress();
+        return userId;
+    }
+
+    private static String getUserIdFromMacAddress() {
+        byte[] mac;
+        try {
+            InetAddress ip = InetAddress.getLocalHost();
+            NetworkInterface network = NetworkInterface.getByInetAddress(ip);
+            mac = network.getHardwareAddress();
+        } catch (Throwable t) {
+            throw Exceptions.propagate(t);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (byte aMac : mac) {
+            sb.append(String.format("%02x", aMac));
+        }
+        return sb.toString();
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultExternalConfigSupplier.java
@@ -1,0 +1,114 @@
+package org.apache.brooklyn.core.config.external.vault;
+
+import com.google.api.client.util.Lists;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.config.external.AbstractExternalConfigSupplier;
+import org.apache.brooklyn.util.core.http.HttpTool;
+import org.apache.brooklyn.util.core.http.HttpToolResponse;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.net.Urls;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.http.client.HttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.Map;
+
+public abstract class VaultExternalConfigSupplier extends AbstractExternalConfigSupplier {
+    public static final String CHARSET_NAME = "UTF-8";
+    public static final ImmutableMap<String, String> MINIMAL_HEADERS = ImmutableMap.of(
+            "Content-Type", "application/json; charset=" + CHARSET_NAME,
+            "Accept", "application/json",
+            "Accept-Charset", CHARSET_NAME);
+    private static final Logger LOG = LoggerFactory.getLogger(VaultExternalConfigSupplier.class);
+    protected final Map<String, String> config;
+    protected final String name;
+    protected final HttpClient httpClient;
+    protected final Gson gson;
+    protected final String endpoint;
+    protected final String path;
+    protected final String token;
+    protected final ImmutableMap<String, String> headersWithToken;
+
+    public VaultExternalConfigSupplier(ManagementContext managementContext, String name, Map<String, String> config) {
+        super(managementContext, name);
+        this.config = config;
+        this.name = name;
+        httpClient = HttpTool.httpClientBuilder().build();
+        gson = new GsonBuilder().create();
+
+        List<String> errors = Lists.newArrayListWithCapacity(2);
+        endpoint = config.get("endpoint");
+        if (Strings.isBlank(endpoint)) errors.add("missing configuration 'endpoint'");
+        path = config.get("path");
+        if (Strings.isBlank(path)) errors.add("missing configuration 'path'");
+        if (!errors.isEmpty()) {
+            String message = String.format("Problem configuration Vault external config supplier '%s': %s",
+                    name, Joiner.on(System.lineSeparator()).join(errors));
+            throw new IllegalArgumentException(message);
+        }
+
+        token = initAndLogIn(config);
+        headersWithToken = ImmutableMap.<String, String>builder()
+                .putAll(MINIMAL_HEADERS)
+                .put("X-Vault-Token", token)
+                .build();
+    }
+
+    protected abstract String initAndLogIn(Map<String, String> config);
+
+    @Override
+    public String get(String key) {
+        JsonObject response = apiGet(Urls.mergePaths("v1", path), headersWithToken);
+        return response.getAsJsonObject("data").get(key).getAsString();
+    }
+
+    protected JsonObject apiGet(String path, ImmutableMap<String, String> headers) {
+        try {
+            String uri = Urls.mergePaths(endpoint, path);
+            LOG.info("Vault request - GET: {}", uri);
+            LOG.info("Vault request - headers: {}", headers.toString());
+            HttpToolResponse response = HttpTool.httpGet(httpClient, Urls.toUri(uri), headers);
+            LOG.info("Vault response - code: {} {}", new Object[]{Integer.toString(response.getResponseCode()), response.getReasonPhrase()});
+            LOG.info("Vault response - headers: {}", response.getHeaderLists().toString());
+            String responseBody = new String(response.getContent(), CHARSET_NAME);
+            LOG.info("Vault response - body: {}", responseBody);
+            if (HttpTool.isStatusCodeHealthy(response.getResponseCode())) {
+                return gson.fromJson(responseBody, JsonObject.class);
+            } else {
+                throw new IllegalStateException("HTTP request returned error");
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    protected JsonObject apiPost(String path, ImmutableMap<String, String> headers, ImmutableMap<String, String> requestData) {
+        try {
+            String body = gson.toJson(requestData);
+            String uri = Urls.mergePaths(endpoint, path);
+            LOG.info("Vault request - POST: {}", uri);
+            LOG.info("Vault request - headers: {}", headers.toString());
+            LOG.info("Vault request - body: {}", body);
+            HttpToolResponse response = HttpTool.httpPost(httpClient, Urls.toUri(uri), headers, body.getBytes(CHARSET_NAME));
+            LOG.info("Vault response - code: {} {}", new Object[]{Integer.toString(response.getResponseCode()), response.getReasonPhrase()});
+            LOG.info("Vault response - headers: {}", response.getHeaderLists().toString());
+            String responseBody = new String(response.getContent(), CHARSET_NAME);
+            LOG.info("Vault response - body: {}", responseBody);
+            if (HttpTool.isStatusCodeHealthy(response.getResponseCode())) {
+                return gson.fromJson(responseBody, JsonObject.class);
+            } else {
+                throw new IllegalStateException("HTTP request returned error");
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultTokenExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultTokenExternalConfigSupplier.java
@@ -1,0 +1,23 @@
+package org.apache.brooklyn.core.config.external.vault;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.config.external.ExternalConfigSupplier;
+import org.apache.brooklyn.util.text.Strings;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class VaultTokenExternalConfigSupplier extends VaultExternalConfigSupplier {
+    public VaultTokenExternalConfigSupplier(ManagementContext managementContext, String name, Map<String, String> config) {
+        super(managementContext, name, config);
+    }
+
+    @Override
+    protected String initAndLogIn(Map<String, String> config) {
+        String tokenProperty = config.get("token");
+        checkArgument(Strings.isNonBlank(tokenProperty), "property not set: token");
+        return tokenProperty;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultUserPassExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultUserPassExternalConfigSupplier.java
@@ -1,0 +1,39 @@
+package org.apache.brooklyn.core.config.external.vault;
+
+import com.google.api.client.util.Lists;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.text.Strings;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class VaultUserPassExternalConfigSupplier extends VaultExternalConfigSupplier {
+    public VaultUserPassExternalConfigSupplier(ManagementContext managementContext, String name, Map<String, String> config) {
+        super(managementContext, name, config);
+    }
+
+    @Override
+    protected String initAndLogIn(Map<String, String> config) {
+        List<String> errors = Lists.newArrayListWithCapacity(2);
+        String username = config.get("username");
+        if (Strings.isBlank(username)) errors.add("missing configuration 'username'");
+        String password = config.get("password");
+        if (Strings.isBlank(username)) errors.add("missing configuration 'password'");
+        if (!errors.isEmpty()) {
+            String message = String.format("Problem configuration Vault external config supplier '%s': %s",
+                    name, Joiner.on(System.lineSeparator()).join(errors));
+            throw new IllegalArgumentException(message);
+        }
+
+        String path = "v1/auth/userpass/login/" + username;
+        ImmutableMap<String, String> requestData = ImmutableMap.of("password", password);
+        ImmutableMap<String, String> headers = MINIMAL_HEADERS;
+        JsonObject response = apiPost(path, headers, requestData);
+        return response.getAsJsonObject("auth").get("client_token").getAsString();
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/config/external/vault/VaultExternalConfigSupplierLiveTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/external/vault/VaultExternalConfigSupplierLiveTest.java
@@ -1,0 +1,151 @@
+package org.apache.brooklyn.core.config.external.vault;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.core.config.external.ExternalConfigSupplier;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test the operation of the Vault external configuration supplier.
+ *
+ * <p>To run this test, you must have a working Vault server, and set a number of properties to allow the test to
+ * query your Vault server.</p>
+ *
+ * <p>You should start, initialise and unseal your vault according to the Vault documentation. Then you should insert
+ * a secret into Vault:</p>
+ *
+ * <p><tt>vault write secret/test password=foobar</tt></p>
+ *
+ * <p>Then set system properties so that the test can reach Vault and knows about the secret:</p>
+ *
+ * <p><tt>-Dtest.brooklyn.vault.endpoint=http://127.0.0.1:8200<br />
+ * -Dtest.brooklyn.vault.path=secret/test<br />
+ * -Dtest.brooklyn.vault.propertyName=password<br />
+ * -Dtest.brooklyn.vault.propertyExpectedValue=foobar</tt></p>
+ *
+ * <p>You will also need to configure authentication methods for the individual tests. Refer to the "see also" section
+ * to find each method that needs further configuration.</p>
+ *
+ * @see #testAppIdAuthenticationWithAutomaticUserId()
+ */
+public class VaultExternalConfigSupplierLiveTest {
+
+    private String endpoint;
+    private String path;
+    private String propertyName;
+    private String propertyExpectedValue;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        endpoint = getTestProperty("endpoint");
+        path = getTestProperty("path");
+        propertyName = getTestProperty("propertyName");
+        propertyExpectedValue = getTestProperty("propertyExpectedValue");
+    }
+
+    private String getTestProperty(String name) {
+        String propName = "test.brooklyn.vault." + name;
+        String propVal = System.getProperty(propName);
+        if (Strings.isBlank(propVal))
+            throw new IllegalArgumentException(propName + " is not set");
+        return propVal;
+    }
+
+    /**
+     * Test using a hard-coded authentication token.
+     *
+     * <p>This provider does not do authentication, but instead uses a known token for authentication. When Vault is
+     * initialised, it will give you an <em>Initial Root Token</em>, which can be used for this test. However,
+     * obviously, passing around a well-known root token is A Bad Idea for use in production, and would largely undo all
+     * the useful security that vault provides.</p>
+     *
+     * <p>Set these system properties:</p>
+     *
+     * <p><tt>-Dtest.brooklyn.vault.token=1091fc84-70c1-b266-b99f-781684dd0d2b</tt></p>
+     */
+    @Test(groups = "Live")
+    public void testHardCodedToken() {
+        String token = getTestProperty("token");
+        ExternalConfigSupplier ecs = new VaultTokenExternalConfigSupplier(null, "test",
+                ImmutableMap.of("endpoint", endpoint, "token", token, "path", path));
+        assertEquals(ecs.get(propertyName), propertyExpectedValue);
+    }
+
+    /**
+     * Test using the "userpass" authentication backend.
+     *
+     * <p>Configure Vault to enable userpass and add a new user ID with password:</p>
+     *
+     * <p><tt>vault auth-enable userpass<br>
+     * vault write auth/userpass/users/brooklynTest password=s3kr1t policies=root  # the "root" policy allows unrestricted access, you will want to use a different policy for real use
+     * </tt></p>
+     *
+     * <p>Set these system properties:</p>
+     *
+     * <p><tt>-Dtest.brooklyn.vault.username=brooklynTest<br />
+     * -Dtest.brooklyn.vault.password=s3kr1t</tt></p>
+     */
+    @Test(groups = "Live")
+    public void testUserPassAuthentication() {
+        String username = getTestProperty("username");
+        String password = getTestProperty("password");
+        ExternalConfigSupplier ecs = new VaultUserPassExternalConfigSupplier(null, "test",
+                ImmutableMap.of("endpoint", endpoint, "username", username, "password", password, "path", path));
+        assertEquals(ecs.get(propertyName), propertyExpectedValue);
+    }
+
+    /**
+     * Test using the "App ID" authentication backend, with a MAC-address based user ID.
+     *
+     * <p>First, determine the MAC address of your system. This is system dependent, but a good guess will be to
+     * inspect the routing table to determine the default route, and take the MAC address of the interface that the
+     * default route would use. Express the MAC address as a series of 12 low-case hexadecimal digits, without any
+     * symbols.</p>
+     *
+     * <p>Configure Vault to enable App-ID, add a new app ID, and authorise the MAC address to the app ID:</p>
+     *
+     * <p><tt>/vault auth-enable app-id<br>
+     * vault write auth/app-id/map/app-id/brooklyn value=root display_name=Brooklyn  # the app ID here is "brooklyn"; the "root" policy allows unrestricted access, you will want to use a different policy for real use
+     * vault write auth/app-id/map/user-id/0c4de9bca2db value=brooklyn
+     * </tt></p>
+     *
+     * <p>Set these system properties:</p>
+     *
+     * <p><tt>-Dtest.brooklyn.vault.appId=brooklyn</tt></p>
+     */
+    @Test(groups = "Live")
+    public void testAppIdAuthenticationWithAutomaticUserId() {
+        String appId = getTestProperty("appId");
+        ExternalConfigSupplier ecs = new VaultAppIdExternalConfigSupplier(null, "test",
+                ImmutableMap.of("endpoint", endpoint, "appId", appId, "path", path));
+        assertEquals(ecs.get(propertyName), propertyExpectedValue);
+    }
+
+    /**
+     * Test using the "App ID" authentication backend, with an explicitly-given user ID.
+     *
+     * <p>Configure Vault to enable App-ID, add a new app ID, and authorise your chosen user ID to the app ID:</p>
+     *
+     * <p><tt>/vault auth-enable app-id<br>
+     * vault write auth/app-id/map/app-id/brooklyn value=root display_name=Brooklyn  # the app ID here is "brooklyn"; the "root" policy allows unrestricted access, you will want to use a different policy for real use
+     * vault write auth/app-id/map/user-id/testUser value=brooklyn
+     * </tt></p>
+     *
+     * <p>Set these system properties:</p>
+     *
+     * <p><tt>-Dtest.brooklyn.vault.appId=brooklyn<br />
+     * -Dtest.brooklyn.vault.userId=testUser</tt></p>
+     */
+    @Test(groups = "Live")
+    public void testAppIdAuthenticationWithExplicitUserId() {
+        String appId = getTestProperty("appId");
+        String userId = getTestProperty("userId");
+        ExternalConfigSupplier ecs = new VaultAppIdExternalConfigSupplier(null, "test",
+                ImmutableMap.of("endpoint", endpoint, "appId", appId, "path", path, "userId", userId));
+        assertEquals(ecs.get(propertyName), propertyExpectedValue);
+    }
+
+}

--- a/docs/guide/ops/externalized-configuration.md
+++ b/docs/guide/ops/externalized-configuration.md
@@ -1,0 +1,225 @@
+---
+title: Externalized Configuration
+layout: website-normal
+---
+
+Sometimes it is useful that configuration in a blueprint, or in Brooklyn itself, is not given explicitly, but is instead
+replaced with a reference to some other storage system. For example, it is undesirable for a blueprint to contain a
+plain-text password for a production system, especially if (as we often recommend) the blueprints are kept in the
+developer's source code control system.
+
+To handle this problem, Apache Brooklyn supports externalized configuration. This allows a blueprint to refer to
+a piece of information that is stored elsewhere. `brooklyn.properties` defines the external suppliers of configuration
+information. At runtime, when Brooklyn finds a reference to externalized configuration in a blueprint, it consults
+`brooklyn.properties` for information about the supplier, and then requests that the supplier return the information
+required by the blueprint.
+
+Take, as a simple example, a web app which connects to a database. In development, the developer is running a local
+instance of PostgreSQL with a simple username and password. But in production, an enterprise-grade cluster of PostgreSQL
+is used, and a dedicated service is used to provide passwords. The same blueprint can be used to service both groups
+of users, with `brooklyn.properties` changing the behaviour depending on the deployment environment.
+
+Here is the blueprint:
+
+{% highlight yaml %}
+name: MyApplication
+services:
+- type: brooklyn.entity.webapp.jboss.JBoss7Server
+  name: AppServer HelloWorld
+  brooklyn.config:
+    wars.root: http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0/brooklyn-example-hello-world-sql-webapp-0.6.0.war
+    http.port: 8080+
+    java.sysprops:
+      brooklyn.example.db.url: $brooklyn:formatString("jdbc:postgresql://%s/myappdb?user=%s\\&password=%s",
+         external("servers", "postgresql"), external("credentials", "postgresql-user"), external("credentials", "postgresql-password"))
+{% endhighlight %}
+
+You can see that when we are building up the JDBC URL, we are using the `external` function. This takes two parameters:
+the first is the name of the configuration supplier, the second is the name of a key that is stored by the configuration
+supplier. In this case we are using two different suppliers: `servers` to store the location of the server, and
+`credentials` which is a security-optimized supplier of secrets.
+
+Developers would add lines like this to the `brooklyn.properties` file on their workstation:
+
+{% highlight properties %}
+brooklyn.external.servers=org.apache.brooklyn.core.config.external.InPlaceExternalConfigSupplier
+brooklyn.external.servers.postgresql=127.0.0.1
+brooklyn.external.credentials=org.apache.brooklyn.core.config.external.InPlaceExternalConfigSupplier
+brooklyn.external.credentials.postgresql-user=admin
+brooklyn.external.credentials.postgresql-password=admin
+{% endhighlight %}
+
+In this case, all of the required information is included in-line in the local `brooklyn.properties`.
+
+Whereas in production, `brooklyn.properties` might look like this:
+
+{% highlight properties %}
+brooklyn.external.servers=org.apache.brooklyn.core.config.external.PropertiesFileExternalConfigSupplier
+brooklyn.external.servers.propertiesUrl=https://ops.example.com/servers.properties
+brooklyn.external.credentials=org.apache.brooklyn.core.config.external.vault.VaultAppIdExternalConfigSupplier
+brooklyn.external.credentials.endpoint=https://vault.example.com
+brooklyn.external.credentials.path=secret/enterprise-postgres
+brooklyn.external.credentials.appId=MyApp
+{% endhighlight %}
+
+In this case, the list of servers is stored in a properties file located on an Operations Department web server, and the
+credentials are stored in an instance of [Vault](https://www.vaultproject.io/).
+
+## Defining Suppliers
+
+External configuration suppliers are defined in `brooklyn.properties`. The minimal definition is of the form:
+
+brooklyn.external.*supplierName* = *className*
+
+This defines a supplier named *supplierName*. Brooklyn will attempt to instantiate *className*; it is this class which
+will provide the behaviour of how to retrieve data from the supplier. Brooklyn includes a number of supplier
+implementations; see below for more details.
+
+Suppliers may require additional configuration options. These are given as additional properties in
+`brooklyn.properties`:
+
+{% highlight properties %}
+brooklyn.external.supplierName = className
+brooklyn.external.supplierName.firstConfig = value
+brooklyn.external.supplierName.secondConfig = value
+{% endhighlight %}
+
+## Referring to External Configuration in Blueprints
+
+Externalized configuration adds a new function to the Brooklyn blueprint language DSL, `$brooklyn:external`. This
+function takes two parameters:
+
+1. supplier
+2. key
+
+When resolving the external reference, Brooklyn will first identify the *supplier* of the information, then it will
+give the supplier the *key*. The returned value will be substituted into the blueprint.
+
+You can use `$brooklyn:external` directly:
+
+{% highlight yaml %}
+name: MyApplication
+brooklyn.config:
+  example: $brooklyn:external("supplier", "key")
+{% endhighlight %}
+
+or embed the `external` function inside another `$brooklyn` DSL function, such as `$brooklyn:formatString`:
+
+{% highlight yaml %}
+name: MyApplication
+brooklyn.config:
+  example: $brooklyn:formatString("%s", external("supplier", "key"))
+{% endhighlight %}
+
+## Suppliers available with Brooklyn
+
+Brooklyn ships with a number of external configuration suppliers ready to use.
+
+### In-place
+
+**InPlaceExternalConfigSupplier** embeds the configuration keys and values as properties inside `brooklyn.properties`.
+For example:
+
+{% highlight properties %}
+brooklyn.external.servers=org.apache.brooklyn.core.config.external.InPlaceExternalConfigSupplier
+brooklyn.external.servers.postgresql=127.0.0.1
+{% endhighlight %}
+
+Then, a blueprint which referred to `$brooklyn:external("servers", "postgresql")` would receive the value `127.0.0.1`.
+
+### Properties file
+
+**PropertiesFileExternalConfigSupplier** loads a properties file from a URL, and uses the keys and values in this
+file to respond to configuration lookups.
+
+Given this configuration:
+
+{% highlight properties %}
+brooklyn.external.servers=org.apache.brooklyn.core.config.external.PropertiesFileExternalConfigSupplier
+brooklyn.external.servers.propertiesUrl=https://ops.example.com/servers.properties
+{% endhighlight %}
+
+This would cause the supplier to download the given URL. Assuming that the file contained this entry:
+
+{% highlight properties %}
+postgresql=127.0.0.1
+{% endhighlight %}
+
+Then, a blueprint which referred to `$brooklyn:external("servers", "postgresql")` would receive the value `127.0.0.1`.
+
+### Vault
+
+[Vault](https://www.vaultproject.io) is a server-based tool for managing secrets. Brooklyn provides suppliers that are
+able to query the Vault REST API for configuration values. The different suppliers implement alternative authentication
+options that Vault provides.
+
+For *all* of the authentication methods, you must always set these properties in `brooklyn.properties`:
+
+{% highlight properties %}
+brooklyn.external.supplierName.endpoint=<Vault HTTP/HTTPs endpoint>
+brooklyn.external.supplierName.path=<path to a Vault object>
+{% endhighlight %}
+
+For example, if the path is set to `secret/brooklyn`, then attempting to retrieve the key `foo` would cause Brooklyn
+to retrieve the value of the `foo` key on the `secret/brooklyn` object. This value can be set using the Vault CLI
+like this:
+
+{% highlight bash %}
+vault write secret/brooklyn foo=bar
+{% endhighlight %}
+
+#### Authentication by username and password
+
+The `userpass` plugin for Vault allows authentication with username and password.
+
+{% highlight properties %}
+brooklyn.external.supplierName=org.apache.brooklyn.core.config.external.vault.VaultUserPassExternalConfigSupplier
+brooklyn.external.supplierName.username=fred
+brooklyn.external.supplierName.password=s3kr1t
+{% endhighlight %}
+
+#### Authentication using App ID
+
+The `app_id` plugin for Vault allows you to specify an "app ID", and then designate particular "user IDs" to be part
+of the app. Typically the app ID would be known and shared, but user ID would be autogenerated on the client in some
+way. Brooklyn implements this by determining the MAC address of the server running Brooklyn (expressed as 12 lower
+case hexadecimal digits without separators) and passing this as the user ID.
+
+{% highlight properties %}
+brooklyn.external.supplierName=org.apache.brooklyn.core.config.external.vault.VaultAppIdExternalConfigSupplier
+brooklyn.external.supplierName.appId=MyApp
+{% endhighlight %}
+
+If you do not wish to use the MAC address as the user ID, you can override it with your own choice of user ID:
+
+{% highlight properties %}
+brooklyn.external.supplierName.userId=server3.cluster2.europe
+{% endhighlight %}
+
+#### Authentication by fixed token
+
+If you have a fixed token string, then you can use the *VaultTokenExternalConfigSupplier* class and provide the token
+in `brooklyn.properties`:
+
+{% highlight properties %}
+brooklyn.external.supplierName=org.apache.brooklyn.core.config.external.vault.VaultTokenExternalConfigSupplier
+brooklyn.external.supplierName.token=1091fc84-70c1-b266-b99f-781684dd0d2b
+{% endhighlight %}
+
+This supplier is suitable for "smoke testing" the Vault supplier using the Initial Root Token or similar. However it
+is not suitable for production use as it is inherently insecure - should the token be compromised, an attacker could
+have complete access to your Vault, and the cleanup operation would be difficult. Instead you should use one of the
+other suppliers.
+
+## Writing Custom External Configuration Suppliers
+
+Supplier implementations must conform to the brooklyn.config.external.ExternalConfigSupplier interface, which is very
+simple:
+
+{% highlight java %}
+String getName();
+String get(String key);
+{% endhighlight %}
+
+Classes implementing this interface can be placed in the `lib/dropins` folder of Brooklyn, and then the supplier
+defined in `brooklyn.properties` as normal.

--- a/docs/guide/ops/index.md
+++ b/docs/guide/ops/index.md
@@ -10,6 +10,7 @@ children:
 - catalog/
 - rest.md
 - logging.md
+- externalized-configuration.md
 - requirements.md
 - production-installation.md
 - troubleshooting/


### PR DESCRIPTION
Adds an implementation of ExternalConfigSupplier for Hashicorp [Vault](https://www.vaultproject.io).

Also provides documentation for the externalized configuration system.