### PR TITLE
EntitySpec duplication should include children

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.util.collections.MutableList;
 
+import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -127,7 +128,7 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
                 .enricherSpecs(otherSpec.getEnricherSpecs())
                 .enrichers(otherSpec.getEnrichers())
                 .addInitializers(otherSpec.getInitializers())
-                .children(otherSpec.getChildren())
+                .children(copyFromSpecs(otherSpec.getChildren()))
                 .members(otherSpec.getMembers())
                 .groups(otherSpec.getGroups())
                 .locations(otherSpec.getLocations());
@@ -136,6 +137,16 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         if (otherSpec.getImplementation() != null) impl(otherSpec.getImplementation());
         
         return this;
+    }
+
+    private List<EntitySpec<?>> copyFromSpecs(List<EntitySpec<?>> children) {
+        return Lists.<EntitySpec<?>,EntitySpec<?>>transform(children, new Function<EntitySpec<?>, EntitySpec<?>>() {
+            @Nullable
+            @Override
+            public EntitySpec<?> apply(@Nullable EntitySpec<?> entitySpec) {
+                return create(entitySpec);
+            }
+        });
     }
 
     @Override

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySpecTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySpecTest.java
@@ -50,14 +50,14 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
 
     private SimulatedLocation loc;
     private TestEntity entity;
-    
+
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
         super.setUp();
         loc = new SimulatedLocation();
     }
-    
+
     @Test
     public void testSetsConfig() throws Exception {
         // TODO Test other permutations
@@ -72,14 +72,14 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
             .displayName("child")
             .child(EntitySpec.create(TestEntity.class)
                 .displayName("grandchild")) );
-        
+
         Entity child = Iterables.getOnlyElement(app.getChildren());
         assertEquals(child, entity);
         assertEquals(child.getDisplayName(), "child");
         Entity grandchild = Iterables.getOnlyElement(child.getChildren());
         assertEquals(grandchild.getDisplayName(), "grandchild");
     }
-    
+
 
     @Test
     public void testAddsPolicySpec() throws Exception {
@@ -88,22 +88,22 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
                         .displayName("mypolicyname")
                         .configure(MyPolicy.CONF1, "myconf1val")
                         .configure("myfield", "myfieldval")));
-        
+
         Policy policy = Iterables.getOnlyElement(entity.policies());
         assertTrue(policy instanceof MyPolicy, "policy="+policy);
         assertEquals(policy.getDisplayName(), "mypolicyname");
         assertEquals(policy.getConfig(MyPolicy.CONF1), "myconf1val");
     }
-    
+
     @Test
     public void testAddsPolicy() throws Exception {
         MyPolicy policy = new MyPolicy();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
                 .policy(policy));
-        
+
         assertEquals(Iterables.getOnlyElement(entity.policies()), policy);
     }
-    
+
     @Test
     public void testAddsEnricherSpec() throws Exception {
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class, TestEntityNoEnrichersImpl.class)
@@ -111,61 +111,61 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
                         .displayName("myenrichername")
                         .configure(MyEnricher.CONF1, "myconf1val")
                         .configure("myfield", "myfieldval")));
-        
+
         Enricher enricher = Iterables.getOnlyElement(entity.enrichers());
         assertTrue(enricher instanceof MyEnricher, "enricher="+enricher);
         assertEquals(enricher.getDisplayName(), "myenrichername");
         assertEquals(enricher.getConfig(MyEnricher.CONF1), "myconf1val");
     }
-    
+
     @Test
     public void testAddsEnricher() throws Exception {
         MyEnricher enricher = new MyEnricher();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class, TestEntityNoEnrichersImpl.class)
                 .enricher(enricher));
-        
+
         assertEquals(Iterables.getOnlyElement(entity.enrichers()), enricher);
     }
-    
+
     @Test
     public void testAddsMembers() throws Exception {
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
         BasicGroup group = app.createAndManageChild(EntitySpec.create(BasicGroup.class)
                 .member(entity));
-        
+
         Asserts.assertEqualsIgnoringOrder(group.getMembers(), ImmutableSet.of(entity));
         Asserts.assertEqualsIgnoringOrder(entity.groups(), ImmutableSet.of(group));
     }
-    
+
     @Test
     public void testAddsGroups() throws Exception {
         BasicGroup group = app.createAndManageChild(EntitySpec.create(BasicGroup.class));
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
                 .group(group));
