### PR TITLE
BROOKLYN-197 Add jetty-schemas to launcher deps

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -168,6 +168,11 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty.toolchain</groupId>
+                <artifactId>jetty-schemas</artifactId>
+                <version>${jetty-schemas.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <felix.framework.version>4.4.0</felix.framework.version>
         <reflections.version>0.9.9-RC1</reflections.version>
         <jetty.version>9.2.13.v20150730</jetty.version>
+        <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.6</airline.version>
         <mockwebserver.version>20121111</mockwebserver.version>
         <freemarker.version>2.3.22</freemarker.version>

--- a/usage/launcher/pom.xml
+++ b/usage/launcher/pom.xml
@@ -117,6 +117,10 @@
             <artifactId>jetty-webapp</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-schemas</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>


### PR DESCRIPTION
Without this, Jetty will try to download XML schemas for the documents it processes. This means that Brooklyn requires a working connection to the public Internet. With this dependency, Jetty can discover the schemas it requires without an Internet connection.