### PR TITLE
Fix poms: include BROOKLYN_VERSION marker

### DIFF
--- a/karaf/apache-brooklyn/pom.xml
+++ b/karaf/apache-brooklyn/pom.xml
@@ -21,15 +21,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.brooklyn</groupId>
-    <artifactId>brooklyn-karaf</artifactId>
-    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
-  </parent>
 
   <artifactId>apache-brooklyn</artifactId>
   <packaging>karaf-assembly</packaging>
   <name>Brooklyn Karaf Distro</name>
+
+  <parent>
+    <groupId>org.apache.brooklyn</groupId>
+    <artifactId>brooklyn-karaf</artifactId>
+    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <dependencies>
     <dependency>

--- a/karaf/commands/pom.xml
+++ b/karaf/commands/pom.xml
@@ -20,16 +20,15 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-    <artifactId>brooklyn-karaf</artifactId>
-    <groupId>org.apache.brooklyn</groupId>
-    <version>0.9.0-SNAPSHOT</version>
-  </parent>
-
-    <groupId>org.apache.brooklyn</groupId>
     <artifactId>brooklyn-commands</artifactId>
     <packaging>bundle</packaging>
-    <version>0.9.0-SNAPSHOT</version>
+
+    <parent>
+    <groupId>org.apache.brooklyn</groupId>
+    <artifactId>brooklyn-karaf</artifactId>
+    <version>0.9.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
     <name>Brooklyn Karaf Shell Commands</name>
     <description>Provides brooklyn commands within karaf's shell</description>


### PR DESCRIPTION
Similar idea to https://github.com/apache/incubator-brooklyn/pull/1077