-        
+
         Asserts.assertEqualsIgnoringOrder(group.getMembers(), ImmutableSet.of(entity));
         Asserts.assertEqualsIgnoringOrder(entity.groups(), ImmutableSet.of(group));
     }
-    
+
     @Test
     public void testCallsConfigureAfterConstruction() throws Exception {
         AbstractEntityLegacyTest.MyEntity entity = app.createAndManageChild(EntitySpec.create(AbstractEntityLegacyTest.MyEntity.class));
-        
+
         assertEquals(entity.getConfigureCount(), 1);
         assertEquals(entity.getConfigureDuringConstructionCount(), 0);
     }
-    
+
     @Test
     public void testDisplayNameUsesDefault() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class));
-        
+
         assertTrue(entity.getDisplayName().startsWith("TestEntity:"+entity.getId().substring(0,4)), "displayName="+entity.getDisplayName());
     }
-    
+
     @Test
     public void testDisplayNameUsesCustom() throws Exception {
         TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).displayName("entityname"));
-        
+
         assertEquals(entity.getDisplayName(), "entityname");
     }
 
@@ -175,7 +175,7 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
                 .impl(TestEntityWithDefaultNameImpl.class)
                 .configure(TestEntityWithDefaultNameImpl.DEFAULT_NAME, "myOverriddenDefaultName"));
         assertEquals(entity.getDisplayName(), "myOverriddenDefaultName");
-    }        
+    }
 
     @Test
     public void testDisplayNameUsesCustomWhenOverriddenDefault() throws Exception {
@@ -184,30 +184,43 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
                 .configure(TestEntityWithDefaultNameImpl.DEFAULT_NAME, "myOverriddenDefaultName")
                 .displayName("myEntityName"));
         assertEquals(entity.getDisplayName(), "myEntityName");
-    }        
+    }
+
+    @Test
+    public void testCreatingEntitySpecFromSpecCreatesDuplicate() {
+        EntitySpec<TestEntity> originalChildSpec = EntitySpec.create(TestEntity.class);
+        EntitySpec<TestEntity> originalEntitySpec = EntitySpec.create(TestEntity.class).child(originalChildSpec);
+        EntitySpec<TestEntity> duplicateEntitySpec = EntitySpec.create(originalEntitySpec);
+        EntitySpec<?> duplicateChildSpec = duplicateEntitySpec.getChildren().get(0);
+
+        assertEquals(originalEntitySpec, duplicateEntitySpec);
+        assertTrue(originalEntitySpec != duplicateEntitySpec);
+        assertEquals(originalChildSpec, duplicateChildSpec);
+        assertTrue(originalChildSpec != duplicateChildSpec);
+    }
 
     public static class TestEntityWithDefaultNameImpl extends TestEntityImpl {
         public static final ConfigKey<String> DEFAULT_NAME = ConfigKeys.newStringConfigKey("defaultName");
-        
+
         @Override
         public void init() {
             super.init();
             if (getConfig(DEFAULT_NAME) != null) setDefaultDisplayName(getConfig(DEFAULT_NAME));
         }
     }
-    
+
     public static class MyPolicy extends AbstractPolicy {
         public static final BasicConfigKey<String> CONF1 = new BasicConfigKey<String>(String.class, "testpolicy.conf1", "my descr, conf1", "defaultval1");
         public static final BasicConfigKey<Integer> CONF2 = new BasicConfigKey<Integer>(Integer.class, "testpolicy.conf2", "my descr, conf2", 2);
-        
+
         @SetFromFlag
         public String myfield;
     }
-    
+
     public static class MyEnricher extends AbstractEnricher {
         public static final BasicConfigKey<String> CONF1 = new BasicConfigKey<String>(String.class, "testenricher.conf1", "my descr, conf1", "defaultval1");
         public static final BasicConfigKey<Integer> CONF2 = new BasicConfigKey<Integer>(Integer.class, "testenricher.conf2", "my descr, conf2", 2);
-        
+
         @SetFromFlag
         public String myfield;
     }


### PR DESCRIPTION
If the memberspec of a dynamiccluster had a child entityspec then it would not be possible to set or expand the cluster to more than 1 node. This is because when addentity is called the parent entity is set on the childspec.  The dynamic cluster uses EntitySpec.create to duplicate the memberspec however this doesn't duplicate any children so the original and duplicate entityspecs share children.

When using EntitySpec.create to duplicate an entityspec this change duplicates children rather than attaching original child specs.

https://issues.apache.org/jira/browse/BROOKLYN-192