### PR TITLE
Reverting changes made in #1060 and fixed root cause

### DIFF
--- a/usage/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/usage/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -65,7 +65,7 @@ public interface CatalogApi {
     @Consumes
     @POST
     @ApiOperation(value = "Add a catalog item (e.g. new type of entity, policy or location) by uploading YAML descriptor "
-        + "Return value is map of ID to CatalogItemSummary, with code 201 CREATED.", response = Response.class)
+        + "Return value is map of ID to CatalogItemSummary, with code 201 CREATED.", response = String.class)
     public Response create(
             @ApiParam(name = "yaml", value = "YAML descriptor of catalog item", required = true)
             @Valid String yaml);

--- a/usage/rest-client/pom.xml
+++ b/usage/rest-client/pom.xml
@@ -101,11 +101,7 @@
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jaxrs-api</artifactId>
         </dependency-->
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-jaxrs</artifactId>
-        </dependency>
-
+        
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/usage/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
+++ b/usage/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
@@ -105,7 +105,8 @@ public class BrooklynApiRestClientTest {
 
     public void testCatalogCreate()throws Exception {
         final Response response = api.getCatalogApi().create(getFileContentsAsString("catalog/test-catalog.bom"));
-        Asserts.assertEquals(response.getStatus(),201);
+        Asserts.assertEquals(response.getStatus(), 201);
+        Asserts.assertStringContains(String.valueOf(response.getEntity()), "simple-tomcat:1.0");
     }
 
 


### PR DESCRIPTION
I incorrectly diagnosed the issue in #1060 ... so changes made reverted

Root cause was due to Swagger updates made in #1040 
`@ApiOperation()` annotation on `CatalogApi#create` had response type set to `javax.ws.rs.core.Response` causing the BrooklynApi to try and marshall the returned entity to that type

