### PR TITLE
Config supplied to SshTool’s constructor

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -18,8 +18,6 @@
  */
 package org.apache.brooklyn.location.ssh;
 
-import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithPrefix;
-import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
 import static org.apache.brooklyn.util.groovy.GroovyJavaMethods.truth;
 
 import java.io.Closeable;
@@ -147,6 +145,25 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
     public static final ConfigKey<String> SSH_TOOL_CLASS = ConfigKeys.newConfigKeyWithPrefixRemoved(
             BrooklynConfigKeys.BROOKLYN_SSH_CONFIG_KEY_PREFIX,
             Preconditions.checkNotNull(BrooklynConfigKeys.SSH_TOOL_CLASS, "static final initializer classload ordering problem"));
+
+    /** 
+     * Prefix for config key:values to be passed to the ssh tool on construction. For example, 
+     * one could define the location below. When executing ssh commands, it would instantiate
+     * an instance of {@code com.acme.brooklyn.MyCustomSshTool}, calling its constructor with a
+     * {@code Map<String, Object>} that contained the configuration. In this case, the map would
+     * include: {@code address=1.2.3.4}; {@code user=myname}; and {@code myparam=myvalue}.
+     * 
+     * <pre>
+     * {@code
+     * brooklyn.location.named.myLocation = byon:(hosts=1.2.3.4,user=myname)
+     * brooklyn.location.named.myLocation.sshToolClass = com.acme.brooklyn.MyCustomSshTool
+     * brooklyn.location.named.myLocation.sshToolClass.myparam = myvalue
+     * }
+     * }
+     * </pre>
+     * <p>
+     */
+    public static final String SSH_TOOL_CLASS_PROPERTIES_PREFIX = SSH_TOOL_CLASS.getName()+".";
 
     public static final ConfigKey<Duration> SSH_CACHE_EXPIRY_DURATION = ConfigKeys.newConfigKey(Duration.class,
             "sshCacheExpiryDuration", "Expiry time for unused cached ssh connections", Duration.FIVE_MINUTES);
@@ -580,10 +597,19 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
                 .configure(SshTool.PROP_HOST, address.getHostName());
 
             for (Map.Entry<String,Object> entry: config().getBag().getAllConfig().entrySet()) {
+                boolean include = false;
                 String key = entry.getKey();
                 if (key.startsWith(SshTool.BROOKLYN_CONFIG_KEY_PREFIX)) {
                     key = Strings.removeFromStart(key, SshTool.BROOKLYN_CONFIG_KEY_PREFIX);
-                } else if (ALL_SSH_CONFIG_KEY_NAMES.contains(entry.getKey())) {
+                    include = true;
+                }
+                
+                if (key.startsWith(SSH_TOOL_CLASS_PROPERTIES_PREFIX)) {
+                    key = Strings.removeFromStart(key, SSH_TOOL_CLASS_PROPERTIES_PREFIX);
+                    include = true;
+                }
+                
+                if (ALL_SSH_CONFIG_KEY_NAMES.contains(entry.getKey())) {
                     // key should be included, and does not need to be changed
 
                     // TODO make this config-setting mechanism more universal
@@ -591,11 +617,12 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
                     // thinking either we know about the tool here,
                     // or we don't allow unadorned keys to be set
                     // (require use of BROOKLYN_CONFIG_KEY_PREFIX)
-                } else {
-                    // this key is not applicable here; ignore it
-                    continue;
+                    include = true;
                 }
-                args.putStringKey(key, entry.getValue());
+                
+                if (include) {
+                    args.putStringKey(key, entry.getValue());
+                }
             }
 
             // Explicit props trump all.

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
@@ -91,7 +91,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
         super.setUp();
         host = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure("address", Networking.getLocalHost()));
-        RecordingSshTool.execScriptCmds.clear();
+        RecordingSshTool.clear();
     }
 
     @AfterMethod(alwaysRun=true)
@@ -99,7 +99,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
         try {
             if (host != null) Streams.closeQuietly(host);
         } finally {
-            RecordingSshTool.execScriptCmds.clear();
+            RecordingSshTool.clear();
             super.tearDown();
         }
     }

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
@@ -51,10 +51,17 @@ public class RecordingSshTool implements SshTool {
     }
     
     public static List<ExecCmd> execScriptCmds = Lists.newCopyOnWriteArrayList();
+    public static List<Map<?,?>> constructorProps = Lists.newCopyOnWriteArrayList();
     
     private boolean connected;
     
+    public static void clear() {
+        execScriptCmds.clear();
+        constructorProps.clear();
+    }
+    
     public RecordingSshTool(Map<?,?> props) {
+        constructorProps.add(props);
     }
     @Override public void connect() {
         connected = true;

--- a/software/base/src/test/java/org/apache/brooklyn/entity/java/JavaOptsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/java/JavaOptsTest.java
@@ -64,7 +64,7 @@ public class JavaOptsTest extends BrooklynAppUnitTestSupport {
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
-        RecordingSshTool.execScriptCmds.clear();
+        RecordingSshTool.clear();
         super.setUp();
         loc = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure("address", "localhost")
@@ -75,7 +75,7 @@ public class JavaOptsTest extends BrooklynAppUnitTestSupport {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        RecordingSshTool.execScriptCmds.clear();
+        RecordingSshTool.clear();
     }
     
     @Test

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/EntitySshToolTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/EntitySshToolTest.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.entity.machine.MachineEntity;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.location.ssh.SshMachineLocationSshToolTest;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecCmd;
 import org.testng.annotations.AfterMethod;
@@ -36,6 +37,9 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * Test that the right SshTool is picked up, based on the entity's configuration.
+ * See {@link SshMachineLocationSshToolTest} for more tests. These ones are just
+ * for those involving the entity (and the config on the top-level brooklyn properties,
+ * as we need a {@link MachineEntity} to do that.
  */
 public class EntitySshToolTest extends BrooklynAppUnitTestSupport {
 
@@ -44,7 +48,7 @@ public class EntitySshToolTest extends BrooklynAppUnitTestSupport {
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         super.setUp();
-        RecordingSshTool.execScriptCmds.clear();
+        RecordingSshTool.clear();
         
         machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure("address", "localhost"));
@@ -52,7 +56,7 @@ public class EntitySshToolTest extends BrooklynAppUnitTestSupport {
 
     @AfterMethod(alwaysRun=true)
     public void tearDown() throws Exception {
-        RecordingSshTool.execScriptCmds.clear();
+        RecordingSshTool.clear();
         super.tearDown();
     }
 


### PR DESCRIPTION
When overriding the SshTool implementation to use, allows extra config to be supplied that will be passed to the constructor.