### PR TITLE
BROOKLYN-144: avoid err when persisting ha-record

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/FileBasedStoreObjectAccessor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/FileBasedStoreObjectAccessor.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 
 /**
@@ -56,7 +55,7 @@ public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.Stor
             if (!exists()) return null;
             return Files.asCharSource(file, Charsets.UTF_8).read();
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw Exceptions.propagate("Problem reading String contents of file "+file, e);
         }
     }
 
@@ -66,7 +65,7 @@ public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.Stor
             if (!exists()) return null;
             return Files.asByteSource(file).read();
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw Exceptions.propagate("Problem reading bytes of file "+file, e);
         }
     }
 
@@ -83,12 +82,13 @@ public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.Stor
             Files.write(val, tmpFile, Charsets.UTF_8);
             FileBasedObjectStore.moveFile(tmpFile, file);
         } catch (IOException e) {
-            throw Exceptions.propagate(e);
+            throw Exceptions.propagate("Problem writing data to file "+file+" (via temporary file "+tmpFile+")", e);
         } catch (InterruptedException e) {
             throw Exceptions.propagate(e);
         }
     }
 
+    // TODO Should this write to the temporary file? Otherwise we'll risk getting a partial view of the write.
     @Override
     public void append(String val) {
         try {
@@ -97,7 +97,7 @@ public class FileBasedStoreObjectAccessor implements PersistenceObjectStore.Stor
             Files.append(val, file, Charsets.UTF_8);
             
         } catch (IOException e) {
-            throw Exceptions.propagate(e);
+            throw Exceptions.propagate("Problem appending to file "+file, e);
         }
     }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/Exceptions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/Exceptions.java
@@ -97,12 +97,31 @@ public class Exceptions {
      * <li> wraps as PropagatedRuntimeException for easier filtering
      */
     public static RuntimeException propagate(Throwable throwable) {
-        if (throwable instanceof InterruptedException)
+        if (throwable instanceof InterruptedException) {
             throw new RuntimeInterruptedException((InterruptedException) throwable);
+        } else if (throwable instanceof RuntimeInterruptedException) {
+            Thread.currentThread().interrupt();
+            throw (RuntimeInterruptedException) throwable;
+        }
         Throwables.propagateIfPossible(checkNotNull(throwable));
         throw new PropagatedRuntimeException(throwable);
     }
 
+    /**
+     * See {@link #propagate(Throwable)}. If wrapping the exception, then include the given message;
+     * otherwise the message is not used.
+     */
+    public static RuntimeException propagate(String msg, Throwable throwable) {
+        if (throwable instanceof InterruptedException) {
+            throw new RuntimeInterruptedException(msg, (InterruptedException) throwable);
+        } else if (throwable instanceof RuntimeInterruptedException) {
+            Thread.currentThread().interrupt();
+            throw (RuntimeInterruptedException) throwable;
+        }
+        Throwables.propagateIfPossible(checkNotNull(throwable));
+        throw new PropagatedRuntimeException(msg, throwable);
+    }
+    
     /** 
      * Propagate exceptions which are fatal.
      * <p>
@@ -110,12 +129,14 @@ public class Exceptions {
      * such as {@link InterruptedException} and {@link Error}s.
      */
     public static void propagateIfFatal(Throwable throwable) {
-        if (throwable instanceof InterruptedException)
+        if (throwable instanceof InterruptedException) {
             throw new RuntimeInterruptedException((InterruptedException) throwable);
-        if (throwable instanceof RuntimeInterruptedException)
+        } else if (throwable instanceof RuntimeInterruptedException) {
+            Thread.currentThread().interrupt();
             throw (RuntimeInterruptedException) throwable;
-        if (throwable instanceof Error)
+        } else if (throwable instanceof Error) {
             throw (Error) throwable;
+        }
     }
 
     /** returns the first exception of the given type, or null */

--- a/utils/common/src/main/java/org/apache/brooklyn/util/io/FileUtil.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/io/FileUtil.java
@@ -26,11 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.io.FileUtil;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.stream.StreamGobbler;
 import org.apache.brooklyn.util.stream.Streams;
@@ -40,12 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableList;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFileAttributeView;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Set;
 
 public class FileUtil {
 
@@ -57,7 +49,7 @@ public class FileUtil {
     private static final FilePermissions permissions700 = new FilePermissions(0700);
 
     public static void setFilePermissionsTo700(File file) throws IOException {
-        file.createNewFile();
+        createNewFile(file);
         try {
             permissions700.apply(file);
             if (LOG.isTraceEnabled()) LOG.trace("Set permissions to 700 for file {}", file.getAbsolutePath());
@@ -67,7 +59,7 @@ public class FileUtil {
     }
 
     public static void setFilePermissionsTo600(File file) throws IOException {
-        file.createNewFile();
+        createNewFile(file);
         try {
             permissions600.apply(file);
             if (LOG.isTraceEnabled()) LOG.trace("Set permissions to 600 for file {}", file.getAbsolutePath());
@@ -186,4 +178,10 @@ public class FileUtil {
         }
     }
 
+    private static boolean createNewFile(File file) throws IOException {
+        if (!file.getParentFile().exists()) {
+            file.getParentFile().mkdirs();
+        }
+        return file.createNewFile();
+    }
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/exceptions/ExceptionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/exceptions/ExceptionsTest.java
@@ -59,6 +59,28 @@ public class ExceptionsTest {
     }
     
     @Test
+    public void testPropagateCheckedExceptionWithMessage() throws Exception {
+        String extraMsg = "my message";
+        Exception tothrow = new Exception("simulated");
+        try {
+            throw Exceptions.propagate(extraMsg, tothrow);
+        } catch (RuntimeException e) {
+            assertEquals(e.getMessage(), "my message");
+            assertEquals(e.getCause(), tothrow);
+        }
+    }
+    
+    @Test
+    public void testPropagateRuntimeExceptionIgnoresMessage() throws Exception {
+        NullPointerException tothrow = new NullPointerException("simulated");
+        try {
+            throw Exceptions.propagate("my message", tothrow);
+        } catch (NullPointerException e) {
+            assertEquals(e, tothrow);
+        }
+    }
+    
+    @Test
     public void testPropagateIfFatalPropagatesInterruptedException() throws Exception {
         InterruptedException tothrow = new InterruptedException("simulated");
         try {


### PR DESCRIPTION
- Adds Exception.propagate(msg, throwable) so can include info about
  the file that could not be created.
- Fix FileUtil.setFilePermissions so that createNewFile creates the
  parent directory if necessary.
- HighAvailabilityManager’s polling task: log.err on first exception,
  then log.debug for subsequent consecutive exceptions.