### PR TITLE
Add YAML port range support

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/location/PortRangesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/PortRangesTest.java
@@ -40,8 +40,8 @@ public class PortRangesTest {
     }
 
     @Test
-    public void testFromCollection() {
-        PortRange r = PortRanges.fromCollection(ImmutableList.of(1234, 2345));
+    public void testFromIterable() {
+        PortRange r = PortRanges.fromIterable(ImmutableList.of(1234, 2345));
         assertContents(r, 1234, 2345);
     }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/StringEscapes.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/StringEscapes.java
@@ -362,7 +362,7 @@ public class StringEscapes {
             String i1 = input.trim();
             
             boolean inBrackets = (i1.startsWith("[") && i1.endsWith("]"));
-            if (inBrackets) i1 = i1.substring(1, i1.length()-2).trim();
+            if (inBrackets) i1 = i1.substring(1, i1.length()-1).trim();
                 
             QuotedStringTokenizer qst = new QuotedStringTokenizer(i1, "\"", true, ",", false);
             while (qst.hasMoreTokens()) {


### PR DESCRIPTION
All values supported by `org.apache.brooklyn.core.location.PortRanges.fromString(String)` can now be included in `inboundPorts` in YAML blueprints.

Example:

```
name: "Port Range Example"
location: <cloud provider>

services:
- type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
  name: VM
  
  provisioning.properties:
    inboundPorts:
    - 88
    - 100-200
    - 8080+
```