### PR TITLE
[BROOKLYN-183] Fix brooklyn-itest

### DIFF
--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -33,7 +33,7 @@
         <!-- Pax Exam Dependencies -->
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-testng</artifactId>
+            <artifactId>pax-exam-junit4</artifactId>
             <version>${pax.exam.version}</version>
             <scope>test</scope>
         </dependency>
@@ -42,6 +42,13 @@
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-invoker-junit</artifactId>
             <version>${pax.exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
 
@@ -90,10 +97,10 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-atinject_1.0_spec</artifactId>
-            <version>1.0</version>
-            <scope>provided</scope>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version> <!-- TODO: version property? -->
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -180,7 +187,6 @@
                 <executions>
                     <execution>
                         <id>generate-depends-file</id>
-                        <phase>generate-resources</phase>
                         <goals>
                             <goal>generate-depends-file</goal>
                         </goals>

--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -153,6 +153,12 @@
             <type>zip</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+            <version>${geronimo-jta_1.1_spec.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -19,15 +19,12 @@
 package org.apache.brooklyn;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.exam.MavenUtils.asInProject;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 
@@ -35,23 +32,25 @@ import javax.inject.Inject;
 
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.runner.RunWith;
+import org.junit.Test;
 import org.ops4j.pax.exam.Configuration;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
-import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
 import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
-import org.ops4j.pax.exam.testng.listener.PaxExam;
 import org.osgi.framework.BundleContext;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
 
 /**
  * Tests the apache-brooklyn karaf runtime assembly.
  */
-@Listeners(PaxExam.class)
+@RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class AssemblyTest {
 
@@ -79,15 +78,8 @@ public class AssemblyTest {
             logLevel(LogLevel.INFO),
             keepRuntimeFolder(),
             features(karafStandardFeaturesRepository(), "eventadmin"),
-            addTestNGBundle()
+            junitBundles()
         };
-    }
-
-    private static MavenArtifactProvisionOption addTestNGBundle() {
-        return mavenBundle()
-                .groupId("org.testng")
-                .artifactId("testng")
-                .version(asInProject());
     }
 
     private static MavenArtifactUrlReference brooklynKarafDist() {

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -54,7 +54,7 @@
     <module>features</module>
     <module>apache-brooklyn</module>
     <module>commands</module>
-    <!-- module>itest</module -->
+    <module>itest</module>
   </modules>
   
   <dependencyManagement>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -38,7 +38,7 @@
     <lifecycle-mapping-plugin.version>1.0.0</lifecycle-mapping-plugin.version>
 
     <!-- pax-exam -->
-    <pax.exam.version>4.5.0</pax.exam.version>
+    <pax.exam.version>4.6.0</pax.exam.version>
     <pax.url.version>2.4.1</pax.url.version>
     <ops4j.base.version>1.5.0</ops4j.base.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <maven-war-plugin.version>2.4</maven-war-plugin.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <geronimo-jms_1.1_spec.version>1.1.1</geronimo-jms_1.1_spec.version>
+        <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>
         <sleepycat-je.version>5.0.34</sleepycat-je.version>
         <org.marre.smsj.version>1.0.0-20051126</org.marre.smsj.version>
         <mysql-connector-java.version>5.1.18</mysql-connector-java.version>


### PR DESCRIPTION
Unfortunately pax-exam-testng is not yet usable. We decided to switch to the junit runner until this gets resolved upstream (see https://ops4j1.jira.com/browse/PAXEXAM-698)