### PR TITLE
Make default values for assertions config be immutable.

### DIFF
--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/BaseTest.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/BaseTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.test.framework;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
@@ -50,7 +51,7 @@ public interface BaseTest extends Entity, Startable {
      * The assertions to be made.
      */
     ConfigKey<Object> ASSERTIONS = ConfigKeys.newConfigKey(Object.class, "assert", "Assertions to be evaluated",
-        new ArrayList<Map<String, Object>>());
+        ImmutableList.<Map<String, Object>>of());
 
     /**
      * THe duration to wait for an assertion to succeed or fail before throwing an exception.

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/SimpleShellCommandTest.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/SimpleShellCommandTest.java
@@ -83,20 +83,20 @@ public interface SimpleShellCommandTest extends BaseTest {
      */
     @SetFromFlag("assertStatus")
     ConfigKey<Object> ASSERT_STATUS = ConfigKeys.newConfigKey(Object.class, "assert.status", "Assertions on command exit code",
-        new ArrayList<Map<String, Object>>());
+        ImmutableList.<Map<String, Object>>of());
 
     /**
      * Assertions on the standard output of the command as a String.
      */
     @SetFromFlag("assertOut")
     ConfigKey<Object> ASSERT_OUT = ConfigKeys.newConfigKey(Object.class, "assert.out", "Assertions on command standard output",
-        new ArrayList<Map<String, Object>>());
+        ImmutableList.<Map<String, Object>>of());
 
     /**
      * Assertions on the standard error of the command as a String.
      */
     @SetFromFlag("assertErr")
     ConfigKey<Object> ASSERT_ERR = ConfigKeys.newConfigKey(Object.class, "assert.err", "Assertions on command standard error",
-        new ArrayList<Map<String, Object>>());
+        ImmutableList.<Map<String, Object>>of());
 
 }

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/SimpleShellCommandTestImpl.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/SimpleShellCommandTestImpl.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.framework.TestFrameworkAssertions.AssertionSupport;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.ssh.SshTasks;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
@@ -232,15 +233,19 @@ public class SimpleShellCommandTestImpl extends AbstractTest implements SimpleSh
     
 
     private List<Map<String, Object>> exitCodeAssertions() {
+
         List<Map<String, Object>> assertStatus = getAssertions(this, ASSERT_STATUS);
         List<Map<String, Object>> assertOut = getAssertions(this, ASSERT_OUT);
         List<Map<String, Object>> assertErr = getAssertions(this, ASSERT_ERR);
 
+        List<Map<String, Object>> result;
         if (assertStatus.isEmpty() && assertOut.isEmpty() && assertErr.isEmpty()) {
             Map<String, Object> shouldSucceed = DEFAULT_ASSERTION;
-            assertStatus.add(shouldSucceed);
+            result = MutableList.of(shouldSucceed);
+        } else {
+            result = assertStatus;
         }
-        return assertStatus;
+        return result;
     }
 
 }

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
@@ -34,7 +34,8 @@ public interface TestHttpCall extends BaseTest {
     @SetFromFlag(nullable = false)
     ConfigKey<String> TARGET_URL = ConfigKeys.newStringConfigKey("url", "URL to test");
 
-    ConfigKey<HttpAssertionTarget> ASSERTION_TARGET = ConfigKeys.newConfigKey(HttpAssertionTarget.class, "applyAssertionTo", "The HTTP field to apply the assertion to [body,status]", HttpAssertionTarget.body);
+    ConfigKey<HttpAssertionTarget> ASSERTION_TARGET = ConfigKeys.newConfigKey(HttpAssertionTarget.class, "applyAssertionTo",
+        "The HTTP field to apply the assertion to [body,status]", HttpAssertionTarget.body);
 
     enum HttpAssertionTarget {
         body("body"), status("status");


### PR DESCRIPTION
This is in response to the comment on 1066, https://github.com/apache/incubator-brooklyn/pull/1066/#issuecomment-160699587.