### PR TITLE
Fix itest/pom: include BROOKLYN_VERSION marker

### DIFF
--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -19,15 +19,16 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>brooklyn-karaf</artifactId>
-        <groupId>org.apache.brooklyn</groupId>
-        <version>0.9.0-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.apache.brooklyn</groupId>
+    
     <artifactId>brooklyn-itest</artifactId>
     <name>Brooklyn Karaf pax-exam itest</name>
+
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-karaf</artifactId>
+        <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <dependencies>
         <!-- Pax Exam Dependencies -->

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -19,16 +19,18 @@
 --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.brooklyn</groupId>
-    <artifactId>brooklyn</artifactId>
-    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
-  </parent>
 
   <artifactId>brooklyn-karaf</artifactId>
   <name>Brooklyn Karaf</name>
   <packaging>pom</packaging>
 
+  <parent>
+    <groupId>org.apache.brooklyn</groupId>
+    <artifactId>brooklyn</artifactId>
+    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  
   <properties>
     <karaf.version>4.0.3</karaf.version>
 


### PR DESCRIPTION
Also follows convention used in other poms, to include relativePath
for parent, and to declare the artifactId+name before the parent.

The `BROOKLYN_VERSION` fix is very important for our release process, so we can easily update the version number everywhere.

Out of interest @CMoH why does kara/pom.xml depend on brooklyn rather than brooklyn-parent? I have not changed that here.