### PR TITLE
Restored getting started guide landing page.

### DIFF
--- a/docs/guide/start/concept-quickstart.md
+++ b/docs/guide/start/concept-quickstart.md
@@ -4,10 +4,7 @@ layout: website-normal
 menu_parent: index.md
 ---
 
-The following section gives a quick summary of the main Brooklyn concepts you will encounter in Getting Started.  For later investigation of these concepts see [The Theory Behind Brooklyn]({{site.path.website}}/learnmore/theory.html), and the detailed description in [Brooklyn Concepts]({{site.path.guide}}/concepts/).
-
-Having examined the concepts below, get started by **[installing and launching](running.html)** Brooklyn.
-
+The following section provides a quick summary of the main Brooklyn concepts you will encounter in Getting Started.  For further discussion of these concepts see [The Theory Behind Brooklyn]({{site.path.website}}/learnmore/theory.html), and the detailed descriptions in [Brooklyn Concepts]({{site.path.guide}}/concepts/).
 
 ***Deployment and Management*** Brooklyn is built for agile deployment of applications across cloud and other targets, and real-time autonomic management. "Autonomic computing" is the concept of components looking after themselves where possible (self-healing, self-optimizing, etc).
 

--- a/docs/guide/start/index.md
+++ b/docs/guide/start/index.md
@@ -1,13 +1,12 @@
 ---
 layout: website-normal
 title: Getting Started
-menu_parent: ../index.md
 children:
-- concept-quickstart.md
 - running.md
 - blueprints.md
 - managing.md
 - policies.md
+- concept-quickstart.md
 ---
 
 {% include list-children.html %}

--- a/docs/guide/start/running.md
+++ b/docs/guide/start/running.md
@@ -7,6 +7,8 @@ menu_parent: index.md
 
 This guide will walk you through deploying an example 3-tier web application to a public cloud, and demonstrate the autoscaling capabilities of the Brooklyn platform.
 
+An overview of core [Brooklyn concepts](./concept-quickstart.html) is available for reference.
+
 This tutorial assumes that you are using Linux or Mac OS X.
 
 ## Install Apache Brooklyn

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -5,7 +5,7 @@ landing: true
 children:
 - learnmore/
 - { path: download/, menu: null }
-- { path: /guide/start/concept-quickstart.md, title: Get Started }
+- { path: /guide/start/index.md, title_in_menu: Get Started, href_path: /guide/start/running.md}
 - path: documentation/
   menu:
   - { path: /guide/index.md, title_in_menu: "User Guide", 


### PR DESCRIPTION
The concepts quickstart is moved to the end of the section and added as an suggested reference to the landing page (which is the Running Brooklyn page again) in order to simplify the flow.