### PR TITLE
Remove incubating references

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,8 +1,0 @@
-
-Apache Brooklyn is an effort undergoing incubation at The Apache Software Foundation (ASF), 
-sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until 
-a further review indicates that the infrastructure, communications, and decision making process 
-have stabilized in a manner consistent with other successful ASF projects. While incubation 
-status is not necessarily a reflection of the completeness or stability of the code, it does 
-indicate that the project has yet to be fully endorsed by the ASF.
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-# [![**Brooklyn**](https://brooklyn.incubator.apache.org/style/img/apache-brooklyn-logo-244px-wide.png)](http://brooklyn.incubator.apache.org/)
+# [![**Brooklyn**](https://brooklyn.apache.org/style/img/apache-brooklyn-logo-244px-wide.png)](http://brooklyn.apache.org/)
 
 ### Apache Brooklyn helps to model, deploy, and manage systems.
 
 It supports blueprints in YAML or Java, and deploys them to many clouds and other target environments.
 It monitors those deployments, maintains a live model, and runs autonomic policies to maintain their health.
 
-For more information see **[brooklyn.incubator.apache.org](https://brooklyn.incubator.apache.org/)**.
+For more information see **[brooklyn.apache.org](https://brooklyn.apache.org/)**.
 
 
 ### To Build
@@ -17,5 +17,5 @@ The code can be built with a:
 
 This creates a build in `usage/dist/target/brooklyn-dist`.  Run with `bin/brooklyn launch`.
 
-The **[developer guide](https://brooklyn.incubator.apache.org/v/latest/dev/)**
+The **[developer guide](https://brooklyn.apache.org/v/latest/dev/)**
 has more information about the source code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,8 @@ familiarise yourself with the standard workflow for Apache Brooklyn:
 * [Guide for contributors][CONTRIB]
 * [Guide for committers][COMMIT]
 
-[CONTRIB]: https://brooklyn.incubator.apache.org/community/how-to-contribute-docs.html
-[COMMIT]: https://brooklyn.incubator.apache.org/developers/committers/index.html
+[CONTRIB]: https://brooklyn.apache.org/community/how-to-contribute-docs.html
+[COMMIT]: https://brooklyn.apache.org/developers/committers/index.html
 
 
 Workstation Setup
@@ -131,7 +131,7 @@ The two micro-sites above are installed on the live website as follows:
 * `/v/<version>`: contains specific versions of the guide,
   with the special folder `/v/latest` containing the recent preferred stable/milestone version 
 
-The site itself is hosted at `brooklyn.incubator.apache.org` with a `CNAME`
+The site itself is hosted at `brooklyn.apache.org` with a `CNAME`
 record from `brooklyn.io`.
 
 Content is published to the site by updating an 

--- a/docs/_build/config-production.yml
+++ b/docs/_build/config-production.yml
@@ -1,6 +1,6 @@
 # in production we always set the URL and dependencies should come from the remote source
 
-url: https://brooklyn.incubator.apache.org
-url_root: https://brooklyn.incubator.apache.org
+url: https://brooklyn.apache.org
+url_root: https://brooklyn.apache.org
 
 dependency_mode: remote

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,11 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-10 text-muted">
-                Apache Brooklyn is distributed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache
-                License v2.0</a>.
-                <br />
-                Apache Brooklyn is currently undergoing Incubation at The Apache Software
-                Foundation.
+                Apache Brooklyn is distributed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a>.
             </div>
             <div class="col-md-2">
                 <a class="btn btn-sm btn-default" href="https://github.com/apache/incubator-brooklyn/edit/master/docs/{{ page.path }}">Edit This Page</a>

--- a/docs/_layouts/website-landing.html
+++ b/docs/_layouts/website-landing.html
@@ -27,16 +27,9 @@ layout: website-base
     <div class="container">
         <div class="row">
             <div class="col-md-9 text-muted">
-                Apache Brooklyn is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the 
-                Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the
-                infrastructure, communications, and decision making process have stabilized in a manner consistent with other
-                successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of
-                the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-                <p>
                 Apache Brooklyn is distributed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License v2.0</a>.
             </div>
             <div class="col-md-3">
-                <p><img src="https://incubator.apache.org/images/egg-logo.png" alt="Apache Incubator" /></p>
                 <p>
                 <a class="btn btn-sm btn-default" href="https://github.com/apache/incubator-brooklyn/edit/master/docs/{{ page.path }}">Edit This Page</a>
                 <a href="{{ site.url_root }}{{ site.path.website }}/community/how-to-contribute-docs.html"

--- a/docs/guide/dev/index.md
+++ b/docs/guide/dev/index.md
@@ -15,7 +15,7 @@ children:
 - tips/logging.md
 - tips/debugging-remote-brooklyn.md
 - rest/rest-api-doc.md
-- { link: "http://brooklyn.incubator.apache.org/v/latest/misc/javadoc", title: "Javadoc" }
+- { link: "https://brooklyn.apache.org/v/latest/misc/javadoc", title: "Javadoc" }
 ---
 
 {% comment %}

--- a/docs/website/community/how-to-contribute-docs.md
+++ b/docs/website/community/how-to-contribute-docs.md
@@ -49,8 +49,8 @@ In particular, note that the Brooklyn documentation is split into two parts:
   
 - **Version-specific user guide**. These pages have a URL with a path that
   begins /v/*version-number*: for example,
-  https://brooklyn.incubator.apache.org/v/0.8.0-incubating and {% comment %}BROOKLYN_VERSION{% endcomment %}
-  the special *latest* set at https://brooklyn.incubator.apache.org/v/latest. Content for this is in the `guide` directory.
+  https://brooklyn.apache.org/v/0.8.0-incubating and {% comment %}BROOKLYN_VERSION{% endcomment %}
+  the special *latest* set at https://brooklyn.apache.org/v/latest. Content for this is in the `guide` directory.
 
 The main user guide shown on this site is for the most recent stable version,
 currently {{ site.brooklyn-stable-version }}.

--- a/docs/website/developers/committers/release-process/announce.md
+++ b/docs/website/developers/committers/release-process/announce.md
@@ -15,7 +15,7 @@ Brooklyn 0.7.0-incubating.
 
 Apache Brooklyn is a framework for modelling, monitoring, and managing
 applications through autonomic blueprints. More details on Apache Brooklyn
-can be found at http://brooklyn.incubator.apache.org/
+can be found at https://brooklyn.apache.org/
 
 Version 0.7.0 is a major step for Apache Brooklyn. It is the first full
 release of the project as part of the Apache incubator.
@@ -27,13 +27,13 @@ As well as a source code release, we offer a full binary distribution
 download, and a full set of Maven artifacts for developers.
 
 Release notes:
-https://brooklyn.incubator.apache.org/v/0.7.0-incubating/misc/release-notes.html
+https://brooklyn.apache.org/v/0.7.0-incubating/misc/release-notes.html
 
 Download:
-https://brooklyn.incubator.apache.org/download/
+https://brooklyn.apache.org/download/
 
 User guide:
-https://brooklyn.incubator.apache.org/v/0.7.0-incubating/
+https://brooklyn.apache.org/v/0.7.0-incubating/
 
 Maven artifacts have also been made available on repository.apache.org and
 Maven Central.

--- a/docs/website/learnmore/catalog/index.html
+++ b/docs/website/learnmore/catalog/index.html
@@ -37,7 +37,7 @@ under the License.
 <div id="container">
   <div id="header">
     <div id="identity">
-      <a href="https://brooklyn.incubator.apache.org/" rel="home">Brooklyn</a>
+      <a href="https://brooklyn.apache.org/" rel="home">Brooklyn</a>
     </div>
   </div>
 


### PR DESCRIPTION
Remove the incubator disclaimer and boilerplate text, and change the web URLs to our new home at https://brooklyn.incubator.apache.org