### PR TITLE
Fix jclouds sshable

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -866,7 +866,7 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
 
     @Override
     public String toString() {
-        return "SshMachineLocation["+getDisplayName()+":"+address+":"+getPort()+"@"+getId()+"]";
+        return "SshMachineLocation["+getDisplayName()+":"+user+"@"+address+":"+getPort()+"(id="+getId()+")]";
     }
 
     @Override

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
@@ -52,6 +52,7 @@ public class AbstractJcloudsLiveTest {
     public static final String AWS_EC2_PROVIDER = "aws-ec2";
     public static final String AWS_EC2_MICRO_HARDWARE_ID = "t1.micro";
     public static final String AWS_EC2_SMALL_HARDWARE_ID = "m1.small";
+    public static final String AWS_EC2_MEDIUM_HARDWARE_ID = "m3.medium";
     public static final String AWS_EC2_EUWEST_REGION_NAME = "eu-west-1";
     public static final String AWS_EC2_USEAST_REGION_NAME = "us-east-1";
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
@@ -60,6 +60,9 @@ public class AbstractJcloudsLiveTest {
     public static final String SOFTLAYER_PROVIDER = "softlayer";
     public static final String SOFTLAYER_AMS01_REGION_NAME = "ams01";
     
+    public static final String GCE_PROVIDER = "google-compute-engine";
+    public static final String GCE_USCENTRAL_REGION_NAME = "us-central1-a";
+    
     protected BrooklynProperties brooklynProperties;
     protected LocalManagementContext managementContext;
     

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLoginLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLoginLiveTest.java
@@ -41,6 +41,15 @@ import com.google.common.collect.ImmutableMap;
  */
 public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
 
+    // TODO Rackspace failed - possibly image no longer exists?
+    // Was using: 
+    //     Image: {id=LON/29fe3e2b-f119-4715-927b-763e99ebe23e, providerId=29fe3e2b-f119-4715-927b-763e99ebe23e, name=Debian 6.06 (Squeeze), location={scope=ZONE, id=LON, description=LON, parent=rackspace-cloudservers-uk, iso3166Codes=[GB-SLG]}, os={family=debian, name=Debian 6.06 (Squeeze), version=6.0, description=Debian 6.06 (Squeeze), is64Bit=true}, description=Debian 6.06 (Squeeze), status=AVAILABLE, loginUser=root, userMetadata={os_distro=debian, com.rackspace__1__visible_core=1, com.rackspace__1__build_rackconnect=1, com.rackspace__1__options=0, image_type=base, cache_in_nova=True, com.rackspace__1__source=kickstart, org.openstack__1__os_distro=org.debian, com.rackspace__1__release_build_date=2013-08-06_13-05-36, auto_disk_config=True, com.rackspace__1__release_version=4, os_type=linux, com.rackspace__1__visible_rackconnect=1, com.rackspace__1__release_id=300, com.rackspace__1__visible_managed=0, com.rackspace__1__build_core=1, org.openstack__1__os_version=6.06, org.openstack__1__architecture=x64, com.rackspace__1__build_managed=0}}
+    //     public static final String RACKSPACE_DEBIAN_IMAGE_NAME_REGEX = "Debian 6";
+
+    // TODO GCE (in GCE_USCENTRAL_REGION_NAME) fails. We get blocked by the VM! e.g. /var/log/auth.log shows:
+    //     Nov  3 14:57:56 ubuntu sshd[1693]: Did not receive identification string from 31.53.199.228
+    //     Nov  3 14:57:56 ubuntu sshguard[971]: Blocking 31.53.199.228:4 for >630secs: 40 danger in 4 attacks over 435 seconds (all: 40d in 1 abuses over 435s).
+
     private static final Logger LOG = LoggerFactory.getLogger(JcloudsLoginLiveTest.class);
 
     public static final String AWS_EC2_REGION_NAME = AWS_EC2_USEAST_REGION_NAME;
@@ -56,14 +65,6 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     // Uses "root" as loginUser
     public static final String AWS_EC2_UBUNTU_10_IMAGE_ID = "us-east-1/ami-5e008437";
 
-    public static final String RACKSPACE_LOCATION_SPEC = "jclouds:" + RACKSPACE_PROVIDER;
-    
-    // Image: {id=LON/c52a0ca6-c1f2-4cd1-b7d6-afbcd1ebda22, providerId=c52a0ca6-c1f2-4cd1-b7d6-afbcd1ebda22, name=CentOS 6.0, location={scope=ZONE, id=LON, description=LON, parent=rackspace-cloudservers-uk, iso3166Codes=[GB-SLG]}, os={family=centos, name=CentOS 6.0, version=6.0, description=CentOS 6.0, is64Bit=true}, description=CentOS 6.0, status=AVAILABLE, loginUser=root, userMetadata={os_distro=centos, com.rackspace__1__visible_core=1, com.rackspace__1__build_rackconnect=1, com.rackspace__1__options=0, image_type=base, cache_in_nova=True, com.rackspace__1__source=kickstart, org.openstack__1__os_distro=org.centos, com.rackspace__1__release_build_date=2013-07-25_18-56-29, auto_disk_config=True, com.rackspace__1__release_version=5, os_type=linux, com.rackspace__1__visible_rackconnect=1, com.rackspace__1__release_id=210, com.rackspace__1__visible_managed=0, com.rackspace__1__build_core=1, org.openstack__1__os_version=6.0, org.openstack__1__architecture=x64, com.rackspace__1__build_managed=0}}
-    public static final String RACKSPACE_CENTOS_IMAGE_NAME_REGEX = "CentOS 6.0";
-    
-    // Image: {id=LON/29fe3e2b-f119-4715-927b-763e99ebe23e, providerId=29fe3e2b-f119-4715-927b-763e99ebe23e, name=Debian 6.06 (Squeeze), location={scope=ZONE, id=LON, description=LON, parent=rackspace-cloudservers-uk, iso3166Codes=[GB-SLG]}, os={family=debian, name=Debian 6.06 (Squeeze), version=6.0, description=Debian 6.06 (Squeeze), is64Bit=true}, description=Debian 6.06 (Squeeze), status=AVAILABLE, loginUser=root, userMetadata={os_distro=debian, com.rackspace__1__visible_core=1, com.rackspace__1__build_rackconnect=1, com.rackspace__1__options=0, image_type=base, cache_in_nova=True, com.rackspace__1__source=kickstart, org.openstack__1__os_distro=org.debian, com.rackspace__1__release_build_date=2013-08-06_13-05-36, auto_disk_config=True, com.rackspace__1__release_version=4, os_type=linux, com.rackspace__1__visible_rackconnect=1, com.rackspace__1__release_id=300, com.rackspace__1__visible_managed=0, com.rackspace__1__build_core=1, org.openstack__1__os_version=6.06, org.openstack__1__architecture=x64, com.rackspace__1__build_managed=0}}
-    public static final String RACKSPACE_DEBIAN_IMAGE_NAME_REGEX = "Debian 6";
-    
     protected JcloudsSshMachineLocation machine;
     
     private File privateRsaFile = new File(Os.tidyPath("~/.ssh/id_rsa"));
@@ -80,12 +81,13 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     private boolean publicDsaFileMoved;
 
     @Test(groups = {"Live"})
+    @SuppressWarnings("deprecation")
     protected void testAwsEc2SpecifyingJustPrivateSshKeyInDeprecatedForm() throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.LEGACY_PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         
-        machine = createEc2Machine(ImmutableMap.<String,Object>of());
+        machine = createEc2Machine();
         assertSshable(machine);
         
         assertSshable(ImmutableMap.builder()
@@ -96,13 +98,14 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     }
     
     @Test(groups = {"Live"})
+    @SuppressWarnings("deprecation")
     protected void testAwsEc2SpecifyingPrivateAndPublicSshKeyInDeprecatedForm() throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.LEGACY_PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.LEGACY_PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         
-        machine = createEc2Machine(ImmutableMap.<String,Object>of());
+        machine = createEc2Machine();
         assertSshable(machine);
         
         assertSshable(ImmutableMap.builder()
@@ -118,7 +121,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         
-        machine = createEc2Machine(ImmutableMap.<String,Object>of());
+        machine = createEc2Machine();
         assertSshable(machine);
         
         assertSshable(ImmutableMap.builder()
@@ -135,9 +138,9 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
             
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
-            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
             
-            machine = createRackspaceMachine(ImmutableMap.of("imageNameRegex", RACKSPACE_DEBIAN_IMAGE_NAME_REGEX));
+            machine = createEc2Machine();
             assertSshable(machine);
             
             assertSshable(ImmutableMap.builder()
@@ -157,9 +160,9 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
             moveSshKeyFiles();
             
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
-            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
             
-            machine = createRackspaceMachine(ImmutableMap.of("imageNameRegex", RACKSPACE_DEBIAN_IMAGE_NAME_REGEX));
+            machine = createEc2Machine();
             assertSshable(machine);
             assertEquals(machine.getUser(), "myname");
         } finally {
@@ -173,9 +176,9 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         
-        machine = createRackspaceMachine(ImmutableMap.of("imageNameRegex", RACKSPACE_DEBIAN_IMAGE_NAME_REGEX));
+        machine = createEc2Machine();
         assertSshable(machine);
         
         assertSshable(ImmutableMap.builder()
@@ -195,9 +198,32 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     protected void testSpecifyingPasswordIgnoresDefaultSshKeys() throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         
-        machine = createRackspaceMachine(ImmutableMap.of("imageNameRegex", RACKSPACE_DEBIAN_IMAGE_NAME_REGEX));
+        machine = createEc2Machine();
+        assertSshable(machine);
+        
+        assertSshable(ImmutableMap.builder()
+                .put("address", machine.getAddress())
+                .put("user", "myname")
+                .put(SshMachineLocation.PASSWORD, "mypassword")
+                .build());
+        
+        assertNotSshable(ImmutableMap.builder()
+            .put("address", machine.getAddress())
+            .put("user", "myname")
+            .put(SshMachineLocation.PRIVATE_KEY_FILE, Os.tidyPath("~/.ssh/id_rsa"))
+            .build());
+    }
+
+    @Test(groups = {"Live"})
+    protected void testSpecifyingPasswordIgnoresDefaultSshKeysSkippingJcloudsInit() throws Exception {
+        brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
+        brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
+        brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USE_JCLOUDS_SSH_INIT.getName(), "false");
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        
+        machine = createEc2Machine();
         assertSshable(machine);
         
         assertSshable(ImmutableMap.builder()
@@ -218,9 +244,9 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         
-        machine = createRackspaceMachine(ImmutableMap.of("imageNameRegex", RACKSPACE_DEBIAN_IMAGE_NAME_REGEX));
+        machine = createEc2Machine();
         assertSshable(machine);
         
         assertSshable(ImmutableMap.builder()
@@ -244,9 +270,9 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
             
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "root");
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
-            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
             
-            machine = createRackspaceMachine(ImmutableMap.of("imageNameRegex", RACKSPACE_DEBIAN_IMAGE_NAME_REGEX));
+            machine = createEc2Machine();
             assertSshable(machine);
             
             assertSshable(ImmutableMap.builder()
@@ -316,6 +342,10 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     protected void releaseMachine(JcloudsSshMachineLocation machine) {
         jcloudsLocation.release(machine);
     }
+
+    private JcloudsSshMachineLocation createEc2Machine() throws Exception {
+        return createEc2Machine(ImmutableMap.<String, Object>of());
+    }
     
     private JcloudsSshMachineLocation createEc2Machine(Map<String,? extends Object> conf) throws Exception {
         return obtainMachine(MutableMap.<String,Object>builder()
@@ -325,14 +355,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
                 .putIfAbsent("inboundPorts", ImmutableList.of(22))
                 .build());
     }
-    
-    private JcloudsSshMachineLocation createRackspaceMachine(Map<String,? extends Object> conf) throws Exception {
-        return obtainMachine(MutableMap.<String,Object>builder()
-                .putAll(conf)
-                .putIfAbsent("inboundPorts", ImmutableList.of(22))
-                .build());
-    }
-    
+
     protected void assertSshable(Map<?,?> machineConfig) {
         SshMachineLocation machineWithThatConfig = managementContext.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure(machineConfig));

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -26,6 +26,7 @@ import java.net.NetworkInterface;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -486,6 +487,12 @@ public class Networking {
     }
     
     public static boolean isReachable(HostAndPort endpoint) {
+        // TODO Should we create an unconnected socket, and then use the calls below (see jclouds' InetSocketAddressConnect):
+        //      socket.setReuseAddress(false);
+        //      socket.setSoLinger(false, 1);
+        //      socket.setSoTimeout(timeout);
+        //      socket.connect(socketAddress, timeout);
+        
         try {
             Socket s = new Socket(endpoint.getHostText(), endpoint.getPort());
             closeQuietly(s);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/ReachableSocketFinder.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/ReachableSocketFinder.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.util.net;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
+import org.apache.brooklyn.util.repeat.Repeater;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+/**
+ * For finding an open/reachable ip:port for a node.
+ */
+public class ReachableSocketFinder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReachableSocketFinder.class);
+
+    private final Predicate<HostAndPort> socketTester;
+    private final ListeningExecutorService userExecutor;
+
+    public ReachableSocketFinder(ListeningExecutorService userExecutor) {
+        this(
+                new Predicate<HostAndPort>() {
+                    @Override public boolean apply(HostAndPort input) {
+                        return Networking.isReachable(input);
+                    }}, 
+                userExecutor);
+    }
+
+    public ReachableSocketFinder(Predicate<HostAndPort> socketTester, ListeningExecutorService userExecutor) {
+        this.socketTester = checkNotNull(socketTester, "socketTester");
+        this.userExecutor = checkNotNull(userExecutor, "userExecutor");
+    }
+
+    /**
+     * 
+     * @param sockets The host-and-ports to test
+     * @param timeout Max time to try to connect to the ip:port
+     * 
+     * @return The reachable ip:port
+     * @throws NoSuchElementException If no ports accessible within the given time
+     * @throws NullPointerException  If the sockets or duration is null
+     * @throws IllegalStateException  If the sockets to test is empty
+     */
+    public HostAndPort findOpenSocketOnNode(final Collection<? extends HostAndPort> sockets, Duration timeout) {
+        checkNotNull(sockets, "sockets");
+        checkState(sockets.size() > 0, "No hostAndPort sockets supplied");
+        
+        LOG.debug("blocking on any reachable socket in {} for {}", sockets, timeout);
+
+        final AtomicReference<HostAndPort> result = new AtomicReference<HostAndPort>();
+        boolean passed = Repeater.create("socket-reachable")
+                .limitTimeTo(timeout)
+                .backoffTo(Duration.FIVE_SECONDS)
+                .until(new Callable<Boolean>() {
+                        public Boolean call() {
+                            Optional<HostAndPort> reachableSocket = tryReachable(sockets, Duration.seconds(2));
+                            if (reachableSocket.isPresent()) {
+                                result.compareAndSet(null, reachableSocket.get());
+                                return true;
+                            }
+                            return false;
+                        }})
+                .run();
+
+        if (passed) {
+            LOG.debug("<< socket {} opened", result);
+            assert result.get() != null;
+            return result.get();
+        } else {
+            LOG.warn("No sockets in {} reachable after {}", sockets, timeout);
+            throw new NoSuchElementException("could not connect to any socket in " + sockets);
+        }
+    }
+
+    /**
+     * Checks if any any of the given HostAndPorts are reachable. It checks them all concurrently, and
+     * returns the first that is reachable (or Optional.absent).
+     */
+    private Optional<HostAndPort> tryReachable(Collection<? extends HostAndPort> sockets, Duration timeout) {
+        final AtomicReference<HostAndPort> reachableSocket = new AtomicReference<HostAndPort>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        List<ListenableFuture<?>> futures = Lists.newArrayList();
+        for (final HostAndPort socket : sockets) {
+            futures.add(userExecutor.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            if (socketTester.apply(socket)) {
+                                reachableSocket.compareAndSet(null, socket);
+                                latch.countDown();
+                            }
+                        } catch (RuntimeInterruptedException e) {
+                            throw e;
+                        } catch (RuntimeException e) {
+                            LOG.warn("Error checking reachability of ip:port "+socket, e);
+                        }
+                    }}));
+        }
+        
+        ListenableFuture<List<Object>> compoundFuture = Futures.successfulAsList(futures);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            while (reachableSocket.get() == null && !compoundFuture.isDone() && timeout.isLongerThan(stopwatch)) {
+                latch.await(50, TimeUnit.MILLISECONDS);
+            }            
+            return Optional.fromNullable(reachableSocket.get());
+            
+        } catch (InterruptedException e) {
+            throw Exceptions.propagate(e);
+        } finally {
+            for (Future<?> future : futures) {
+                future.cancel(true);
+            }
+        }
+    }
+}

--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/NetworkingUtilsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/NetworkingUtilsTest.java
@@ -100,14 +100,15 @@ public class NetworkingUtilsTest {
     
     @Test
     public void testIsPortAvailableReportsTrueWhenPortIsFree() throws Exception {
+        final int MIN_FREE = 5;
         int port = 58769;
         int numFree = 0;
-        for (int i = 0; i < 10; i++) {
-            if (Networking.isPortAvailable(port))
+        for (int i = 0; i < 50 && numFree < MIN_FREE; i++) {
+            if (Networking.isPortAvailable(port+i))
                 numFree++;
         }
-        if (numFree<=5)
-            fail("This test requires that at least some ports near 58769+ not be in use.");
+        if (numFree < MIN_FREE)
+            fail("This test requires that at least some ports near "+port+"+ not be in use.");
     }
 
     @Test

--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/ReachableSocketFinderTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/ReachableSocketFinderTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.util.net;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
+
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+
+public class ReachableSocketFinderTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReachableSocketFinderTest.class);
+
+    private HostAndPort socket1;
+    private HostAndPort socket2;
+    private Map<HostAndPort, Boolean> reachabilityResults;
+    private ListeningExecutorService executor;
+    private Predicate<HostAndPort> socketTester;
+    private ReachableSocketFinder finder;
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        socket1 = HostAndPort.fromParts("1.1.1.1", 1111);
+        socket2 = HostAndPort.fromParts("1.1.1.2", 1112);
+        reachabilityResults = Maps.newConcurrentMap();
+        executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+        socketTester = new Predicate<HostAndPort>() {
+            @Override public boolean apply(HostAndPort input) {
+                return Boolean.TRUE.equals(reachabilityResults.get(input));
+            }
+        };
+        
+        finder = new ReachableSocketFinder(socketTester, executor);
+    }
+
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        if (executor != null) executor.shutdownNow();
+    }
+    
+    @Test(expectedExceptions=IllegalStateException.class)
+    public void testWhenNoSocketsThrowsIllegalState() throws Exception {
+        finder.findOpenSocketOnNode(ImmutableList.<HostAndPort>of(), Duration.TEN_SECONDS);
+    }
+    
+    @Test
+    public void testReturnsReachableSocket() throws Exception {
+        reachabilityResults.put(socket1, true);
+        reachabilityResults.put(socket2, false);
+        assertEquals(finder.findOpenSocketOnNode(ImmutableList.<HostAndPort>of(socket1, socket2), Duration.TEN_SECONDS), socket1);
+        
+        reachabilityResults.put(socket1, false);
+        reachabilityResults.put(socket2, true);
+        assertEquals(finder.findOpenSocketOnNode(ImmutableList.<HostAndPort>of(socket1, socket2), Duration.TEN_SECONDS), socket2);
+    }
+    
+    @Test
+    public void testPollsUntilPortReachable() throws Exception {
+        reachabilityResults.put(socket1, false);
+        reachabilityResults.put(socket2, false);
+        final ListenableFuture<HostAndPort> future = executor.submit(new Callable<HostAndPort>() {
+                @Override public HostAndPort call() throws Exception {
+                    return finder.findOpenSocketOnNode(ImmutableList.<HostAndPort>of(socket1, socket2), Duration.TEN_SECONDS);
+                }});
+
+        // Should keep trying
+        Asserts.succeedsContinually(new Runnable() {
+            @Override public void run() {
+                assertFalse(future.isDone());
+            }});
+
+        // When port is reached, it completes
+        reachabilityResults.put(socket1, true);
+        assertEquals(future.get(30, TimeUnit.SECONDS), socket1);
+    }
+    
+    // Mark as integration, as can't rely (in Apache infra) for a port to stay unused during test!
+    @Test(groups="Integration")
+    public void testReturnsRealReachableSocket() throws Exception {
+        ReachableSocketFinder realFinder = new ReachableSocketFinder(executor);
+        ServerSocket socket = connectToPort();
+        try {
+            HostAndPort addr = HostAndPort.fromParts(socket.getInetAddress().getHostAddress(), socket.getLocalPort());
+            HostAndPort wrongAddr = HostAndPort.fromParts(socket.getInetAddress().getHostAddress(), findAvailablePort());
+            
+            assertEquals(realFinder.findOpenSocketOnNode(ImmutableList.of(addr, wrongAddr), Duration.ONE_MINUTE), addr);
+        } finally {
+            if (socket != null) {
+                socket.close();
+            }
+        }
+    }
+
+    // Mark as integration, as can't rely (in Apache infra) for a port to stay unused during test!
+    // And slow test - takes 5 seconds.
+    @Test(groups="Integration")
+    public void testFailsIfRealSocketUnreachable() throws Exception {
+        ReachableSocketFinder realFinder = new ReachableSocketFinder(executor);
+        HostAndPort wrongAddr = HostAndPort.fromParts(Networking.getLocalHost().getHostAddress(), findAvailablePort());
+        
+        try {
+            HostAndPort result = realFinder.findOpenSocketOnNode(ImmutableList.of(wrongAddr), Duration.FIVE_SECONDS);
+            fail("Expected failure, but got "+result);
+        } catch (NoSuchElementException e) {
+            // success
+        }
+    }
+
+    private ServerSocket connectToPort() throws Exception {
+        ServerSocket result = new ServerSocket(0);
+        LOG.info("Acquired port "+result+" for test "+JavaClassNames.niceClassAndMethod());
+        return result;
+    }
+    
+    private int findAvailablePort() throws Exception {
+        final int startPort = 58767;
+        final int endPort = 60000;
+        int port = startPort;
+        do {
+            if (Networking.isPortAvailable(port)) {
+                return port;
+            }
+            port++;
+            // repeat until we can get a port
+        } while (port <= endPort);
+        throw new Exception("could not get a port in range "+startPort+"-"+endPort);
+    }
+}


