### PR TITLE
[BROOKLYN-183] Fix karaf package wiring for brooklyn-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -281,6 +281,7 @@
                         <Export-Package>brooklyn.*,org.apache.brooklyn.*</Export-Package>
                         <Import-Package>
                             !org.apache.brooklyn.rt.felix,
+                            !org.apache.felix.framework,
                             *
                         </Import-Package>
                         <Implementation-SHA-1>${buildNumber}</Implementation-SHA-1>


### PR DESCRIPTION
For some reason the `brooklyn-core` bundle still imports `org.apache.felix.framework`, even if the actual code was moved to `brooklyn-rt-felix` and excluded from `brooklyn-core`'s imports.

This PR addresses this issue.