### PR TITLE
ParallelTestCase change and documentation updates

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -12,6 +12,7 @@ children:
 - { path: /guide/java/index.md }
 - { path: /guide/ops/index.md }
 - { path: /guide/misc/index.md }
+- { path: /guide/test/index.md }
 ---
 
 This is the Brooklyn User Guide for v{{ site.brooklyn-version }}:

--- a/docs/guide/test/entities.md
+++ b/docs/guide/test/entities.md
@@ -1,5 +1,7 @@
-# Entities
-
+---
+title: Entities
+layout: website-normal
+---
 ## TestCase
 A logical grouping for tests, e.g. Restart tests.
 

--- a/docs/guide/test/index.md
+++ b/docs/guide/test/index.md
@@ -1,0 +1,8 @@
+---
+title: QA Test Framework
+layout: website-normal
+children:
+  - entities.md
+---
+
+{% include list-children.html %}

--- a/usage/test-framework/README.md
+++ b/usage/test-framework/README.md
@@ -1,17 +1,29 @@
 # Entities
 
 ## TestCase
-A logical grouping for tests eg Restart tests
+A logical grouping for tests, e.g. Restart tests.
+
 ```
 type: org.apache.brooklyn.test.framework.TestCase
-  name: Stop Test
-  brooklyn.children:
+name: Stop Test
+brooklyn.children:
+  - ***
+  - ***
+```
+
+## ParallelTestCase
+A logical grouping for tests where each child is started in parallel instead of being run sequentially.
+
+```
+type: org.apache.brooklyn.test.framework.ParallelTestCase
+name: Start Test
+brooklyn.children:
   - ***
   - ***
 ```
 
 ## TestSensor
-Entity that tests a sensor value on another entity eg service.isUp == TRUE
+Entity that tests a sensor value on another entity, e.g. service.isUp == TRUE.
 
 #### Configuration
 | Key | Description | Required |
@@ -37,7 +49,7 @@ timeout: 5m
 ```
 
 ## TestEffector
-Entity that invokes an effector on another entity eg restart
+Entity that invokes an effector on another entity, e.g. restart.
 
 #### Configuration
 | Key | Description | Required |
@@ -64,7 +76,7 @@ params:
 ```
 
 ## TestHtmlCall
-Entity that makes a HTTP Request and tests the response
+Entity that makes a HTTP Request and tests the response.
 
 #### Configuration
 | Key | Description | Required |

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/ParallelTestCaseImpl.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/ParallelTestCaseImpl.java
@@ -18,8 +18,9 @@
  */
 package org.apache.brooklyn.test.framework;
 
+import java.util.Collection;
+
 import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Attributes;
@@ -30,9 +31,11 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.concurrent.ExecutionException;
-
+/**
+ * This implementation will start all child entities in parallel.
+ * 
+ * @author Chris Burke
+ */
 public class ParallelTestCaseImpl extends AbstractEntity implements ParallelTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(ParallelTestCaseImpl.class);
@@ -40,7 +43,7 @@ public class ParallelTestCaseImpl extends AbstractEntity implements ParallelTest
     /**
      * {@inheritDoc}
      */
-    public void start(Collection<? extends Location> locations) {
+    public void start(final Collection<? extends Location> locations) {
         // Let everyone know we're starting up (so that the GUI shows the correct icon).
         sensors().set(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STARTING);
         try {
@@ -77,6 +80,7 @@ public class ParallelTestCaseImpl extends AbstractEntity implements ParallelTest
             // Submit the task to the ExecutionManager so that they actually get stopped
             // and then wait until all the parallel entities have completed.
             submitTaskAndWait(taskAdaptable);
+            
             // Let everyone know we've stopped successfully (changes the icon in the GUI).
             logger.debug("Tasks successfully run. Update state of {} to STOPPED.", this);
             setServiceState(false, Lifecycle.STOPPED);
@@ -115,27 +119,22 @@ public class ParallelTestCaseImpl extends AbstractEntity implements ParallelTest
 
     /**
      * Submits the task to the ExecutionManager and then waits until the task has completed.
-     *
+     * 
      * @param taskAdaptable the TaskAdaptable to submit for execution.
-     * @throws ExecutionException   if the task threw an exception
-     * @throws InterruptedException if the current thread was interrupted while waiting
      */
-    private void submitTaskAndWait(final TaskAdaptable<?> taskAdaptable)
-            throws InterruptedException, ExecutionException {
-        logger.debug("{}, Submitting taskAdaptable: {}", this, taskAdaptable);
+    private void submitTaskAndWait(final TaskAdaptable<?> taskAdaptable) {
         // Submit the task to the ExecutionManager.
-        final Task<?> task = DynamicTasks.submit(taskAdaptable, this);
-
-        // Block until the task has completed.
-        logger.debug("{}, Blocking until task complete.", this);
-        task.blockUntilEnded();
-        logger.debug("{}, Task complete.", this);
-
-        // Get the result of the task. We don't really care about the
-        // actual result but this will throw an exception if the task failed.
-        task.get();
+        DynamicTasks.queue(taskAdaptable);
+        // Block until the task has completed. This will also throw if anything went wrong.
+        DynamicTasks.waitForLast();
     }
 
+    /**
+     * Sets the state of the Entity. Useful so that the GUI shows the correct icon.
+     * 
+     * @param serviceUpState Whether or not the entity is up.
+     * @param serviceStateActual The actual state of the entity.
+     */
     private void setServiceState(final boolean serviceUpState, final Lifecycle serviceStateActual) {
         sensors().set(SERVICE_UP, serviceUpState);
         sensors().set(Attributes.SERVICE_STATE_ACTUAL, serviceStateActual);


### PR DESCRIPTION
Addressed review comments.

* Changed how ParallelTestCase task is submitted and waited upon. Functionally no change.
* Also added ParallelTestCase documentation to the docs.
* Moved the Test Entities documentation to within the Brooklyn docs guide.