### PR TITLE
Feature: entity monitoring disablable

### DIFF
--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/mariadb/MariaDbLiveEc2Test.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/mariadb/MariaDbLiveEc2Test.java
@@ -18,15 +18,22 @@
  */
 package org.apache.brooklyn.entity.database.mariadb;
 
+import static org.testng.Assert.assertNotNull;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
-import org.testng.annotations.Test;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.database.DatastoreMixins.DatastoreCommon;
 import org.apache.brooklyn.entity.database.VogellaExampleAccess;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 @Test(groups = { "Live" })
 public class MariaDbLiveEc2Test extends AbstractEc2LiveTest {
@@ -48,8 +55,25 @@ public class MariaDbLiveEc2Test extends AbstractEc2LiveTest {
     @Test(enabled=false, groups = "Live")
     public void test_Debian_7_2() throws Exception { } // Disabled because MariaDB not available
 
-    @Test(enabled=false)
-    public void testDummy() {} // Convince testng IDE integration that this really does have test methods  
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
 
+        MariaDbNode server = app.createAndManageChild(EntitySpec.create(MariaDbNode.class)
+                .configure(MariaDbNode.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22)));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(MariaDbNode.MARIADB_PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
 }
-

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlLiveEc2Test.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/mysql/MySqlLiveEc2Test.java
@@ -18,14 +18,21 @@
  */
 package org.apache.brooklyn.entity.database.mysql;
 
+import static org.testng.Assert.assertNotNull;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
-import org.testng.annotations.Test;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.database.DatastoreMixins.DatastoreCommon;
 import org.apache.brooklyn.entity.database.VogellaExampleAccess;
+import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 @Test(groups = { "Live" })
 public class MySqlLiveEc2Test extends AbstractEc2LiveTest {
@@ -45,8 +52,25 @@ public class MySqlLiveEc2Test extends AbstractEc2LiveTest {
     @Test(enabled=false, groups = "Live")
     public void test_Debian_7_2() throws Exception { } // Disabled because MySQl not available
 
-    @Test(enabled=false)
-    public void testDummy() {} // Convince testng IDE integration that this really does have test methods  
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
 
+        MySqlNode server = app.createAndManageChild(EntitySpec.create(MySqlNode.class)
+                .configure(MySqlNode.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22)));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(MySqlNode.MYSQL_PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
 }
-

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlEc2LiveTest.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlEc2LiveTest.java
@@ -18,14 +18,21 @@
  */
 package org.apache.brooklyn.entity.database.postgresql;
 
+import static org.testng.Assert.assertNotNull;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
-import org.testng.annotations.Test;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.database.DatastoreMixins.DatastoreCommon;
 import org.apache.brooklyn.entity.database.VogellaExampleAccess;
+import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class PostgreSqlEc2LiveTest extends AbstractEc2LiveTest {
 
@@ -47,7 +54,25 @@ public class PostgreSqlEc2LiveTest extends AbstractEc2LiveTest {
     @Test(enabled=false, groups = "Live")
     public void test_Ubuntu_10_0() throws Exception { } // Disabled because PostgreSql 9.1 not available
 
-    @Test(enabled=false)
-    public void testDummy() { } // Convince testng IDE integration that this really does have test methods
-}
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
 
+        PostgreSqlNode server = app.createAndManageChild(EntitySpec.create(PostgreSqlNode.class)
+                .configure(PostgreSqlNode.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22)));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(PostgreSqlNode.POSTGRESQL_PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
+}

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitEc2LiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitEc2LiveTest.java
@@ -19,20 +19,26 @@
 package org.apache.brooklyn.entity.messaging.rabbit;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.entity.AbstractEc2LiveTest;
+import org.apache.brooklyn.entity.messaging.MessageBroker;
+import org.apache.brooklyn.entity.messaging.amqp.AmqpExchange;
 import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.entity.messaging.MessageBroker;
-import org.apache.brooklyn.entity.messaging.amqp.AmqpExchange;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -92,6 +98,28 @@ public class RabbitEc2LiveTest extends AbstractEc2LiveTest {
         throw new SkipException("Centos 5 is not supported");
     }
 
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
+
+        final RabbitBroker server = app.createAndManageChild(EntitySpec.create(RabbitBroker.class)
+                .configure(RabbitBroker.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22)));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(RabbitBroker.AMQP_PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
+    
     @Test(enabled=false)
     public void testDummy() {} // Convince testng IDE integration that this really does have test methods  
 }

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNode.java
@@ -141,6 +141,9 @@ public interface CassandraNode extends DatastoreMixins.DatastoreCommon, Software
     BasicAttributeSensorAndConfigKey<Set<BigInteger>> TOKENS = new BasicAttributeSensorAndConfigKey<Set<BigInteger>>(
             new TypeToken<Set<BigInteger>>() {}, "cassandra.tokens", "Cassandra Tokens");
 
+    @SetFromFlag("useThriftMonitoring")
+    ConfigKey<Boolean> USE_THRIFT_MONITORING = ConfigKeys.newConfigKey("thriftMonitoring.enabled", "Thrift-port monitoring enabled", Boolean.TRUE);
+
     AttributeSensor<Integer> PEERS = Sensors.newIntegerSensor( "cassandra.peers", "Number of peers in cluster");
 
     AttributeSensor<Integer> LIVE_NODE_COUNT = Sensors.newIntegerSensor( "cassandra.liveNodeCount", "Number of live nodes in cluster");

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBServer.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBServer.java
@@ -50,6 +50,9 @@ public interface MongoDBServer extends AbstractMongoDBServer {
     ConfigKey<Boolean> ENABLE_REST_INTERFACE = ConfigKeys.newBooleanConfigKey(
             "mongodb.config.enable_rest", "Adds --rest to server startup flags when true", Boolean.FALSE);
 
+    @SetFromFlag("useClientMonitoring")
+    ConfigKey<Boolean> USE_CLIENT_MONITORING = ConfigKeys.newConfigKey("clientMonitoring.enabled", "Monitoring via the MongoDB client enabled", Boolean.TRUE);
+
     AttributeSensor<String> HTTP_INTERFACE_URL = Sensors.newStringSensor(
             "mongodb.server.http_interface", "URL of the server's HTTP console");
 

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
@@ -109,6 +109,9 @@ public interface RiakNode extends SoftwareProcess, UsesJava {
     @SetFromFlag("riakPbPort")
     PortAttributeSensorAndConfigKey RIAK_PB_PORT = new PortAttributeSensorAndConfigKey("riak.pbPort", "Riak Protocol Buffers Port", "8087+");
 
+    @SetFromFlag("useHttpMonitoring")
+    ConfigKey<Boolean> USE_HTTP_MONITORING = ConfigKeys.newConfigKey("httpMonitoring.enabled", "HTTP(S) monitoring enabled", Boolean.TRUE);
+
     AttributeSensor<Boolean> RIAK_PACKAGE_INSTALL = Sensors.newBooleanSensor(
             "riak.install.package", "Flag to indicate whether Riak was installed using an OS package");
     AttributeSensor<Boolean> RIAK_ON_PATH = Sensors.newBooleanSensor(

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -44,9 +44,9 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.guava.Functionals;
 import org.apache.brooklyn.util.time.Duration;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
@@ -116,74 +116,76 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
         connectServiceUpIsRunning();
         HostAndPort accessible = BrooklynAccessUtils.getBrooklynAccessibleAddress(this, getRiakWebPort());
 
-        HttpFeed.Builder httpFeedBuilder = HttpFeed.builder()
-                .entity(this)
-                .period(500, TimeUnit.MILLISECONDS)
-                .baseUri(String.format("http://%s/stats", accessible.toString()))
-                .poll(new HttpPollConfig<Integer>(NODE_GETS)
-                        .onSuccess(HttpValueFunctions.jsonContents("node_gets", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(NODE_GETS_TOTAL)
-                        .onSuccess(HttpValueFunctions.jsonContents("node_gets_total", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(NODE_PUTS)
-                        .onSuccess(HttpValueFunctions.jsonContents("node_puts", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(NODE_PUTS_TOTAL)
-                        .onSuccess(HttpValueFunctions.jsonContents("node_puts_total", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(VNODE_GETS)
-                        .onSuccess(HttpValueFunctions.jsonContents("vnode_gets", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(VNODE_GETS_TOTAL)
-                        .onSuccess(HttpValueFunctions.jsonContents("vnode_gets_total", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(VNODE_PUTS)
-                        .onSuccess(HttpValueFunctions.jsonContents("vnode_puts", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(VNODE_PUTS_TOTAL)
-                        .onSuccess(HttpValueFunctions.jsonContents("vnode_puts_total", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(READ_REPAIRS_TOTAL)
-                        .onSuccess(HttpValueFunctions.jsonContents("read_repairs_total", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(COORD_REDIRS_TOTAL)
-                        .onSuccess(HttpValueFunctions.jsonContents("coord_redirs_total", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(MEMORY_PROCESSES_USED)
-                        .onSuccess(HttpValueFunctions.jsonContents("memory_processes_used", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(SYS_PROCESS_COUNT)
-                        .onSuccess(HttpValueFunctions.jsonContents("sys_process_count", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(PBC_CONNECTS)
-                        .onSuccess(HttpValueFunctions.jsonContents("pbc_connects", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<Integer>(PBC_ACTIVE)
-                        .onSuccess(HttpValueFunctions.jsonContents("pbc_active", Integer.class))
-                        .onFailureOrException(Functions.constant(-1)))
-                .poll(new HttpPollConfig<List<String>>(RING_MEMBERS)
-                        .onSuccess(Functionals.chain(
-                                HttpValueFunctions.jsonContents("ring_members", String[].class),
-                                new Function<String[], List<String>>() {
-                                    @Nullable
-                                    @Override
-                                    public List<String> apply(@Nullable String[] strings) {
-                                        return Arrays.asList(strings);
+        if (isHttpMonitoringEnabled()) {
+            HttpFeed.Builder httpFeedBuilder = HttpFeed.builder()
+                    .entity(this)
+                    .period(500, TimeUnit.MILLISECONDS)
+                    .baseUri(String.format("http://%s/stats", accessible.toString()))
+                    .poll(new HttpPollConfig<Integer>(NODE_GETS)
+                            .onSuccess(HttpValueFunctions.jsonContents("node_gets", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(NODE_GETS_TOTAL)
+                            .onSuccess(HttpValueFunctions.jsonContents("node_gets_total", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(NODE_PUTS)
+                            .onSuccess(HttpValueFunctions.jsonContents("node_puts", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(NODE_PUTS_TOTAL)
+                            .onSuccess(HttpValueFunctions.jsonContents("node_puts_total", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(VNODE_GETS)
+                            .onSuccess(HttpValueFunctions.jsonContents("vnode_gets", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(VNODE_GETS_TOTAL)
+                            .onSuccess(HttpValueFunctions.jsonContents("vnode_gets_total", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(VNODE_PUTS)
+                            .onSuccess(HttpValueFunctions.jsonContents("vnode_puts", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(VNODE_PUTS_TOTAL)
+                            .onSuccess(HttpValueFunctions.jsonContents("vnode_puts_total", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(READ_REPAIRS_TOTAL)
+                            .onSuccess(HttpValueFunctions.jsonContents("read_repairs_total", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(COORD_REDIRS_TOTAL)
+                            .onSuccess(HttpValueFunctions.jsonContents("coord_redirs_total", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(MEMORY_PROCESSES_USED)
+                            .onSuccess(HttpValueFunctions.jsonContents("memory_processes_used", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(SYS_PROCESS_COUNT)
+                            .onSuccess(HttpValueFunctions.jsonContents("sys_process_count", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(PBC_CONNECTS)
+                            .onSuccess(HttpValueFunctions.jsonContents("pbc_connects", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<Integer>(PBC_ACTIVE)
+                            .onSuccess(HttpValueFunctions.jsonContents("pbc_active", Integer.class))
+                            .onFailureOrException(Functions.constant(-1)))
+                    .poll(new HttpPollConfig<List<String>>(RING_MEMBERS)
+                            .onSuccess(Functionals.chain(
+                                    HttpValueFunctions.jsonContents("ring_members", String[].class),
+                                    new Function<String[], List<String>>() {
+                                        @Nullable
+                                        @Override
+                                        public List<String> apply(@Nullable String[] strings) {
+                                            return Arrays.asList(strings);
+                                        }
                                     }
-                                }
-                        ))
-                        .onFailureOrException(Functions.constant(Arrays.asList(new String[0]))));
-
-        for (AttributeSensor<Integer> sensor : ONE_MINUTE_SENSORS) {
-            httpFeedBuilder.poll(new HttpPollConfig<Integer>(sensor)
-                    .period(Duration.ONE_MINUTE)
-                    .onSuccess(HttpValueFunctions.jsonContents(sensor.getName().substring(5), Integer.class))
-                    .onFailureOrException(Functions.constant(-1)));
+                            ))
+                            .onFailureOrException(Functions.constant(Arrays.asList(new String[0]))));
+    
+            for (AttributeSensor<Integer> sensor : ONE_MINUTE_SENSORS) {
+                httpFeedBuilder.poll(new HttpPollConfig<Integer>(sensor)
+                        .period(Duration.ONE_MINUTE)
+                        .onSuccess(HttpValueFunctions.jsonContents(sensor.getName().substring(5), Integer.class))
+                        .onFailureOrException(Functions.constant(-1)));
+            }
+    
+            httpFeed = httpFeedBuilder.build();
         }
-
-        httpFeed = httpFeedBuilder.build();
-
+        
         enrichers().add(Enrichers.builder().combining(NODE_GETS, NODE_PUTS).computingSum().publishing(NODE_OPS).build());
         enrichers().add(Enrichers.builder().combining(NODE_GETS_TOTAL, NODE_PUTS_TOTAL).computingSum().publishing(NODE_OPS_TOTAL).build());
         WebAppServiceMethods.connectWebAppServerPolicies(this);
@@ -243,6 +245,9 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
         getDriver().recoverFailedNode(nodeName);
     }
 
+    protected boolean isHttpMonitoringEnabled() {
+        return Boolean.TRUE.equals(getConfig(USE_HTTP_MONITORING));
+    }
     @Override
     public Integer getRiakWebPort() {
         return getAttribute(RiakNode.RIAK_WEB_PORT);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBEc2LiveTest.java
@@ -18,19 +18,24 @@
  */
 package org.apache.brooklyn.entity.nosql.mongodb;
 
-import com.google.common.collect.ImmutableList;
-import com.mongodb.DBObject;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.entity.AbstractEc2LiveTest;
+import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-
-import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.mongodb.DBObject;
 
 public class MongoDBEc2LiveTest extends AbstractEc2LiveTest {
 
@@ -50,6 +55,29 @@ public class MongoDBEc2LiveTest extends AbstractEc2LiveTest {
         assertEquals(docOut.get("hello"), "world!");
     }
 
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
+
+        MongoDBServer server = app.createAndManageChild(EntitySpec.create(MongoDBServer.class)
+                .configure(MongoDBServer.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22))
+                .configure(MongoDBServer.USE_CLIENT_MONITORING, false));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(MongoDBServer.PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
+    
     @Test(enabled=false)
     public void testDummy() {} // Convince TestNG IDE integration that this really does have test methods
 

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisEc2LiveTest.java
@@ -18,10 +18,16 @@
  */
 package org.apache.brooklyn.entity.nosql.redis;
 
+import static org.testng.Assert.assertNotNull;
+
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
@@ -30,6 +36,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class RedisEc2LiveTest extends AbstractEc2LiveTest {
 
@@ -60,6 +67,25 @@ public class RedisEc2LiveTest extends AbstractEc2LiveTest {
 
     }
 
-    @Test(enabled=false)
-    public void testDummy() {} // Convince testng IDE integration that this really does have test methods  
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
+
+        RedisStore server = app.createAndManageChild(EntitySpec.create(RedisStore.class)
+                .configure(RedisStore.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22)));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(RedisStore.REDIS_PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
 }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeEc2LiveTest.java
@@ -18,8 +18,14 @@
  */
 package org.apache.brooklyn.entity.nosql.riak;
 
+import static org.testng.Assert.assertNotNull;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
@@ -27,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class RiakNodeEc2LiveTest extends AbstractEc2LiveTest {
 
@@ -42,9 +49,26 @@ public class RiakNodeEc2LiveTest extends AbstractEc2LiveTest {
 
     }
 
-    @Test(enabled = false)
-    public void testDummy() {
-    } // Convince TestNG IDE integration that this really does have test methods
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
 
-
+        RiakNode server = app.createAndManageChild(EntitySpec.create(RiakNode.class)
+                .configure(RiakNode.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22))
+                .configure(RiakNode.USE_HTTP_MONITORING, false));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        Integer port = server.getAttribute(RiakNode.RIAK_PB_PORT);
+        assertNotNull(port);
+        
+        assertViaSshLocalPortListeningEventually(server, port);
+    }
 }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6SshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6SshDriver.java
@@ -134,7 +134,7 @@ public class JBoss6SshDriver extends JavaWebAppSshDriver implements JBoss6Driver
     public void launch() {
         Map<String,Integer> ports = new HashMap<String, Integer>();
         ports.put("httpPort",getHttpPort());
-        ports.put("jmxPort",getJmxPort());
+        if (isJmxEnabled()) ports.put("jmxPort",getJmxPort());
 
         Networking.checkPortsValid(ports);
 

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7Server.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7Server.java
@@ -25,9 +25,9 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.StringAttributeSensorAndConfigKey;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcess;
 import org.apache.brooklyn.util.core.ResourcePredicates;
@@ -93,6 +93,9 @@ public interface JBoss7Server extends JavaWebAppSoftwareProcess, HasShortName {
     @SetFromFlag("managementPassword")
     ConfigKey<String> MANAGEMENT_PASSWORD =
             ConfigKeys.newStringConfigKey("webapp.jboss.managementPassword", "Password for MANAGEMENT_USER.");
+
+    @SetFromFlag("useHttpMonitoring")
+    ConfigKey<Boolean> USE_HTTP_MONITORING = ConfigKeys.newConfigKey("httpMonitoring.enabled", "HTTP(S) monitoring enabled", Boolean.TRUE);
 
     AttributeSensor<String> MANAGEMENT_URL =
             Sensors.newStringSensor("webapp.jboss.managementUrl", "URL where management endpoint is available");

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6ServerAwsEc2LiveTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6ServerAwsEc2LiveTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.brooklyn.entity.webapp.jboss;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.testng.Assert.assertNotNull;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.HttpTestUtils;
@@ -30,6 +33,7 @@ import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A simple test of installing+running on AWS-EC2, using various OS distros and versions. 
@@ -62,6 +66,31 @@ public class JBoss6ServerAwsEc2LiveTest extends AbstractEc2LiveTest {
                 assertNotNull(server.getAttribute(JBoss6Server.BYTES_RECEIVED));
                 assertNotNull(server.getAttribute(JBoss6Server.BYTES_SENT));
             }});
+    }
+    
+    @Test(groups = {"Live"})
+    public void testWithOnlyPort22() throws Exception {
+        // CentOS-6.3-x86_64-GA-EBS-02-85586466-5b6c-4495-b580-14f72b4bcf51-ami-bb9af1d2.1
+        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, ImmutableMap.of(
+                "tags", ImmutableList.of(getClass().getName()),
+                "imageId", "us-east-1/ami-a96b01c0", 
+                "hardwareId", SMALL_HARDWARE_ID));
+
+        final JBoss6Server server = app.createAndManageChild(EntitySpec.create(JBoss6Server.class)
+                .configure(JBoss6Server.PROVISIONING_PROPERTIES.subKey(CloudLocationConfig.INBOUND_PORTS.getName()), ImmutableList.of(22))
+                .configure(JBoss6Server.USE_JMX, false)
+                .configure(JBoss6Server.OPEN_IPTABLES, true)
+                .configure("war", getTestWar()));
+        
+        app.start(ImmutableList.of(jcloudsLocation));
+        
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        
+        String url = server.getAttribute(JBoss6Server.ROOT_URL);
+        assertNotNull(url);
+        
+        assertViaSshLocalUrlListeningEventually(server, url);
     }
     
     @Test(enabled=false)

--- a/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
@@ -375,11 +375,14 @@ public class BashCommands {
                         ok(sudo("apt-get update")), 
                         sudo(aptInstall))));
         if (yumInstall != null)
+            // Need to upgrade ca-certificates sometimes:
+            // http://serverfault.com/questions/637549/epel-repo-for-centos-6-causing-error?newreg=7c6019c0d0ae483c8bb3af387166ce49
             commands.add(ifExecutableElse1("yum", 
                     chainGroup(
                         "echo yum exists, doing update",
                         ok(sudo("yum check-update")),
                         ok(sudo("yum -y install epel-release")),
+                        ok(sudo("yum upgrade -y ca-certificates --disablerepo=epel")),
                         sudo(yumInstall))));
         if (brewInstall != null)
             commands.add(ifExecutableElse1("brew", brewInstall));

--- a/utils/common/src/test/java/org/apache/brooklyn/util/ssh/IptablesCommandsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/ssh/IptablesCommandsTest.java
@@ -38,12 +38,19 @@ public class IptablesCommandsTest {
     private static final String appendIptablesRuleAll = "( if test \"$UID\" -eq 0; then ( /sbin/iptables -A INPUT -p tcp --dport 3306 -j ACCEPT ); "
             + "else sudo -E -n -S -- /sbin/iptables -A INPUT -p tcp --dport 3306 -j ACCEPT; fi )";
     private static final String saveIptablesRules = "( ( if test \"$UID\" -eq 0; then ( service iptables save ); else sudo -E -n -S -- service iptables save; fi ) || " +
-            "( ( { which zypper && { echo zypper exists, doing refresh && (( if test \"$UID\" -eq 0; then ( zypper --non-interactive --no-gpg-checks refresh ); else sudo -E -n -S -- zypper --non-interactive --no-gpg-checks refresh; fi ) || true) && ( if test \"$UID\" -eq 0; then ( zypper --non-interactive --no-gpg-checks install iptables-persistent ); else sudo -E -n -S -- zypper --non-interactive --no-gpg-checks install iptables-persistent; fi ) ; } ; } || " +
-            "{ which apt-get && { echo apt-get exists, doing update && export DEBIAN_FRONTEND=noninteractive && (( if test \"$UID\" -eq 0; then ( apt-get update ); else sudo -E -n -S -- apt-get update; fi ) || true) && ( if test \"$UID\" -eq 0; then ( apt-get install -y --allow-unauthenticated iptables-persistent ); else sudo -E -n -S -- apt-get install -y --allow-unauthenticated iptables-persistent; fi ) ; } ; } || " +
-            "{ which yum && { echo yum exists, doing update && (( if test \"$UID\" -eq 0; then ( yum check-update ); else sudo -E -n -S -- yum check-update; fi ) || true) && (( if test \"$UID\" -eq 0; then ( yum -y install epel-release ); else sudo -E -n -S -- yum -y install epel-release; fi ) || true) && ( if test \"$UID\" -eq 0; then ( yum -y --nogpgcheck install iptables-persistent ); else sudo -E -n -S -- yum -y --nogpgcheck install iptables-persistent; fi ) ; } ; } || " +
+            "( ( { which zypper && { echo zypper exists, doing refresh && (( if test \"$UID\" -eq 0; then ( zypper --non-interactive --no-gpg-checks refresh ); else sudo -E -n -S -- zypper --non-interactive --no-gpg-checks refresh; fi ) || true) "
+                    + "&& ( if test \"$UID\" -eq 0; then ( zypper --non-interactive --no-gpg-checks install iptables-persistent ); else sudo -E -n -S -- zypper --non-interactive --no-gpg-checks install iptables-persistent; fi ) ; } ; } || " +
+            "{ which apt-get && { echo apt-get exists, doing update && export DEBIAN_FRONTEND=noninteractive "
+                    + "&& (( if test \"$UID\" -eq 0; then ( apt-get update ); else sudo -E -n -S -- apt-get update; fi ) || true) "
+                    + "&& ( if test \"$UID\" -eq 0; then ( apt-get install -y --allow-unauthenticated iptables-persistent ); else sudo -E -n -S -- apt-get install -y --allow-unauthenticated iptables-persistent; fi ) ; } ; } || " +
+            "{ which yum && { echo yum exists, doing update && (( if test \"$UID\" -eq 0; then ( yum check-update ); else sudo -E -n -S -- yum check-update; fi ) || true) "
+                    + "&& (( if test \"$UID\" -eq 0; then ( yum -y install epel-release ); else sudo -E -n -S -- yum -y install epel-release; fi ) || true) "
+                    + "&& (( if test \"$UID\" -eq 0; then ( yum upgrade -y ca-certificates --disablerepo=epel ); else sudo -E -n -S -- yum upgrade -y ca-certificates --disablerepo=epel; fi ) || true) "
+                    + "&& ( if test \"$UID\" -eq 0; then ( yum -y --nogpgcheck install iptables-persistent ); else sudo -E -n -S -- yum -y --nogpgcheck install iptables-persistent; fi ) ; } ; } || " +
             "{ which brew && brew install iptables-persistent ; } || " +
             "{ which port && ( if test \"$UID\" -eq 0; then ( port install iptables-persistent ); else sudo -E -n -S -- port install iptables-persistent; fi ) ; } || " +
-            "(( echo \"WARNING: no known/successful package manager to install iptables-persistent, may fail subsequently\" | tee /dev/stderr ) || true) ) && ( if test \"$UID\" -eq 0; then ( /etc/init.d/iptables-persistent save ); else sudo -E -n -S -- /etc/init.d/iptables-persistent save; fi ) ) )";
+            "(( echo \"WARNING: no known/successful package manager to install iptables-persistent, may fail subsequently\" | tee /dev/stderr ) || true) ) " +
+            "&& ( if test \"$UID\" -eq 0; then ( /etc/init.d/iptables-persistent save ); else sudo -E -n -S -- /etc/init.d/iptables-persistent save; fi ) ) )";
 
     @Test
     public void testCleanUpIptablesRules() {


### PR DESCRIPTION
Important if the entity is running in a locked-down location, e.g. such that only ssh access to the VM is available. This adds configuration to disable the use of jmx, http, thrift (for Cassandra), mongodb client, etc.

There is also a PR to fix java install, failing for the reason described at http://serverfault.com/questions/637549/epel-repo-for-centos-6-causing-error?newreg=7c6019c0d0ae483c8bb3af387166ce49 - i.e. adding `yum upgrade -y ca-certificates --disablerepo=epel`.