### PR TITLE
Add ManagementContext.getConfigWithExternalConfigResolved()

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -180,7 +180,9 @@ public interface ManagementContext {
      * Defaults to reading ~/.brooklyn/brooklyn.properties but configurable in the management context.
      */
     StringConfigMap getConfig();
-    
+
+    StringConfigMap getConfigWithExternalConfigResolved();
+
     /**
      * Whether the management context has been initialized and not yet terminated.
      * This does not mean startup is entirely completed. See also {@link #isStartupComplete()}.

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -284,6 +284,12 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     }
 
     @Override
+    public StringConfigMap getConfigWithExternalConfigResolved() {
+        checkInitialManagementContextReal();
+        return initialManagementContext.getConfigWithExternalConfigResolved();
+    }
+
+    @Override
     public BrooklynProperties getBrooklynProperties() {
         checkInitialManagementContextReal();
         return initialManagementContext.getBrooklynProperties();


### PR DESCRIPTION
I'm not really sure about this. Throwing it out there to see what people think.

The external configuration supplier feature is great, but it doesn't work with site-wide configuration defined in brooklyn.properties. This PR is an attempt to add this function.

It, unfortunately, is not a simple matter. Because external configuration is *defined* in brooklyn.properties, there's a possible recursion problem. We could resolve this during initialisation of the management context, but we want to keep the behaviour that the configuration suppliers are invoked whenever required and always return fresh values, rather than resolving them at startup and leaving them to go stale. Some of my attempted solutions exposed weird bugs.

So the simplest possible thing is to not attempt to retro-fit this but instead add a new method which explicitly retrieves the brooklyn.properties values, with configuration resolved there and then.