### PR TITLE
SoftwareProcess.dontRequireTtyForSudo - sudoers file verification

### DIFF
--- a/core/src/test/resources/brooklyn/util/ssh/test_sudoers
+++ b/core/src/test/resources/brooklyn/util/ssh/test_sudoers
@@ -1,0 +1,24 @@
+#    Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#    
+#     http://www.apache.org/licenses/LICENSE-2.0
+#    
+#    Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+#    under the License.
+
+# Defaults specification
+
+#
+# Disable "ssh hostname sudo <cmd>", because it will show the password in clear. 
+#         You have to run "ssh -t hostname sudo <cmd>".
+#
+Defaults    requiretty

--- a/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
@@ -162,7 +162,15 @@ public class BashCommands {
      * (having a tty for sudo seems like another case of imaginary security which is just irritating.
      * like water restrictions at airport security.) */
     public static String dontRequireTtyForSudo() {
-        return ifFileExistsElse0("/etc/sudoers", sudo("sed -i.brooklyn.bak 's/.*requiretty.*/#brooklyn-removed-require-tty/' /etc/sudoers"));
+        String sudoersFileName =  "/etc/sudoers";
+
+        // Visudo's quiet mode (-q) is not enabled. visudo's output is used for diagnostic purposes 
+        return ifFileExistsElse0(sudoersFileName, 
+                chainGroup(
+                  sudo(format("cp %1$s %1$s.tmp", sudoersFileName)),
+                  sudo(format("sed -i.brooklyn.bak 's/.*requiretty.*/#brooklyn-removed-require-tty/' %1$s.tmp", sudoersFileName)),
+                  sudo(format("visudo -c -f %1$s.tmp", sudoersFileName)), 
+                  sudo(format("mv %1$s.tmp %1$s", sudoersFileName))));
     }
 
     /** generates ~/.ssh/id_rsa if that file does not exist */


### PR DESCRIPTION
- it doesn't directly edit /etc/sudoers
- uses visudo to verify the prepared file
- added integration test
- excluded test sudoers file from rat plugin checks