### PR DESCRIPTION
(Unrelated to other changes, fixes `NetworkingUtilsTest.testIsPortAvailableReportsTrueWhenPortIsFree`).

Lots of fixes to get the `JcloudsLoginLiveTest` working again.

- registerJcloudsSshMachineLocation: use the userCredentials that are passed into the method, rather than looking up what we expect from the config.  
  (Hopefully fixes testSpecifyingPasswordAndSshKeysPrefersKeys).
- Fix waitForSshable to when password supplied on JcloudsLocation config, and using useJcloudsSshInit=false.
- Fix use of DISABLE_ROOT_AND_PASSWORD_SSH: if for root user with password-based login, then explicitly set PasswordAuthentication=yes.  
  If root user, then explicitly set PermitRootLogin=true
- Fix getPublicHostnameAws so pass in the credentials (some code-paths will not have configured the credentials in the generic config).  
  Same for getPrivateHostnameAws.
- Tidy up the createTemporarySshMachineLocaton
- Logging of timing: include how long to get semaphore
- Logging of failure: include how long for each stage
    
Previously hit a problem when the jclouds location was configured with
a password + a blank ssh key, and using useJcloudsSshInit=false.
It failed to ssh to the newly provisioned AWS VM in waitForSshable. It
got the node.getCredentials, which gives us the ssh-key from the AWS
key-pair. But then we instantiate an SshMachineLocation to check if we
can connection (before continuing with the user-setup). That
machineLocation inherits the password (which has not been set on the
machine), so it fails to ssh - the password takes precedence over the
ssh-key.
