### PR TITLE
Unwrap camp plan with parent overriding child displayName

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -287,8 +287,10 @@ public class EntityManagementUtils {
         return isWrapperApp(spec) && hasSingleChild(spec) &&
                 //equivalent to no keys starting with "brooklyn."
                 spec.getEnrichers().isEmpty() &&
+                spec.getEnricherSpecs().isEmpty() &&
                 spec.getInitializers().isEmpty() &&
-                spec.getPolicies().isEmpty();
+                spec.getPolicies().isEmpty() &&
+                spec.getPolicySpecs().isEmpty();
     }
 
     public static boolean isWrapperApp(EntitySpec<?> spec) {

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/AppYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/AppYamlTest.java
@@ -19,10 +19,13 @@
 package org.apache.brooklyn.camp.brooklyn;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.StringReader;
 
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.stock.BasicApplication;
@@ -66,10 +69,10 @@ public class AppYamlTest extends AbstractYamlTest {
                 "- serviceType: org.apache.brooklyn.core.test.entity.TestApplication",
                 "  name: myEntityName");
         
-        BasicApplication app = (BasicApplication) createStartWaitAndLogApplication(new StringReader(yaml));
-        TestApplication entity = (TestApplication) Iterables.getOnlyElement(app.getChildren());
+        Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
+        assertNull(app.getConfig(EntityManagementUtils.WRAPPER_APP_MARKER));
         assertEquals(app.getDisplayName(), "myTopLevelName");
-        assertEquals(entity.getDisplayName(), "myEntityName");
+        assertEquals(app.getChildren().size(), 0);
     }
     
     @Test

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ApplicationsYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ApplicationsYamlTest.java
@@ -67,6 +67,34 @@ public class ApplicationsYamlTest extends AbstractYamlTest {
         assertEquals(app.getChildren().size(), 2);
     }
 
+    @Test
+    public void testWrapsWhenEnrichers() throws Exception {
+        Entity app = createAndStartApplication(
+                "brooklyn.enrichers:",
+                "- type: " + TestEnricher.class.getName(),
+                "services:",
+                "- type: " + BasicApplication.class.getName());
+        assertWrapped(app, BasicApplication.class);
+    }
+
+    @Test
+    public void testWrapsWhenPolicy() throws Exception {
+        Entity app = createAndStartApplication(
+                "brooklyn.policies:",
+                "- type: " + TestPolicy.class.getName(),
+                "services:",
+                "- type: " + BasicApplication.class.getName());
+        assertWrapped(app, BasicApplication.class);
+    }
+
+    @Test
+    public void testWrapsWhenInitializer() throws Exception {
+        Entity app = createAndStartApplication(
+                "brooklyn.initializers:",
+                "- type: " + TestConfigurableInitializer.class.getName(),
+                "services:",
+                "- type: " + BasicApplication.class.getName());
+        assertWrapped(app, BasicApplication.class);
     }
 
     @Test


### PR DESCRIPTION
There's an unexpected side effect presently where pointing to a catalog item and giving a top-level name to the plan will prevent unwrapping. It's surprising to users and even more so because it wasn't the case a few months ago.

For example the following catalog item:

```
brooklyn.catalog:
  id: simpleApp
  version: 1.0
  displayName: Simple App
  itemType: template
  item:
    services:
    - type: my-simple-app
```

when started in the Application Wizard and given a name, equivalent to the following plan:

```
name: My App
services:
  - type: "simpleApp:1.0"
```

will result in this hierarchy:

```
* My App (BasicApplication)
    * Simple App (my-simple-app)
```

I propose that we change the logic such that the root level name will overwrite the child's name, so the hierarchy becomes:

```
* My App (my-simple-app)
```