### PR TITLE
Guards against blank string in mysql.datadir

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlSshDriver.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlSshDriver.java
@@ -100,7 +100,7 @@ public class MySqlSshDriver extends AbstractSoftwareProcessSshDriver implements 
 
     public String getDataDir() {
         String result = entity.getConfig(MySqlNode.DATA_DIR);
-        return (result == null) ? "." : result;
+        return Strings.isBlank(result) ? "." : result;
     }
 
     public String getLogFile() {


### PR DESCRIPTION
A downstream project was inadvertently setting this to an empty string. I've fixed the downstream, but MySQL should also play nicely