### PR TITLE
added missing URI/URL to String coercions

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -586,10 +586,22 @@ public class TypeCoercions {
                 }
             }
         });
+        registerAdapter(URL.class, String.class, new Function<URL,String>() {
+            @Override
+            public String apply(URL input) {
+                return input.toString();
+            }
+        });
         registerAdapter(String.class, URI.class, new Function<String,URI>() {
             @Override
             public URI apply(String input) {
                 return URI.create(input);
+            }
+        });
+        registerAdapter(URI.class, String.class, new Function<URI,String>() {
+            @Override
+            public String apply(URI input) {
+                return input.toString();
             }
         });
         registerAdapter(Closure.class, ConfigurableEntityFactory.class, new Function<Closure,ConfigurableEntityFactory>() {

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/TypeCoercionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/TypeCoercionsTest.java
@@ -23,6 +23,9 @@ import static org.testng.Assert.assertNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -316,6 +319,18 @@ public class TypeCoercionsTest {
     public void testKeyEqualsOrColonValueWithoutBracesStringToMapCoercion() {
         Map<?,?> s = TypeCoercions.coerce("a=1, b: 2", Map.class);
         Assert.assertEquals(s, ImmutableMap.of("a", "1", "b", 2));
+    }
+
+    @Test
+    public void testURItoStringCoercion() {
+        String s = TypeCoercions.coerce(URI.create("http://localhost:1234/"), String.class);
+        Assert.assertEquals(s, "http://localhost:1234/");
+    }
+
+    @Test
+    public void testURLtoStringCoercion() throws MalformedURLException {
+        String s = TypeCoercions.coerce(new URL("http://localhost:1234/"), String.class);
+        Assert.assertEquals(s, "http://localhost:1234/");
     }
 
     @Test


### PR DESCRIPTION
Added coercions to handle cases where a String ConfigKey is being populated from URI/URL typed sensors. For example (where `url` is a `String`, and `main.uri` is a `URI`):

```
url: $brooklyn:component("tomcat").attributeWhenReady("main.uri")
```

*Note*: I can only find Brooklyn entities using either `URI` or `String` to store URLs, have included a `URL` coercion for completeness.
