### PR TITLE
location is not serializable

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/location/Location.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/Location.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.api.location;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
@@ -30,7 +29,7 @@ import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
  * A location that an entity can be in. Examples of locations include a single machine
  * or a pool of machines, or a region within a given cloud. 
  */
-public interface Location extends Serializable, BrooklynObject {
+public interface Location extends BrooklynObject {
 
     /**
      * A unique id for this location.

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
@@ -96,8 +96,6 @@ import com.google.common.reflect.TypeToken;
  */
 public abstract class AbstractLocation extends AbstractBrooklynObject implements LocationInternal, HasHostGeoInfo, Configurable {
     
-    private static final long serialVersionUID = -7495805474138619830L;
-
     /** @deprecated since 0.7.0 shouldn't be public */
     @Deprecated
     public static final Logger LOG = LoggerFactory.getLogger(AbstractLocation.class);

--- a/core/src/main/java/org/apache/brooklyn/core/location/AggregatingMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AggregatingMachineProvisioningLocation.java
@@ -42,8 +42,6 @@ import com.google.common.collect.Maps;
 public class AggregatingMachineProvisioningLocation<T extends MachineLocation> extends AbstractLocation 
         implements MachineProvisioningLocation<T>, Closeable {
 
-    private static final long serialVersionUID = -8818006672883481775L;
-
     private Object lock;
     
     @SetFromFlag

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerClient.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerClient.java
@@ -39,8 +39,6 @@ import com.google.common.net.HostAndPort;
 @Deprecated
 public class PortForwardManagerClient implements PortForwardManager {
 
-    private static final long serialVersionUID = -295204304305332895L;
-    
     protected final Supplier<PortForwardManager> delegateSupplier;
     private transient volatile PortForwardManager _delegate;
     

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeMap.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.core.sensor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
@@ -43,9 +42,7 @@ import com.google.common.collect.Maps;
 /**
  * A {@link Map} of {@link Entity} attribute values.
  */
-public final class AttributeMap implements Serializable {
-
-    private static final long serialVersionUID = -6834883734250888344L;
+public final class AttributeMap {
 
     static final Logger log = LoggerFactory.getLogger(AttributeMap.class);
 

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/EffectorStartableImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/EffectorStartableImpl.java
@@ -42,8 +42,6 @@ import com.google.common.reflect.TypeToken;
  * (and same for stop and restart) */
 public class EffectorStartableImpl extends AbstractEntity implements BasicStartable {
 
-    private static final long serialVersionUID = -7109357808001370568L;
-    
     private static final Logger log = LoggerFactory.getLogger(EffectorStartableImpl.class);
 
     public static class StartParameters { 

--- a/core/src/main/java/org/apache/brooklyn/location/byon/SingleMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/SingleMachineProvisioningLocation.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableMap;
 
 public class SingleMachineProvisioningLocation<T extends MachineLocation> extends FixedListMachineProvisioningLocation<T> {
-    private static final long serialVersionUID = -4216528515792151062L;
 
     private static final Logger log = LoggerFactory.getLogger(SingleMachineProvisioningLocation.class);
     

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -71,8 +71,6 @@ import com.google.common.collect.Sets;
  */
 public class LocalhostMachineProvisioningLocation extends FixedListMachineProvisioningLocation<SshMachineLocation> implements AddressableLocation, LocationWithObjectStore {
 
-    private static final long serialVersionUID = -7791239672433897762L;
-
     /** @deprecated since 0.9.0; shouldn't be public */
     @Deprecated
     public static final Logger LOG = LoggerFactory.getLogger(LocalhostMachineProvisioningLocation.class);

--- a/core/src/main/java/org/apache/brooklyn/location/multi/MultiLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/multi/MultiLocation.java
@@ -55,8 +55,6 @@ import com.google.common.reflect.TypeToken;
  * is used, it may stripe across each of the locations.  See notes at {@link AvailabilityZoneExtension}. */
 public class MultiLocation<T extends MachineLocation> extends AbstractLocation implements MachineProvisioningLocation<T> {
 
-    private static final long serialVersionUID = 7993091317970457862L;
-    
     @SuppressWarnings("serial")
     @SetFromFlag("subLocations")
     public static final ConfigKey<List<MachineProvisioningLocation<?>>> SUB_LOCATIONS = ConfigKeys.newConfigKey(

--- a/core/src/test/java/org/apache/brooklyn/core/location/AbstractLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/AbstractLocationTest.java
@@ -46,7 +46,6 @@ import com.google.common.collect.ImmutableMap;
 public class AbstractLocationTest {
 
     public static class ConcreteLocation extends AbstractLocation {
-        private static final long serialVersionUID = 3954199300889119970L;
         @SetFromFlag(defaultVal="mydefault")
         String myfield;
 

--- a/core/src/test/java/org/apache/brooklyn/core/location/LocationExtensionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/LocationExtensionsTest.java
@@ -36,8 +36,6 @@ import org.testng.annotations.Test;
 public class LocationExtensionsTest {
 
     public static class ConcreteLocation extends AbstractLocation {
-        private static final long serialVersionUID = 2407231019435442876L;
-
         public ConcreteLocation() {
             super();
         }

--- a/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
@@ -49,8 +49,6 @@ import com.google.common.collect.Sets;
  */
 public class SimulatedLocation extends AbstractLocation implements MachineProvisioningLocation<MachineLocation>, MachineLocation, PortSupplier {
 
-    private static final long serialVersionUID = 1L;
-    
     private static final InetAddress address;
     static {
         address = Networking.getLocalHost();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindLocationTest.java
@@ -286,8 +286,6 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
     }
     
     public static class MyOldStyleLocation extends AbstractLocation {
-        private static final long serialVersionUID = 1L;
-        
         @SetFromFlag
         String myfield;
 
@@ -297,8 +295,6 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
     }
     
     public static class MyLocation extends AbstractLocation {
-        private static final long serialVersionUID = 1L;
-        
         @SetFromFlag
         public static final ConfigKey<String> MY_CONFIG_WITH_SETFROMFLAG_NO_SHORT_NAME = ConfigKeys.newStringConfigKey("myconfig.withSetfromflag.noShortName");
 
@@ -335,8 +331,6 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
     }
     
     public static class MyLocationReffingOthers extends AbstractLocation {
-        private static final long serialVersionUID = 1L;
-        
         @SetFromFlag(defaultVal="a")
         String myfield;
 
@@ -355,8 +349,6 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
     }
     
     public static class MyLocationCustomProps extends AbstractLocation {
-        private static final long serialVersionUID = 1L;
-        
         String myfield;
         boolean rebound;
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -68,7 +68,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 public class JcloudsSshMachineLocation extends SshMachineLocation implements JcloudsMachineLocation {
     
     private static final Logger LOG = LoggerFactory.getLogger(JcloudsSshMachineLocation.class);
-    private static final long serialVersionUID = -443866395634771659L;
 
     @SetFromFlag
     JcloudsLocation jcloudsParent;

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
@@ -61,8 +61,6 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
     public static final ConfigKey<Boolean> BUILD_TEMPLATE = ConfigKeys.newBooleanConfigKey(
             "buildtemplate");
 
-    private static final long serialVersionUID = -3373789512935057842L;
-
     ConfigBag lastConfigBag;
     Template template;
 
@@ -149,7 +147,6 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
 
     /** As {@link BailOutJcloudsLocation}, counting the number of {@link #buildTemplate} calls. */
     public static class CountingBailOutJcloudsLocation extends BailOutJcloudsLocation {
-        private static final long serialVersionUID = 2433684033045735773L;
         int buildTemplateCount = 0;
         @Override
         public Template buildTemplate(ComputeService computeService, ConfigBag config) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyTest.java
@@ -51,8 +51,6 @@ public class CreateUserPolicyTest extends BrooklynAppUnitTestSupport {
     private static final Logger LOG = LoggerFactory.getLogger(CreateUserPolicyTest.class);
 
     public static class RecordingSshMachineLocation extends SshMachineLocation {
-        private static final long serialVersionUID = 1641930081769106380L;
-        
         public static List<List<String>> execScriptCalls = Lists.newArrayList();
 
         @Override 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLocation.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLocation.java
@@ -40,8 +40,6 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public class ServerPoolLocation extends AbstractLocation implements MachineProvisioningLocation<MachineLocation>,
         DynamicLocation<ServerPool, ServerPoolLocation> {
 
-    private static final long serialVersionUID = -6771844611899475409L;
-
     private static final Logger LOG = LoggerFactory.getLogger(ServerPoolLocation.class);
 
     @SetFromFlag("owner")

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityRebindTest.java
@@ -145,8 +145,6 @@ public class SoftwareProcessEntityRebindTest extends BrooklynAppUnitTestSupport 
     }
     
     public static class MyProvisioningLocation extends AbstractLocation implements MachineProvisioningLocation<SshMachineLocation> {
-        private static final long serialVersionUID = 1L;
-        
         @SetFromFlag(defaultVal="0")
         AtomicInteger inUseCount;
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
@@ -742,8 +742,6 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
     }
 
     public static class ReleaseLatchLocation extends SimulatedLocation {
-        private static final long serialVersionUID = 1L;
-        
         private CountDownLatch lock = new CountDownLatch(1);
         private volatile boolean isBlocked;
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/StartStopSshDriverTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/StartStopSshDriverTest.java
@@ -83,8 +83,6 @@ public class StartStopSshDriverTest {
 
     @SuppressWarnings("rawtypes")
     protected static class SshMachineLocationWithSshTool extends SshMachineLocation {
-        private static final long serialVersionUID = 1L;
-
         SshTool lastTool;
         public SshMachineLocationWithSshTool(Map flags) { super(flags); }
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/core/mgmt/usage/LocationUsageTrackingTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/core/mgmt/usage/LocationUsageTrackingTest.java
@@ -130,8 +130,6 @@ public class LocationUsageTrackingTest extends BrooklynAppUnitTestSupport {
     }
 
     public static class DynamicLocalhostMachineProvisioningLocation extends LocalhostMachineProvisioningLocation {
-        private static final long serialVersionUID = 4822009936654077946L;
-
         @Override
         public SshMachineLocation obtain(Map<?, ?> flags) throws NoMachinesAvailableException {
             System.out.println("called DynamicLocalhostMachineProvisioningLocation.obtain");

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogParametersTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogParametersTest.java
@@ -59,7 +59,6 @@ public class CatalogParametersTest extends AbstractYamlTest {
         public static final ConfigKey<String> SAMPLE_CONFIG = SHARED_CONFIG;
     }
     public static class ConfigLocationForTest extends AbstractLocation {
-        private static final long serialVersionUID = 1L;
         public static final ConfigKey<String> SAMPLE_CONFIG = SHARED_CONFIG;
     }
 

--- a/usage/rest-server/src/test/java/org/apache/brooklyn/rest/resources/UsageResourceTest.java
+++ b/usage/rest-server/src/test/java/org/apache/brooklyn/rest/resources/UsageResourceTest.java
@@ -420,8 +420,6 @@ public class UsageResourceTest extends BrooklynRestResourceTest {
     }
     
     public static class DynamicLocalhostMachineProvisioningLocation extends LocalhostMachineProvisioningLocation {
-        private static final long serialVersionUID = 2163357613938738967L;
-
         @Override
         public SshMachineLocation obtain(Map<?, ?> flags) throws NoMachinesAvailableException {
             return super.obtain(flags);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/JavaGroovyEquivalents.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/JavaGroovyEquivalents.java
@@ -72,6 +72,7 @@ public class JavaGroovyEquivalents {
     public static <T> T elvis(Iterable<?> preferences) {
         return elvis(Iterables.toArray(preferences, Object.class));
     }
+    @SuppressWarnings("unchecked")
     public static <T> T elvis(Object... preferences) {
         if (preferences.length == 0) throw new IllegalArgumentException("preferences must not be empty for elvis");
         for (Object contender : preferences) {
@@ -109,13 +110,13 @@ public class JavaGroovyEquivalents {
         } else if (o instanceof String) {
             return !((String)o).isEmpty();
         } else if (o instanceof Collection) {
-            return !((Collection)o).isEmpty();
+            return !((Collection<?>)o).isEmpty();
         } else if (o instanceof Map) {
-            return !((Map)o).isEmpty();
+            return !((Map<?,?>)o).isEmpty();
         } else if (o instanceof Iterator) {
-            return ((Iterator)o).hasNext();
+            return ((Iterator<?>)o).hasNext();
         } else if (o instanceof Enumeration) {
-            return ((Enumeration)o).hasMoreElements();
+            return ((Enumeration<?>)o).hasMoreElements();
         } else {
             return true;
         }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/maven/MavenArtifactTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/maven/MavenArtifactTest.java
@@ -198,9 +198,13 @@ public class MavenArtifactTest {
         // Note URLClassLoader.close was only added in Java 7; do not call it until Java 6 support is not needed!
         URL realUrl = followRedirects(new URL(url));
         URLClassLoader classLoader = new URLClassLoader(new URL[] { realUrl });
-        URL innerU = classLoader.findResource(resource);
-        InputStream innerUin = innerU.openConnection().getInputStream();
-        innerUin.close();
+        try {
+            URL innerU = classLoader.findResource(resource);
+            InputStream innerUin = innerU.openConnection().getInputStream();
+            innerUin.close();
+        } finally {
+            classLoader.close();
+        }
     }
 
     /*

--- a/utils/common/src/test/java/org/apache/brooklyn/util/ssh/IptablesCommandsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/ssh/IptablesCommandsTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.brooklyn.util.ssh;
 
+import org.apache.brooklyn.util.net.Protocol;
 import org.apache.brooklyn.util.ssh.IptablesCommands;
 import org.apache.brooklyn.util.ssh.IptablesCommands.Chain;
 import org.apache.brooklyn.util.ssh.IptablesCommands.Policy;
-import org.apache.brooklyn.util.ssh.IptablesCommands.Protocol;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/utils/test-support/src/main/java/org/apache/brooklyn/test/support/TestResourceUnavailableException.java
+++ b/utils/test-support/src/main/java/org/apache/brooklyn/test/support/TestResourceUnavailableException.java
@@ -42,9 +42,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * is not available. The exception message is then derived from this. The two-string constructors take both the
  * resource name and an explicit exception message.</p>
  */
-@SuppressWarnings("UnusedDeclaration")
 public class TestResourceUnavailableException extends SkipException {
 
+    private static final long serialVersionUID = -6150059547094292069L;
+    
     private final String resourceName;
 
     /**


### PR DESCRIPTION
Deletes `extends Serializable` from location interface, and removes all declared serialVersionUID from location implementations.
    
Location was not really serialisable anyway - for example it had non-transient references to `ManagementContext`. The declaration of “Serializable” was a throwback to very old days when persistence was imagined to be very different.

Also has some other very minor tidy up (in separate commits).