### PR TITLE
BROOKLYN-193: Add configuration for skipping invalid configs

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/RebindExceptionHandler.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/RebindExceptionHandler.java
@@ -24,6 +24,7 @@ import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.rebind.mementos.EntityMemento;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
 import org.apache.brooklyn.api.policy.Policy;
@@ -31,6 +32,7 @@ import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
 
 import com.google.common.annotations.Beta;
+import org.apache.brooklyn.config.ConfigKey;
 
 /**
  * Handler called on all exceptions to do with rebind.
@@ -90,6 +92,8 @@ public interface RebindExceptionHandler {
     void onNotFound(BrooklynObjectType type, String id);
 
     void onRebindFailed(BrooklynObjectType type, BrooklynObject instance, Exception e);
+
+    void onAddConfigFailed(EntityMemento type, ConfigKey<?> value, Exception e);
 
     void onAddPolicyFailed(EntityLocal entity, Policy policy, Exception e);
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
@@ -92,6 +92,9 @@ public class RebindManagerImpl implements RebindManager {
     public static final ConfigKey<RebindFailureMode> REBIND_FAILURE_MODE =
             ConfigKeys.newConfigKey(RebindFailureMode.class, "rebind.failureMode.rebind",
                     "Action to take if a failure occurs during rebind", RebindFailureMode.FAIL_AT_END);
+    public static final ConfigKey<RebindFailureMode> ADD_CONFIG_FAILURE_MODE =
+            ConfigKeys.newConfigKey(RebindFailureMode.class, "rebind.failureMode.addConfig",
+                    "Action to take if a failure occurs when setting a config value. It could happen coercion of the value type to fail.", RebindFailureMode.FAIL_AT_END);
     public static final ConfigKey<RebindFailureMode> ADD_POLICY_FAILURE_MODE =
             ConfigKeys.newConfigKey(RebindFailureMode.class, "rebind.failureMode.addPolicy",
                     "Action to take if a failure occurs when adding a policy or enricher", RebindFailureMode.CONTINUE);
@@ -131,6 +134,7 @@ public class RebindManagerImpl implements RebindManager {
     
     private RebindFailureMode danglingRefFailureMode;
     private RebindFailureMode rebindFailureMode;
+    private RebindFailureMode addConfigFailureMode;
     private RebindFailureMode addPolicyFailureMode;
     private RebindFailureMode loadPolicyFailureMode;
     private QuorumCheck danglingRefsQuorumRequiredHealthy;
@@ -177,6 +181,7 @@ public class RebindManagerImpl implements RebindManager {
 
         danglingRefFailureMode = managementContext.getConfig().getConfig(DANGLING_REFERENCE_FAILURE_MODE);
         rebindFailureMode = managementContext.getConfig().getConfig(REBIND_FAILURE_MODE);
+        addConfigFailureMode = managementContext.getConfig().getConfig(ADD_CONFIG_FAILURE_MODE);
         addPolicyFailureMode = managementContext.getConfig().getConfig(ADD_POLICY_FAILURE_MODE);
         loadPolicyFailureMode = managementContext.getConfig().getConfig(LOAD_POLICY_FAILURE_MODE);
         
@@ -384,6 +389,7 @@ public class RebindManagerImpl implements RebindManager {
                 .danglingRefFailureMode(danglingRefFailureMode)
                 .danglingRefQuorumRequiredHealthy(danglingRefsQuorumRequiredHealthy)
                 .rebindFailureMode(rebindFailureMode)
+                .addConfigFailureMode(addConfigFailureMode)
                 .addPolicyFailureMode(addPolicyFailureMode)
                 .loadPolicyFailureMode(loadPolicyFailureMode)
                 .build();
@@ -479,6 +485,7 @@ public class RebindManagerImpl implements RebindManager {
                 .danglingRefFailureMode(danglingRefFailureMode)
                 .danglingRefQuorumRequiredHealthy(danglingRefsQuorumRequiredHealthy)
                 .rebindFailureMode(rebindFailureMode)
+                .addConfigFailureMode(addConfigFailureMode)
                 .addPolicyFailureMode(addPolicyFailureMode)
                 .loadPolicyFailureMode(loadPolicyFailureMode)
                 .build();
@@ -509,6 +516,7 @@ public class RebindManagerImpl implements RebindManager {
         RebindExceptionHandler exceptionHandler = RebindExceptionHandlerImpl.builder()
                 .danglingRefFailureMode(danglingRefFailureMode)
                 .rebindFailureMode(rebindFailureMode)
+                .addConfigFailureMode(addConfigFailureMode)
                 .addPolicyFailureMode(addPolicyFailureMode)
                 .loadPolicyFailureMode(loadPolicyFailureMode)
                 .build();

--- a/docs/guide/ops/persistence/index.md
+++ b/docs/guide/ops/persistence/index.md
@@ -191,6 +191,7 @@ rebind.failureMode.danglingRef=continue
 rebind.failureMode.loadPolicy=continue
 rebind.failureMode.addPolicy=continue
 rebind.failureMode.rebind=fail_at_end
+rebind.failureMode.addConfig=fail_at_end
 {% endhighlight %} 
 
 For each of these configuration options, the possible values are:
@@ -212,6 +213,7 @@ The meaning of the configuration options is:
 * `rebind.failureMode.addPolicy`: if there is an error re-adding the policy or enricher to
   its associated entity... whether to continue (discarding the policy or enricher) 
   or fail.
+* `rebind.failureMode.addConfig`: if there is invalid config value, or some other error occurs when adding a config.
 * `rebind.failureMode.rebind`: any errors on rebind not covered by the more specific error cases described above.
 
 


### PR DESCRIPTION
Add configuration option for skipping invalid config values