### PR TITLE
tidy of HttpAssertsTest

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityAssertsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityAssertsTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.brooklyn.core.entity;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -34,16 +34,16 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests on {@link EntityAsserts}.
  */
 public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
 
-    private static final int TIMEOUT_MS = 10*1000;
     private static final String STOOGE = "stooge";
 
     private SimulatedLocation loc;
@@ -99,7 +99,7 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
         EntityAsserts.assertConfigEquals(entity, TestEntity.CONF_NAME, "bogus");
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertAttributeEqualsEventually() {
         entity.sensors().set(TestEntity.NAME, "before");
         final String after = "after";
@@ -107,8 +107,7 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
         EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, after);
     }
 
-
-    @Test(expectedExceptions = AssertionError.class)
+    @Test(groups="Integration", expectedExceptions = AssertionError.class)
     public void shouldFailToAssertAttributeEqualsEventually() {
         entity.sensors().set(TestEntity.NAME, "before");
         final String after = "after";
@@ -125,14 +124,14 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
         }, delay.toUnit(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertAttributeEventuallyNonNull() {
         EntityAsserts.assertAttributeEquals(entity, TestEntity.NAME, null);
         setSensorValueLater(TestEntity.NAME, "something", Duration.seconds(1));
         EntityAsserts.assertAttributeEventuallyNonNull(entity, TestEntity.NAME);
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertAttributeEventually() {
         setSensorValueLater(TestEntity.NAME, "testing testing 123", Duration.seconds(1));
         EntityAsserts.assertAttributeEventually(entity, TestEntity.NAME, new Predicate<String>() {
@@ -150,7 +149,7 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
         EntityAsserts.assertAttribute(entity, TestEntity.NAME, Predicates.equalTo(before));
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertPredicateEventuallyTrue() {
         final int testVal = 987654321;
         executor.schedule(new Runnable() {
@@ -167,7 +166,7 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
         });
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertAttributeEqualsContinually() {
         final String myName = "myname";
         entity.sensors().set(TestEntity.NAME, myName);
@@ -175,7 +174,7 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
                 ImmutableMap.of("timeout", "2s"), entity, TestEntity.NAME, myName);
     }
 
-    @Test(expectedExceptions = AssertionError.class)
+    @Test(groups="Integration", expectedExceptions = AssertionError.class)
     public void shouldFailAssertAttributeEqualsContinually() {
         final String myName = "myname";
         entity.sensors().set(TestEntity.NAME, myName);
@@ -184,7 +183,7 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
                 ImmutableMap.of("timeout", "2s"), entity, TestEntity.NAME, myName);
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertGroupSizeEqualsEventually() {
         setGroupFilterLater(STOOGE, 1);
         EntityAsserts.assertGroupSizeEqualsEventually(ImmutableMap.of("timeout", "2s"), stooges, 3);
@@ -201,14 +200,14 @@ public class EntityAssertsTest extends BrooklynAppUnitTestSupport {
         }, delaySeconds, TimeUnit.SECONDS);
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertAttributeChangesEventually () {
         entity.sensors().set(TestEntity.NAME, "before");
         setSensorValueLater(TestEntity.NAME, "after", Duration.seconds(2));
         EntityAsserts.assertAttributeChangesEventually(entity, TestEntity.NAME);
     }
 
-    @Test
+    @Test(groups="Integration")
     public void shouldAssertAttributeNever() {
         entity.sensors().set(TestEntity.NAME, "ever");
         EntityAsserts.assertAttributeContinuallyNotEqualTo(ImmutableMap.of("timeout", "5s"), entity, TestEntity.NAME, "after");

--- a/utils/common/src/main/java/org/apache/brooklyn/test/http/TestHttpServer.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/http/TestHttpServer.java
@@ -137,6 +137,10 @@ public class TestHttpServer {
 
     public String getUrl() {
         try {
+            if (server==null) {
+                // guess the URL, in those cases where the server is not started yet
+                return new URL("http", getLocalAddress().getHostAddress(), basePort, "").toExternalForm();
+            }
             return new URL("http", server.getInetAddress().getHostAddress(), server.getLocalPort(), "").toExternalForm();
         } catch (MalformedURLException e) {
             throw Exceptions.propagate(e);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/http/HttpAsserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/http/HttpAsserts.java
@@ -19,33 +19,15 @@
 package org.apache.brooklyn.util.http;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSession;
 
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.crypto.SslTrustUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.stream.Streams;
-import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -120,7 +102,7 @@ public class HttpAsserts {
      * @param url The URL
      */
     public static void assertUrlUnreachableEventually(final String url) {
-        assertUrlUnreachableEventually(Maps.newLinkedHashMap(), url);
+        assertUrlUnreachableEventually(Maps.<String,Object>newLinkedHashMap(), url);
     }
 
 
@@ -131,7 +113,7 @@ public class HttpAsserts {
      *              For details see {@link org.apache.brooklyn.test.Asserts#succeedsEventually(java.util.Map, java.util.concurrent.Callable)}
      * @param url The URL
      */
-    public static void assertUrlUnreachableEventually(Map flags, final String url) {
+    public static void assertUrlUnreachableEventually(Map<String,?> flags, final String url) {
         assertEventually(flags, new Runnable() {
             public void run() {
                 assertUrlUnreachable(url);
@@ -163,10 +145,10 @@ public class HttpAsserts {
     }
 
     public static void assertHttpStatusCodeEventuallyEquals(final String url, final int expectedCode) {
-        assertHttpStatusCodeEventuallyEquals(Maps.newLinkedHashMap(),  url, expectedCode);
+        assertHttpStatusCodeEventuallyEquals(Maps.<String,Object>newLinkedHashMap(), url, expectedCode);
     }
 
-    public static void assertHttpStatusCodeEventuallyEquals(Map flags, final String url, final int expectedCode) {
+    public static void assertHttpStatusCodeEventuallyEquals(Map<String,?> flags, final String url, final int expectedCode) {
         assertEventually(flags, new Runnable() {
             public void run() {
                 assertHttpStatusCodeEquals(url, expectedCode);
@@ -241,10 +223,10 @@ public class HttpAsserts {
     }
 
     public static void assertContentEventuallyContainsText(final String url, final String phrase, final String ...additionalPhrases) {
-        assertContentEventuallyContainsText(MutableMap.of(), url, phrase, additionalPhrases);
+        assertContentEventuallyContainsText(MutableMap.<String,Object>of(), url, phrase, additionalPhrases);
     }
     
-    public static void assertContentEventuallyContainsText(Map flags, final String url, final String phrase, final String ...additionalPhrases) {
+    public static void assertContentEventuallyContainsText(Map<String,?> flags, final String url, final String phrase, final String ...additionalPhrases) {
         assertEventually(flags, new Runnable() {
             public void run() {
                 assertContentContainsText(url, phrase, additionalPhrases);
@@ -252,7 +234,7 @@ public class HttpAsserts {
         });
     }
 
-    private static void assertEventually(Map flags, Runnable r) {
+    private static void assertEventually(Map<String,?> flags, Runnable r) {
         try {
             Asserts.succeedsEventually(flags, r);
         } catch (Exception e) {
@@ -304,7 +286,7 @@ public class HttpAsserts {
      * {@code
      * Future<?> future = assertAsyncHttpStatusCodeContinuallyEquals(executor, url, 200);
      * // do other stuff...
-     * if (future.isDone()) future.get(); // get exception if it's Asserts.failed
+     * if (future.isDone()) future.get(); // get exception if its Asserts.failed
      * }
      * </pre>
      *


### PR DESCRIPTION
@geomacy a few tidies to HttpAssertsTest

i think this should fix the failures we've seen on hosted jenkins, which i think are due to delays cleaning up ports.

however it should remain an integration test except for those which run with no delays (btw i think doing that is low priority -- good integration coverage is sufficient)