### PR TITLE
Adds WinRmTool interface

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -177,6 +177,10 @@ public class BrooklynConfigKeys {
      * and have this prefix pre-prended to the config keys in this class. */
     public static final String BROOKLYN_SSH_CONFIG_KEY_PREFIX = "brooklyn.ssh.config.";
 
+    /** Public-facing global config keys for Brooklyn are defined in ConfigKeys, 
+     * and have this prefix pre-prended to the config keys in this class. */
+    public static final String BROOKLYN_WINRM_CONFIG_KEY_PREFIX = "brooklyn.winrm.config.";
+
     // some checks (this line, and a few Preconditions below) that the remote values aren't null, 
     // because they have some funny circular references
     static { assert BROOKLYN_SSH_CONFIG_KEY_PREFIX.equals(SshTool.BROOKLYN_CONFIG_KEY_PREFIX) : "static final initializer classload ordering problem"; }
@@ -184,6 +188,11 @@ public class BrooklynConfigKeys {
     public static final ConfigKey<String> SSH_TOOL_CLASS = newStringConfigKey(
             BROOKLYN_SSH_CONFIG_KEY_PREFIX + "sshToolClass", 
             "SshTool implementation to use (or null for default)", 
+            null);
+
+    public static final ConfigKey<String> WINRM_TOOL_CLASS = newStringConfigKey(
+            BROOKLYN_WINRM_CONFIG_KEY_PREFIX + "winrmToolClass", 
+            "WinRmTool implementation to use (or null for default)", 
             null);
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshTool.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshTool.java
@@ -46,7 +46,7 @@ import org.apache.brooklyn.util.time.Duration;
 public interface SshTool extends ShellTool {
     
     /** Public-facing global config keys for Brooklyn are defined in ConfigKeys, 
-     * and have this prefix pre-prended to the config keys in this class. 
+     * and have this prefix prepended to the config keys in this class. 
      * These keys are detected from entity/global config and automatically applied to ssh executions. */
     public static final String BROOKLYN_CONFIG_KEY_PREFIX = "brooklyn.ssh.config.";
     

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -18,9 +18,17 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
-import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
+import static org.apache.brooklyn.util.JavaGroovyEquivalents.elvis;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -31,6 +39,8 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.software.base.lifecycle.NativeWindowsScriptRunner;
 import org.apache.brooklyn.entity.software.base.lifecycle.WinRmExecuteHelper;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.ReferenceWithError;
@@ -42,16 +52,9 @@ import org.python.core.PyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
-import static org.apache.brooklyn.util.JavaGroovyEquivalents.elvis;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
 public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwareProcessDriver implements NativeWindowsScriptRunner {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractSoftwareProcessWinRmDriver.class);
@@ -260,7 +263,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     }
 
     public int executePsScriptNoRetry(List<String> psScript) {
-        return getLocation().executePsScriptNoRetry(psScript).getStatusCode();
+        return getLocation().executePsScript(ImmutableMap.of(WinRmTool.PROP_EXEC_TRIES, 1), psScript).getStatusCode();
     }
 
     public int executePsScript(List<String> psScript) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
@@ -59,8 +60,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
-
 /**
  * Tests execution of commands (batch and powershell) on Windows over WinRM, and of
  * file upload.
@@ -72,8 +71,8 @@ import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
  * Please update the docs if you encountered new situations, or change the behaviuor 
  * of existing use-cases.
  */
-public class WinRmMachineLocationLiveTest {
 
+public class WinRmMachineLocationLiveTest {
     private static final int MAX_EXECUTOR_THREADS = 100;
 
     /*

--- a/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.feed.windows;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -49,6 +48,7 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.internal.winrm;
+
+import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKey;
+import static org.apache.brooklyn.core.config.ConfigKeys.newIntegerConfigKey;
+import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
+
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.util.time.Duration;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+
+@Beta
+public interface WinRmTool {
+
+    /** Public-facing global config keys for Brooklyn are defined in ConfigKeys, 
+     * and have this prefix prepended to the config keys in this class. 
+     * These keys are detected from entity/global config and automatically applied to ssh executions. */
+    String BROOKLYN_CONFIG_KEY_PREFIX = Preconditions.checkNotNull(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, 
+            "static final initializer classload ordering problem");
+    
+    ConfigKey<String> PROP_HOST = newStringConfigKey("host", "Host to connect to (required)", null);
+    ConfigKey<Integer> PROP_PORT = newIntegerConfigKey("port", "WinRM port to use when connecting to the remote machine", 5985);
+    ConfigKey<String> PROP_USER = newStringConfigKey("user", "User to connect as", null);
+    ConfigKey<String> PROP_PASSWORD = newStringConfigKey("password", "Password to use to connect", null);
+
+    // TODO See SshTool#PROP_SSH_TRIES, where it was called "sshTries"; remove duplication? Merge into one well-named thing?
+    ConfigKey<Integer> PROP_EXEC_TRIES = ConfigKeys.newIntegerConfigKey(
+            "execTries", 
+            "Max number of times to attempt WinRM operations", 
+            10);
+
+    ConfigKey<Duration> PROP_EXEC_RETRY_DELAY = newConfigKey(
+            Duration.class,
+            "execRetryDelay",
+            "Max time between retries (backing off exponentially to this delay)",
+            Duration.TEN_SECONDS);
+
+    // May be ignored by implementations that more efficiently copy the file.
+    @Beta
+    ConfigKey<Integer> COPY_FILE_CHUNK_SIZE_BYTES = ConfigKeys.newIntegerConfigKey(
+            "windows.copy.file.size.bytes",
+            "Size of file chunks (in bytes) to be used when copying a file to the remote server", 
+            1024);
+
+    WinRmToolResponse executeScript(List<String> commands);
+
+    WinRmToolResponse executePs(List<String> commands);
+    
+    WinRmToolResponse copyToServer(InputStream source, String destination);
+}

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmToolResponse.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmToolResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.internal.winrm;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public class WinRmToolResponse {
+    private final String stdout;
+    private final String stderr;
+    private final int statusCode;
+
+    public WinRmToolResponse(String stdout, String stderr, int statusCode) {
+        this.stdout = stdout;
+        this.stderr = stderr;
+        this.statusCode = statusCode;
+    }
+
+    public String getStdOut() {
+        return stdout;
+    }
+
+    public String getStdErr() {
+        return stderr;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/pywinrm/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/pywinrm/Winrm4jTool.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.internal.winrm.pywinrm;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.Sanitizer;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
+
+@Beta
+public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm.WinRmTool {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Winrm4jTool.class);
+
+    private final ConfigBag bag;
+    private final String host;
+    private final Integer port;
+    private final String user;
+    private final String password;
+    private final int execTries;
+    private final Duration execRetryDelay;
+
+    public Winrm4jTool(Map<String,?> config) {
+        this(ConfigBag.newInstance(config));
+    }
+    
+    public Winrm4jTool(ConfigBag config) {
+        this.bag = checkNotNull(config, "config bag");
+        host = getRequiredConfig(config, PROP_HOST);
+        port = getRequiredConfig(config, PROP_PORT);
+        user = getRequiredConfig(config, PROP_USER);
+        password = getRequiredConfig(config, PROP_PASSWORD);
+        execTries = getRequiredConfig(config, PROP_EXEC_TRIES);
+        execRetryDelay = getRequiredConfig(config, PROP_EXEC_RETRY_DELAY);
+    }
+    
+    @Override
+    public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse executeScript(final List<String> commands) {
+        return exec(new Callable<io.cloudsoft.winrm4j.winrm.WinRmToolResponse>() {
+            @Override public WinRmToolResponse call() throws Exception {
+                return connect().executeScript(commands);
+            }
+        });
+    }
+
+    @Override
+    public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse executePs(final List<String> commands) {
+        return exec(new Callable<io.cloudsoft.winrm4j.winrm.WinRmToolResponse>() {
+            @Override public WinRmToolResponse call() throws Exception {
+                return connect().executePs(commands);
+            }
+        });
+    }
+
+    @Override
+    public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse copyToServer(InputStream source, String destination) {
+        executePs(ImmutableList.of("rm -ErrorAction SilentlyContinue " + destination));
+        try {
+            int chunkSize = getRequiredConfig(bag, COPY_FILE_CHUNK_SIZE_BYTES);
+            byte[] inputData = new byte[chunkSize];
+            int bytesRead;
+            int expectedFileSize = 0;
+            while ((bytesRead = source.read(inputData)) > 0) {
+                byte[] chunk;
+                if (bytesRead == chunkSize) {
+                    chunk = inputData;
+                } else {
+                    chunk = Arrays.copyOf(inputData, bytesRead);
+                }
+                executePs(ImmutableList.of("If ((!(Test-Path " + destination + ")) -or ((Get-Item '" + destination + "').length -eq " +
+                        expectedFileSize + ")) {Add-Content -Encoding Byte -path " + destination +
+                        " -value ([System.Convert]::FromBase64String(\"" + new String(Base64.encodeBase64(chunk)) + "\"))}"));
+                expectedFileSize += bytesRead;
+            }
+
+            return new org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse("", "", 0);
+        } catch (java.io.IOException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    private org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse exec(Callable<io.cloudsoft.winrm4j.winrm.WinRmToolResponse> task) {
+        Collection<Throwable> exceptions = Lists.newArrayList();
+        for (int i = 0; i < execTries; i++) {
+            try {
+                return wrap(task.call());
+            } catch (Exception e) {
+                Exceptions.propagateIfFatal(e);
+                Duration sleep = Duration.millis(Math.min(Math.pow(2, i) * 1000, execRetryDelay.toMilliseconds()));
+                if (i == (execTries+1)) {
+                    LOG.info("Propagating WinRM exception (attempt "+(i+1)+" of "+execTries+")", e);
+                } else if (i == 0) {
+                    LOG.warn("Ignoring WinRM exception and will retry after "+sleep+" (attempt "+(i+1)+" of "+execTries+")", e);
+                    Time.sleep(sleep);
+                } else {
+                    LOG.debug("Ignoring WinRM exception and will retry after "+sleep+" (attempt "+(i+1)+" of "+execTries+")", e);
+                    Time.sleep(sleep);
+                }
+                exceptions.add(e);
+            }
+        }
+        throw Exceptions.propagate("failed to execute command", exceptions);
+    }
+
+    private io.cloudsoft.winrm4j.winrm.WinRmTool connect() {
+        return io.cloudsoft.winrm4j.winrm.WinRmTool.connect(host+":"+port, user, password);
+    }
+    
+    private <T> T getRequiredConfig(ConfigBag bag, ConfigKey<T> key) {
+        T result = bag.get(key);
+        if (result == null) {
+            throw new IllegalArgumentException("Missing config "+key+" in "+Sanitizer.sanitize(bag));
+        }
+        return result;
+    }
+    
+    private org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse wrap(io.cloudsoft.winrm4j.winrm.WinRmToolResponse resp) {
+        return new org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse(resp.getStdOut(), resp.getStdErr(), resp.getStatusCode());
+    }
+}

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeedTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeedTest.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +42,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
-
-import io.cloudsoft.winrm4j.winrm.WinRmToolResponse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;


### PR DESCRIPTION
We want the interface/class within Brooklyn so that the rest of the code doesn't depend on winrm4j directly.

We also want to be able to swap out the Winrm4jTool for an alternative implementation, just through configuration.

Note that the unqualified interface name / class name are the same as the names in `io.cloudsoft.winrm4j.winrm.WinRmTool` and ` io.cloudsoft.winrm4j.winrm.WinRmToolResponse`. Is that a good idea? Any better suggestions for names?