### PR TITLE
Adds support for interfaces tag on catalog items

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -558,7 +558,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             throw new IllegalStateException("Could not resolve plan once id and itemType are known (recursive reference?): "+sourceYaml);
         }
         String sourcePlanYaml = planInterpreter.getPlanYaml();
-        
+
         CatalogItemDtoAbstract<?, ?> dto = createItemBuilder(itemType, symbolicName, version)
             .libraries(libraryBundles)
             .displayName(displayName)
@@ -859,6 +859,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         log.debug("Adding manual catalog item to "+mgmt+": "+yaml);
         checkNotNull(yaml, "yaml");
         List<CatalogItemDtoAbstract<?, ?>> result = collectCatalogItems(yaml);
+
         // do this at the end for atomic updates; if there are intra-yaml references, we handle them specially
         for (CatalogItemDtoAbstract<?, ?> item: result) {
             addItemDto(item, forceUpdate);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogClasspathDo.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogClasspathDo.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.javalang.ReflectionScanner;
@@ -46,6 +47,7 @@ import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Time;
+import org.apache.commons.lang3.ClassUtils;
 import org.reflections.util.ClasspathHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -299,14 +301,17 @@ public class CatalogClasspathDo {
      * @deprecated since 0.7.0 the classpath DO is replaced by libraries */
     @Deprecated
     public CatalogItem<?,?> addCatalogEntry(CatalogItemDtoAbstract<?,?> item, Class<?> c) {
-        Catalog annotations = c.getAnnotation(Catalog.class);
+        Catalog catalogAnnotation = c.getAnnotation(Catalog.class);
         item.setSymbolicName(c.getName());
         item.setJavaType(c.getName());
         item.setDisplayName(firstNonEmpty(c.getSimpleName(), c.getName()));
-        if (annotations!=null) {
-            item.setDisplayName(firstNonEmpty(annotations.name(), item.getDisplayName()));
-            item.setDescription(firstNonEmpty(annotations.description()));
-            item.setIconUrl(firstNonEmpty(annotations.iconUrl()));
+        if (catalogAnnotation!=null) {
+            item.setDisplayName(firstNonEmpty(catalogAnnotation.name(), item.getDisplayName()));
+            item.setDescription(firstNonEmpty(catalogAnnotation.description()));
+            item.setIconUrl(firstNonEmpty(catalogAnnotation.iconUrl()));
+        }
+        if (item instanceof CatalogEntityItemDto || item instanceof CatalogTemplateItemDto) {
+            item.tags().addTag(BrooklynTags.newInterfacesTag(ClassUtils.getAllInterfaces(c)));
         }
         if (log.isTraceEnabled())
             log.trace("adding to catalog: "+c+" (from catalog "+catalog+")");

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
@@ -126,6 +126,11 @@ public class CatalogItemBuilder<CIConcreteType extends CatalogItemDtoAbstract<?,
         return this;
     }
 
+    public CatalogItemBuilder<CIConcreteType> tag(Object tag) {
+        dto.tags().addTag(tag);
+        return this;
+    }
+
     public CIConcreteType build() {
         Preconditions.checkNotNull(dto.getSymbolicName());
         Preconditions.checkNotNull(dto.getVersion());

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDo.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDo.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.core.catalog.internal;
 
 import java.util.Collection;
-import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -28,7 +27,6 @@ import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.CatalogItemMemento;
-import org.apache.brooklyn.api.objs.SpecParameter;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.core.relations.EmptyRelationSupport;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
@@ -19,10 +19,12 @@
 package org.apache.brooklyn.core.mgmt;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Objects;
 
 /** @since 0.7.0 some strongly typed tags for reference; note these may migrate elsewhere! */
 @Beta
@@ -51,9 +53,42 @@ public class BrooklynTags {
             return contents;
         }
     }
+
+    public static class InterfacesTag {
+        @JsonProperty
+        final List<Class<?>> interfaces;
+
+        public InterfacesTag(List<Class<?>> interfaces) {
+            this.interfaces = interfaces;
+        }
+
+        public List<Class<?>> getInterfaces() {
+            return interfaces;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            InterfacesTag that = (InterfacesTag) o;
+
+            return interfaces == null
+                    ? that.interfaces == null
+                    : interfaces.equals(that.interfaces);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(interfaces);
+        }
+    }
     
     public static NamedStringTag newYamlSpecTag(String contents) { return new NamedStringTag(YAML_SPEC_KIND, contents); }
     public static NamedStringTag newNotesTag(String contents) { return new NamedStringTag(NOTES_KIND, contents); }
+    public static InterfacesTag newInterfacesTag(List<Class<?>> interfaces) {
+        return new InterfacesTag(interfaces);
+    }
     
     public static NamedStringTag findFirst(String kind, Iterable<Object> tags) {
         for (Object object: tags) {

--- a/core/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilderTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.catalog.internal;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.brooklyn.api.catalog.CatalogItem;
+import org.apache.brooklyn.api.objs.SpecParameter;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class CatalogItemBuilderTest {
+
+    private String symbolicName = "test";
+    private String version = "1.0.0";
+    private String javaType = "1.0.0";
+    private String name = "My name";
+    private String displayName = "My display name";
+    private String description = "My long description";
+    private String iconUrl = "http://my.icon.url";
+    private boolean deprecated = true;
+    private boolean disabled = true;
+    private String plan = "name: my.yaml.plan";
+    private List<CatalogItem.CatalogBundle> libraries = ImmutableList.<CatalogItem.CatalogBundle>of(new CatalogBundleDto(name, version, null));
+    private Object tag = new Object();
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testCannotBuildWithoutName() {
+        new CatalogItemBuilder<CatalogEntityItemDto>(new CatalogEntityItemDto())
+                .symbolicName(null)
+                .build();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testCannotBuildWithoutVersion() {
+        new CatalogItemBuilder<CatalogEntityItemDto>(new CatalogEntityItemDto())
+                .version(null)
+                .build();
+    }
+
+    @Test
+    public void testNewEntityReturnCatalogEntityItemDto() {
+        final CatalogItem catalogItem = CatalogItemBuilder.newEntity(symbolicName, version).build();
+
+        assertTrue(catalogItem != null);
+    }
+
+    @Test
+    public void testNewLocationReturnCatalogLocationItemDto() {
+        final CatalogItem catalogItem = CatalogItemBuilder.newLocation(symbolicName, version).build();
+
+        assertTrue(catalogItem != null);
+    }
+
+    @Test
+    public void testNewPolicyReturnCatalogPolicyItemDto() {
+        final CatalogItem catalogItem = CatalogItemBuilder.newPolicy(symbolicName, version).build();
+
+        assertTrue(catalogItem != null);
+    }
+
+    @Test
+    public void testNewTemplateReturnCatalogTemplateItemDto() {
+        final CatalogItem<?, ?> catalogItem = CatalogItemBuilder.newTemplate(symbolicName, version).build();
+
+        assertTrue(catalogItem != null);
+    }
+
+    @Test
+    public void testEmptyLibrariesIfNotSpecified() {
+        final CatalogItem catalogItem = CatalogItemBuilder.newEntity(symbolicName, version).build();
+
+        assertEquals(catalogItem.getLibraries().size(), 0);
+    }
+
+    @Test
+    public void testNameReplacedByDisplayName() {
+        final CatalogEntityItemDto catalogItem = CatalogItemBuilder.newEntity(symbolicName, version)
+                .name(name)
+                .displayName(displayName)
+                .build();
+
+        assertEquals(catalogItem.getName(), displayName);
+    }
+
+    @Test
+    public void testBuiltEntity() {
+        final CatalogEntityItemDto catalogItem = CatalogItemBuilder.newEntity(symbolicName, version)
+                .javaType(javaType)
+                .displayName(displayName)
+                .description(description)
+                .iconUrl(iconUrl)
+                .deprecated(deprecated)
+                .disabled(disabled)
+                .plan(plan)
+                .libraries(libraries)
+                .tag(tag)
+                .build();
+
+        assertEquals(catalogItem.getSymbolicName(), symbolicName);
+        assertEquals(catalogItem.getVersion(), version);
+        assertEquals(catalogItem.getJavaType(), javaType);
+        assertEquals(catalogItem.getDisplayName(), displayName);
+        assertEquals(catalogItem.getIconUrl(), iconUrl);
+        assertEquals(catalogItem.isDeprecated(), deprecated);
+        assertEquals(catalogItem.isDisabled(), disabled);
+        assertEquals(catalogItem.getPlanYaml(), plan);
+        assertEquals(catalogItem.getLibraries(), libraries);
+        assertEquals(catalogItem.tags().getTags().size(), 1);
+        assertTrue(catalogItem.tags().getTags().contains(tag));
+    }
+}

--- a/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogEntitySummary.java
+++ b/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogEntitySummary.java
@@ -29,7 +29,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 public class CatalogEntitySummary extends CatalogItemSummary {
 
     private static final long serialVersionUID = 1063908984191424539L;
-    
+
     @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final Set<EntityConfigSummary> config;
     
@@ -46,13 +46,14 @@ public class CatalogEntitySummary extends CatalogItemSummary {
             @JsonProperty("planYaml") String planYaml,
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
+            @JsonProperty("tags") Set<Object> tags,
             @JsonProperty("config") Set<EntityConfigSummary> config, 
             @JsonProperty("sensors") Set<SensorSummary> sensors, 
             @JsonProperty("effectors") Set<EffectorSummary> effectors,
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
         ) {
-        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, deprecated, links);
+        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, tags, deprecated, links);
         this.config = config;
         this.sensors = sensors;
         this.effectors = effectors;

--- a/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogItemSummary.java
+++ b/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogItemSummary.java
@@ -20,7 +20,10 @@ package org.apache.brooklyn.rest.domain;
 
 import java.io.Serializable;
 import java.net.URI;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
@@ -29,6 +32,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /** variant of Catalog*ItemDto objects for JS/JSON serialization;
@@ -55,6 +59,8 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
     @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final String iconUrl;
     private final String planYaml;
+    @JsonSerialize(include=Inclusion.NON_EMPTY)
+    private final List<Object> tags;
     private final boolean deprecated;
     
     private final Map<String, URI> links;
@@ -67,6 +73,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
             @JsonProperty("planYaml") String planYaml,
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
+            @JsonProperty("tags") Set<Object> tags,
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
             ) {
@@ -79,6 +86,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
         this.planYaml = planYaml;
         this.description = description;
         this.iconUrl = iconUrl;
+        this.tags = (tags == null) ? ImmutableList.of() : ImmutableList.copyOf(tags);
         this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
         this.deprecated = deprecated;
     }
@@ -121,6 +129,10 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
         return iconUrl;
     }
 
+    public Collection<Object> getTags() {
+        return tags;
+    }
+
     public Map<String, URI> getLinks() {
         return links;
     }
@@ -140,7 +152,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(symbolicName, version, name, javaType, deprecated);
+        return Objects.hashCode(symbolicName, version, name, javaType, tags, deprecated);
     }
     
     @Override

--- a/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogLocationSummary.java
+++ b/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogLocationSummary.java
@@ -41,10 +41,11 @@ public class CatalogLocationSummary extends CatalogItemSummary {
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
             @JsonProperty("config") Set<LocationConfigSummary> config,
+            @JsonProperty("tags") Set<Object> tags,
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
         ) {
-        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, deprecated, links);
+        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, tags, deprecated, links);
         // TODO expose config from policies
         this.config = (config == null) ? ImmutableSet.<LocationConfigSummary>of() : config;
     }

--- a/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogPolicySummary.java
+++ b/usage/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogPolicySummary.java
@@ -44,10 +44,11 @@ public class CatalogPolicySummary extends CatalogItemSummary {
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
             @JsonProperty("config") Set<PolicyConfigSummary> config,
+            @JsonProperty("tags") Set<Object> tags,
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
         ) {
-        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, deprecated, links);
+        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, tags, deprecated, links);
         // TODO expose config from policies
         this.config = (config == null) ? ImmutableSet.<PolicyConfigSummary>of() : config;
     }

--- a/usage/rest-server/pom.xml
+++ b/usage/rest-server/pom.xml
@@ -231,6 +231,13 @@
             <artifactId>jersey-test-framework-inmemory</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-rt-osgi</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.core.entity.EntityDynamicType;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.objs.BrooklynTypes;
 import org.apache.brooklyn.rest.domain.CatalogEntitySummary;
 import org.apache.brooklyn.rest.domain.CatalogItemSummary;
@@ -48,7 +49,9 @@ import org.apache.brooklyn.rest.domain.SensorSummary;
 import org.apache.brooklyn.rest.domain.SummaryComparators;
 import org.apache.brooklyn.rest.util.BrooklynRestResourceUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.commons.lang.ClassUtils;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
@@ -63,9 +66,10 @@ public class CatalogTransformer {
         Set<SensorSummary> sensors = Sets.newTreeSet(SummaryComparators.nameComparator());
         Set<EffectorSummary> effectors = Sets.newTreeSet(SummaryComparators.nameComparator());
 
+        EntitySpec<?> spec = null;
+
         try {
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            EntitySpec<?> spec = (EntitySpec<?>) b.getCatalog().createSpec((CatalogItem) item);
+            spec = (EntitySpec<?>) b.getCatalog().createSpec((CatalogItem) item);
             EntityDynamicType typeMap = BrooklynTypes.getDefinedEntityType(spec.getType());
             EntityType type = typeMap.getSnapshot();
 
@@ -75,7 +79,7 @@ public class CatalogTransformer {
                 sensors.add(SensorTransformer.sensorSummaryForCatalog(x));
             for (Effector<?> x: type.getEffectors())
                 effectors.add(EffectorTransformer.effectorSummaryForCatalog(x));
-            
+
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
             
@@ -91,7 +95,7 @@ public class CatalogTransformer {
         return new CatalogEntitySummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
             item.getJavaType(), item.getPlanYaml(),
             item.getDescription(), tidyIconLink(b, item, item.getIconUrl()),
-            config, sensors, effectors,
+            makeTags(spec, item), config, sensors, effectors,
             item.isDeprecated(), makeLinks(item));
     }
 
@@ -115,7 +119,7 @@ public class CatalogTransformer {
         }
         return new CatalogItemSummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
             item.getJavaType(), item.getPlanYaml(),
-            item.getDescription(), tidyIconLink(b, item, item.getIconUrl()), item.isDeprecated(), makeLinks(item));
+            item.getDescription(), tidyIconLink(b, item, item.getIconUrl()), item.tags().getTags(), item.isDeprecated(), makeLinks(item));
     }
 
     public static CatalogPolicySummary catalogPolicySummary(BrooklynRestResourceUtils b, CatalogItem<? extends Policy,PolicySpec<?>> item) {
@@ -123,7 +127,7 @@ public class CatalogTransformer {
         return new CatalogPolicySummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
                 item.getJavaType(), item.getPlanYaml(),
                 item.getDescription(), tidyIconLink(b, item, item.getIconUrl()), config,
-                item.isDeprecated(), makeLinks(item));
+                item.tags().getTags(), item.isDeprecated(), makeLinks(item));
     }
 
     public static CatalogLocationSummary catalogLocationSummary(BrooklynRestResourceUtils b, CatalogItem<? extends Location,LocationSpec<?>> item) {
@@ -131,7 +135,7 @@ public class CatalogTransformer {
         return new CatalogLocationSummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
                 item.getJavaType(), item.getPlanYaml(),
                 item.getDescription(), tidyIconLink(b, item, item.getIconUrl()), config,
-                item.isDeprecated(), makeLinks(item));
+                item.tags().getTags(), item.isDeprecated(), makeLinks(item));
     }
 
     protected static Map<String, URI> makeLinks(CatalogItem<?,?> item) {
@@ -158,6 +162,20 @@ public class CatalogTransformer {
         if (b.isUrlServerSideAndSafe(iconUrl))
             return "/v1/catalog/icon/"+item.getSymbolicName() + "/" + item.getVersion();
         return iconUrl;
+    }
+
+    private static Set<Object> makeTags(EntitySpec<?> spec, CatalogItem<?, ?> item) {
+        Class<?> type = null;
+        if (spec.getImplementation() != null) {
+            type = spec.getImplementation();
+        } else {
+            type = spec.getType();
+        }
+
+        return MutableSet.builder()
+                .addAll(item.tags().getTags())
+                .add(new BrooklynTags.InterfacesTag(ClassUtils.getAllInterfaces(type)))
+                .build();
     }
     
 }


### PR DESCRIPTION
This adds, for each catalog item, all its implemented interfaces as a tag. It also exposed catalog items' tags on the REST API.

This is based on the code provided by #1020 