### PR TITLE
Jclouds machines: do not persist NodeMetadata or Template

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -102,6 +102,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
@@ -1003,6 +1004,15 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
         return getMachineDetails().getOsDetails();
     }
 
+    /**
+     * Returns the machine details only if they are already loaded, or available directly as 
+     * config.
+     */
+    protected Optional<MachineDetails> getOptionalMachineDetails() {
+        MachineDetails result = machineDetails != null ? machineDetails : config().get(MACHINE_DETAILS);
+        return Optional.fromNullable(result);
+    }
+    
     @Override
     public MachineDetails getMachineDetails() {
         synchronized (machineDetailsLock) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineLocation.java
@@ -23,13 +23,30 @@ import org.apache.brooklyn.core.location.HasSubnetHostname;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 
+import com.google.common.base.Optional;
+
 public interface JcloudsMachineLocation extends MachineLocation, HasSubnetHostname {
     
     @Override
     public JcloudsLocation getParent();
     
+    public Optional<NodeMetadata> getOptionalNode();
+
+    /**
+     * @deprecated since 0.9.0; instead use {@link #getOptionalNode()}. After rebind, the node will 
+     *             not be available if the VM is no longer running.
+     * 
+     * @throws IllegalStateException If the node is not available (i.e. not cached, and cannot be  
+     *         found from cloud provider).
+     */
+    @Deprecated
     public NodeMetadata getNode();
     
+    /**
+     * @deprecated since 0.9.0; instead use {@link #getOptionalNode()}. After rebind, the node will not
+     * be available if the VM is no longer running.
+     */
+    @Deprecated
     public Template getTemplate();
 
     public String getJcloudsId();

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
@@ -21,21 +21,23 @@ package org.apache.brooklyn.location.jclouds;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.net.Networking;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.callables.RunScriptOnNode;
+import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
-import com.google.common.net.HostAndPort;
+import com.google.common.collect.ImmutableSet;
 
 public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements JcloudsMachineLocation {
 
@@ -44,15 +46,88 @@ public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements
     @SetFromFlag
     JcloudsLocation jcloudsParent;
     
+    /**
+     * @deprecated since 0.9.0; the node should not be persisted.
+     */
     @SetFromFlag
+    @Deprecated
     NodeMetadata node;
     
+    /**
+     * @deprecated since 0.9.0; the template should not be persisted.
+     */
     @SetFromFlag
+    @Deprecated
     Template template;
+    
+    @SetFromFlag
+    String nodeId;
 
+    @SetFromFlag
+    String imageId;
+
+    @SetFromFlag
+    Set<String> privateAddresses;
+    
+    @SetFromFlag
+    Set<String> publicAddresses;
+
+    @SetFromFlag
+    String hostname;
+
+    /**
+     * Historically, "node" and "template" were persisted. However that is a very bad idea!
+     * It means we pull in lots of jclouds classes into the persisted state. We are at an  
+     * intermediate stage, where we want to handle rebinding to old state that has "node"
+     * and new state that should not. We therefore leave in the {@code @SetFromFlag} on node
+     * so that we read it back, but we ensure the value is null when we write it out!
+     * 
+     * TODO We will rename these to get rid of the ugly underscore when the old node/template 
+     * fields are deleted.
+     */
+    private transient Optional<NodeMetadata> _node;
+
+    private transient Optional<Template> _template;
+
+    private transient Optional<Image> _image;
+
+    private transient String _privateHostname;
+    
     public JcloudsWinRmMachineLocation() {
     }
 
+    @Override
+    public void init() {
+        if (jcloudsParent != null) {
+            super.init();
+            if (node != null) {
+                setNode(node);
+            }
+            if (template != null) {
+                setTemplate(template);
+            }
+        } else {
+            // TODO Need to fix the rebind-detection, and not call init() on rebind.
+            // This will all change when locations become entities.
+            if (LOG.isDebugEnabled()) LOG.debug("Not doing init() of {} because parent not set; presuming rebinding", this);
+        }
+    }
+    
+    @Override
+    public void rebind() {
+        super.rebind();
+        
+        if (node != null) {
+            setNode(node);
+            node = null;
+        }
+
+        if (template != null) {
+            setTemplate(template);
+            template = null;
+        }
+    }
+    
     @Override
     public String toVerboseString() {
         return Objects.toStringHelper(this).omitNullValues()
@@ -60,13 +135,30 @@ public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements
                 .add("user", getUser())
                 .add("address", getAddress())
                 .add("port", getPort())
-                .add("node", getNode())
-                .add("jcloudsId", getJcloudsId())
-                .add("privateAddresses", node.getPrivateAddresses())
-                .add("publicAddresses", node.getPublicAddresses())
+                .add("node", _node)
+                .add("nodeId", getJcloudsId())
+                .add("imageId", getImageId())
+                .add("privateAddresses", getPrivateAddresses())
+                .add("publicAddresses", getPublicAddresses())
                 .add("parentLocation", getParent())
                 .add("osDetails", getOsDetails())
                 .toString();
+    }
+
+    protected void setNode(NodeMetadata node) {
+        this.node = null;
+        nodeId = node.getId();
+        imageId = node.getImageId();
+        privateAddresses = node.getPrivateAddresses();
+        publicAddresses = node.getPublicAddresses();
+        hostname = node.getHostname();
+        _node = Optional.of(node);
+    }
+
+    protected void setTemplate(Template template) {
+        this.template = null;
+        _template = Optional.of(template);
+        _image = Optional.fromNullable(template.getImage());
     }
 
     @Override
@@ -75,79 +167,142 @@ public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements
     }
     
     @Override
-    public NodeMetadata getNode() {
-        return node;
-    }
-    
-    @Override
-    public Template getTemplate() {
-        return template;
-    }
-    
-    @Override
     public JcloudsLocation getParent() {
         return jcloudsParent;
     }
     
     @Override
+    public Optional<NodeMetadata> getOptionalNode() {
+      if (_node == null) {
+          _node = Optional.fromNullable(getParent().getComputeService().getNodeMetadata(nodeId));
+      }
+      return _node;
+    }
+
+    @VisibleForTesting
+    Optional<NodeMetadata> peekNode() {
+        return _node;
+    }
+
+    protected Optional<Image> getOptionalImage() {
+        if (_image == null) {
+            _image = Optional.fromNullable(getParent().getComputeService().getImage(imageId));
+        }
+        return _image;
+    }
+
+    /**
+     * @since 0.9.0
+     * @deprecated since 0.9.0 (only added as aid until the deprecated {@link #getTemplate()} is deleted)
+     */
+    @Deprecated
+    protected Optional<Template> getOptionalTemplate() {
+        if (_template == null) {
+            _template = Optional.absent();
+        }
+        return _template;
+    }
+
+    /**
+     * @deprecated since 0.9.0
+     */
+    @Override
+    @Deprecated
+    public NodeMetadata getNode() {
+        Optional<NodeMetadata> result = getOptionalNode();
+        if (result.isPresent()) {
+            return result.get();
+        } else {
+            throw new IllegalStateException("Node "+nodeId+" not present in "+getParent());
+        }
+    }
+
+    /**
+     * @deprecated since 0.9.0
+     */
+    @Override
+    @Deprecated
+    public Template getTemplate() {
+        Optional<Template> result = getOptionalTemplate();
+        if (result.isPresent()) {
+            String msg = "Deprecated use of getTemplate() for "+this;
+            LOG.warn(msg + " - see debug log for stacktrace");
+            LOG.debug(msg, new Exception("for stacktrace"));
+            return result.get();
+        } else {
+            throw new IllegalStateException("Template for "+nodeId+" (in "+getParent()+") not cached (deprecated use of getTemplate())");
+        }
+    }
+
+    @Override
     public String getHostname() {
+        if (hostname != null) {
+            return hostname;
+        }
         InetAddress address = getAddress();
         return (address != null) ? address.getHostAddress() : null;
     }
-    
+
+
+    /** In clouds like AWS, the public hostname is the only way to ensure VMs in different zones can access each other. */
     @Override
     public Set<String> getPublicAddresses() {
-        return node.getPublicAddresses();
+        return (publicAddresses == null) ? ImmutableSet.<String>of() : publicAddresses;
     }
     
     @Override
     public Set<String> getPrivateAddresses() {
-        return node.getPrivateAddresses();
+        return (privateAddresses == null) ? ImmutableSet.<String>of() : privateAddresses;
     }
+
 
     @Override
     public String getSubnetHostname() {
-        // TODO: TEMP FIX: WAS:
-        // String publicHostname = jcloudsParent.getPublicHostname(node, Optional.<HostAndPort>absent(), config().getBag());
-        // but this causes a call to JcloudsUtil.getFirstReachableAddress, which searches for accessible SSH service.
-        // This workaround is good for public nodes but not private-subnet ones.
-        return getHostname();
+        // Same impl as JcloudsSshMachineLocation
+        if (_privateHostname == null) {
+            for (String p : getPrivateAddresses()) {
+                if (Networking.isLocalOnly(p)) continue;
+                _privateHostname = p;
+            }
+            if (groovyTruth(getPublicAddresses())) {
+                _privateHostname = getPublicAddresses().iterator().next();
+            } else if (groovyTruth(getHostname())) {
+                _privateHostname = getHostname();
+            } else {
+                return null;
+            }
+        }
+        return _privateHostname;
     }
 
     @Override
     public String getSubnetIp() {
+        // Same impl as JcloudsSshMachineLocation
         Optional<String> privateAddress = getPrivateAddress();
         if (privateAddress.isPresent()) {
             return privateAddress.get();
         }
-
-        String hostname = jcloudsParent.getPublicHostname(node, Optional.<HostAndPort>absent(), config().getBag());
-        if (hostname != null && !Networking.isValidIp4(hostname)) {
-            try {
-                return InetAddress.getByName(hostname).getHostAddress();
-            } catch (UnknownHostException e) {
-                LOG.debug("Cannot resolve IP for hostname {} of machine {} (so returning hostname): {}", new Object[] {hostname, this, e});
-            }
+        if (groovyTruth(node.getPublicAddresses())) {
+            return node.getPublicAddresses().iterator().next();
         }
-        return hostname;
+        return null;
     }
 
     protected Optional<String> getPrivateAddress() {
-        if (groovyTruth(node.getPrivateAddresses())) {
-            Iterator<String> pi = node.getPrivateAddresses().iterator();
-            while (pi.hasNext()) {
-                String p = pi.next();
-                // disallow local only addresses
-                if (Networking.isLocalOnly(p)) continue;
-                // other things may be public or private, but either way, return it
-                return Optional.of(p);
-            }
+        // Same impl as JcloudsSshMachineLocation
+        for (String p : getPrivateAddresses()) {
+            if (Networking.isLocalOnly(p)) continue;
+            return Optional.of(p);
         }
         return Optional.absent();
     }
     
     @Override
     public String getJcloudsId() {
-        return node.getId();
+        return nodeId;
+    }
+    
+    protected String getImageId() {
+        return imageId;
     }
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -62,6 +62,7 @@ import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
@@ -100,7 +101,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
     
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        managementContext = LocalManagementContextForTests.newInstance(BrooklynProperties.Factory.builderEmpty().build());
+        managementContext = LocalManagementContextForTests.newInstance(BrooklynProperties.Factory.newDefault());
     }
     
     @AfterMethod(alwaysRun=true)
@@ -472,7 +473,12 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
                 .configure("address", "127.0.0.1") 
                 .configure("port", 22) 
                 .configure("user", "bob")
-                .configure("jcloudsParent", this));
+                .configure("jcloudsParent", this)
+                .configure("nodeId", "myNodeId")
+                .configure("imageId", "myImageId")
+                .configure("privateAddresses", ImmutableSet.of("10.0.0.1"))
+                .configure("publicAddresses", ImmutableSet.of("56.0.0.1"))
+                );
             registerJcloudsMachineLocation("bogus", result);
             
             // explicitly invoke this customizer, to comply with tests

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.location.jclouds;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -29,17 +30,23 @@ import org.apache.brooklyn.api.location.OsDetails;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
 import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.commons.io.FileUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
+import com.google.common.net.HostAndPort;
 
 public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
 
@@ -47,27 +54,28 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
     public static final String AWS_EC2_LOCATION_SPEC = "jclouds:" + AWS_EC2_PROVIDER + ":" + AWS_EC2_REGION_NAME;
 
     private ClassLoader classLoader = getClass().getClassLoader();
-    private TestApplication origApp;
-    private LiveTestEntity origEntity;
     private File mementoDir;
+    private TestApplication origApp;
     
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        origApp = ApplicationBuilder.newManagedApp(EntitySpec.create(TestApplication.class), managementContext);
-        origEntity = origApp.createAndManageChild(EntitySpec.create(LiveTestEntity.class));
 
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
         jcloudsLocation.config().set(JcloudsLocation.HARDWARE_ID, AWS_EC2_SMALL_HARDWARE_ID);
+        
+        origApp = TestApplication.Factory.newManagedInstanceForTests(managementContext);
     }
 
     @AfterMethod(alwaysRun = true)
     @Override
     public void tearDown() throws Exception {
-        super.tearDown();
-        if (origApp != null) Entities.destroyAll(origApp.getManagementContext());
-        if (mementoDir != null) RebindTestUtils.deleteMementoDir(mementoDir);
+        try {
+            super.tearDown();
+        } finally {
+            if (mementoDir != null) RebindTestUtils.deleteMementoDir(mementoDir);
+        }
     }
     
     @Override
@@ -78,6 +86,8 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
     
     @Test(groups="Live")
     public void testRebindsToJcloudsMachine() throws Exception {
+        LiveTestEntity origEntity = origApp.addChild(EntitySpec.create(LiveTestEntity.class));
+
         origApp.start(ImmutableList.of(jcloudsLocation));
         JcloudsLocation origJcloudsLocation = jcloudsLocation;
         System.out.println("orig locations: " + origEntity.getLocations());
@@ -87,33 +97,194 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
         LiveTestEntity newEntity = (LiveTestEntity) Iterables.find(newApp.getChildren(), Predicates.instanceOf(LiveTestEntity.class));
         JcloudsSshMachineLocation newMachine = (JcloudsSshMachineLocation) Iterables.find(newEntity.getLocations(), Predicates.instanceOf(JcloudsSshMachineLocation.class));
 
-        assertMachineEquals(newMachine, origMachine);
+        assertMachineEquals(newMachine, origMachine, true); // Don't expect OsDetails, because that is not persisted.
         assertTrue(newMachine.isSshable());
 
         JcloudsLocation newJcloudsLoction = newMachine.getParent();
         assertJcloudsLocationEquals(newJcloudsLoction, origJcloudsLocation);
     }
 
-    private void assertMachineEquals(JcloudsSshMachineLocation actual, JcloudsSshMachineLocation expected) {
+    // TODO In jclouds-azure, the AzureComputeTemplateOptions fields changed, which meant old 
+    // persisted state could not be deserialized. These files are examples of the old format.
+    @Test(groups={"Live", "WIP"}, enabled=false)
+    public void testRebindsToJcloudsMachineWithInvalidTemplate() throws Exception {
+        ResourceUtils resourceUtils = ResourceUtils.create(this);
+        FileUtils.write(
+                new File(mementoDir, "locations/briByOel"),
+                resourceUtils.getResourceAsString("classpath://org/apache/brooklyn/location/jclouds/persisted-azure-parent-briByOel"));
+        FileUtils.write(
+                new File(mementoDir, "locations/VNapYjwp"),
+                resourceUtils.getResourceAsString("classpath://org/apache/brooklyn/location/jclouds/persisted-azure-machine-VNapYjwp"));
+        
+        TestApplication newApp = rebind();
+        
+        JcloudsLocation loc = (JcloudsLocation) newApp.getManagementContext().getLocationManager().getLocation("briByOel");
+        JcloudsSshMachineLocation machine = (JcloudsSshMachineLocation) newApp.getManagementContext().getLocationManager().getLocation("VNapYjwp");
+        assertEquals(ImmutableSet.of(loc.getChildren()), ImmutableSet.of(machine));
+    }
+
+    @Test(groups={"Live", "Live-sanity"})
+    public void testRebindsToJcloudsSshMachineWithTemplateAndNode() throws Exception {
+        // Populate the mementoDir with some old-style peristed state
+        ResourceUtils resourceUtils = ResourceUtils.create(this);
+        String origParentXml = resourceUtils.getResourceAsString("classpath://org/apache/brooklyn/location/jclouds/persisted-aws-parent-lCYB3mTb");
+        String origMachineXml = resourceUtils.getResourceAsString("classpath://org/apache/brooklyn/location/jclouds/persisted-aws-machine-aKEcbxKN");
+        File persistedParentFile = new File(mementoDir, "locations/lCYB3mTb");
+        File persistedMachineFile = new File(mementoDir, "locations/aKEcbxKN");
+        FileUtils.write(
+                persistedParentFile,
+                origParentXml);
+        FileUtils.write(
+                persistedMachineFile,
+                origMachineXml);
+
+        assertTrue(origMachineXml.contains("AWSEC2TemplateOptions"), origMachineXml);
+        assertTrue(origMachineXml.contains("NodeMetadataImpl"), origMachineXml);
+
+        // Rebind to the old-style persisted state, which includes the NodeMetadata and the Template objects.
+        // Expect to parse that ok.
+        TestApplication app2 = rebind();
+        
+        JcloudsLocation loc2 = (JcloudsLocation) app2.getManagementContext().getLocationManager().getLocation("lCYB3mTb");
+        JcloudsSshMachineLocation machine2 = (JcloudsSshMachineLocation) app2.getManagementContext().getLocationManager().getLocation("aKEcbxKN");
+        assertEquals(ImmutableSet.copyOf(loc2.getChildren()), ImmutableSet.of(machine2));
+        
+        String errmsg = "loc="+loc2.toVerboseString()+"; machine="+machine2.toVerboseString();
+        assertEquals(machine2.getId(), "aKEcbxKN", errmsg);
+        assertEquals(machine2.getJcloudsId(), "ap-southeast-1/i-56fd53f2", errmsg);
+        assertEquals(machine2.getSshHostAndPort(), HostAndPort.fromParts("ec2-54-254-23-53.ap-southeast-1.compute.amazonaws.com", 22), errmsg);
+        assertEquals(machine2.getPrivateAddresses(), ImmutableSet.of("10.144.66.5"), errmsg);
+        assertEquals(machine2.getPublicAddresses(), ImmutableSet.of("54.254.23.53"), errmsg);
+        assertEquals(machine2.getPrivateAddress(), Optional.of("10.144.66.5"), errmsg);
+        assertEquals(machine2.getHostname(), "ip-10-144-66-5", errmsg); // TODO would prefer the hostname that works inside and out
+        assertEquals(machine2.getOsDetails().isWindows(), false, errmsg);
+        assertEquals(machine2.getOsDetails().isLinux(), true, errmsg);
+        assertEquals(machine2.getOsDetails().isMac(), false, errmsg);
+        assertEquals(machine2.getOsDetails().getName(), "centos", errmsg);
+        assertEquals(machine2.getOsDetails().getArch(), "x86_64", errmsg);
+        assertEquals(machine2.getOsDetails().getVersion(), "6.5", errmsg);
+        assertEquals(machine2.getOsDetails().is64bit(), true, errmsg);
+
+        // Force it to be persisted again. Expect to pesist without the NodeMetadata and Template.
+        app2.getManagementContext().getRebindManager().getChangeListener().onChanged(loc2);
+        app2.getManagementContext().getRebindManager().getChangeListener().onChanged(machine2);
+        RebindTestUtils.waitForPersisted(app2);
+        
+        String newMachineXml = new String(java.nio.file.Files.readAllBytes(persistedMachineFile.toPath()));
+        assertFalse(newMachineXml.contains("AWSEC2TemplateOptions"), newMachineXml);
+        assertFalse(newMachineXml.contains("NodeMetadataImpl"), newMachineXml);
+        
+        // Rebind again, with the re-written persisted state.
+        TestApplication app3 = rebind();
+        
+        JcloudsLocation loc3 = (JcloudsLocation) app3.getManagementContext().getLocationManager().getLocation("lCYB3mTb");
+        JcloudsSshMachineLocation machine3 = (JcloudsSshMachineLocation) app3.getManagementContext().getLocationManager().getLocation("aKEcbxKN");
+        assertEquals(ImmutableSet.copyOf(loc3.getChildren()), ImmutableSet.of(machine3));
+        
+        errmsg = "loc="+loc3.toVerboseString()+"; machine="+machine3.toVerboseString();
+        assertEquals(machine3.getId(), "aKEcbxKN", errmsg);
+        assertEquals(machine3.getJcloudsId(), "ap-southeast-1/i-56fd53f2", errmsg);
+        assertEquals(machine3.getSshHostAndPort(), HostAndPort.fromParts("ec2-54-254-23-53.ap-southeast-1.compute.amazonaws.com", 22), errmsg);
+        assertEquals(machine3.getPrivateAddresses(), ImmutableSet.of("10.144.66.5"), errmsg);
+        assertEquals(machine3.getPublicAddresses(), ImmutableSet.of("54.254.23.53"), errmsg);
+        assertEquals(machine3.getPrivateAddress(), Optional.of("10.144.66.5"), errmsg);
+        assertEquals(machine3.getHostname(), "ip-10-144-66-5", errmsg); // TODO would prefer the hostname that works inside and out
+        
+        // The VM is no longer running, so won't be able to infer OS Details.
+        assertFalse(machine3.getOptionalOsDetails().isPresent(), errmsg);
+    }
+
+    @Test(groups={"Live", "Live-sanity"})
+    public void testRebindsToJcloudsWinrmMachineWithTemplateAndNode() throws Exception {
+        // Populate the mementoDir with some old-style peristed state
+        ResourceUtils resourceUtils = ResourceUtils.create(this);
+        String origParentXml = resourceUtils.getResourceAsString("classpath://org/apache/brooklyn/location/jclouds/persisted-aws-winrm-parent-fKc0Ofyn");
+        String origMachineXml = resourceUtils.getResourceAsString("classpath://org/apache/brooklyn/location/jclouds/persisted-aws-winrm-machine-KYSryzW8");
+        File persistedParentFile = new File(mementoDir, "locations/fKc0Ofyn");
+        File persistedMachineFile = new File(mementoDir, "locations/KYSryzW8");
+        FileUtils.write(
+                persistedParentFile,
+                origParentXml);
+        FileUtils.write(
+                persistedMachineFile,
+                origMachineXml);
+
+        assertTrue(origMachineXml.contains("NodeMetadataImpl"), origMachineXml);
+
+        // Rebind to the old-style persisted state, which includes the NodeMetadata and the Template objects.
+        // Expect to parse that ok.
+        TestApplication app2 = rebind();
+        
+        JcloudsLocation loc2 = (JcloudsLocation) app2.getManagementContext().getLocationManager().getLocation("fKc0Ofyn");
+        JcloudsWinRmMachineLocation machine2 = (JcloudsWinRmMachineLocation) app2.getManagementContext().getLocationManager().getLocation("KYSryzW8");
+        assertEquals(ImmutableSet.copyOf(loc2.getChildren()), ImmutableSet.of(machine2));
+        
+        String errmsg = "loc="+loc2.toVerboseString()+"; machine="+machine2.toVerboseString();
+        assertEquals(machine2.getId(), "KYSryzW8", errmsg);
+        assertEquals(machine2.getJcloudsId(), "eu-central-1/i-372eda8a", errmsg);
+        assertEquals(machine2.getAddress().getHostAddress(), "52.28.153.46", errmsg);
+        assertEquals(machine2.getPort(), 5985, errmsg);
+        // FIXME assertEquals(machine2.getAddress().getHostAddress(), HostAndPort.fromParts("ec2-52-28-153-46.eu-central-1.compute.amazonaws.com", 22), errmsg);
+        assertEquals(machine2.getPrivateAddresses(), ImmutableSet.of("172.31.18.175"), errmsg);
+        assertEquals(machine2.getPublicAddresses(), ImmutableSet.of("52.28.153.46"), errmsg);
+        assertEquals(machine2.getPrivateAddress(), Optional.of("172.31.18.175"), errmsg);
+        assertEquals(machine2.getHostname(), "ip-172-31-18-175", errmsg); // TODO would prefer the hostname that works inside and out
+        assertNull(machine2.getOsDetails(), errmsg); // JcloudsWinRmMachineLocation never had OsDetails
+
+        // Force it to be persisted again. Expect to pesist without the NodeMetadata and Template.
+        app2.getManagementContext().getRebindManager().getChangeListener().onChanged(loc2);
+        app2.getManagementContext().getRebindManager().getChangeListener().onChanged(machine2);
+        RebindTestUtils.waitForPersisted(app2);
+        
+        String newMachineXml = new String(java.nio.file.Files.readAllBytes(persistedMachineFile.toPath()));
+        assertFalse(newMachineXml.contains("NodeMetadataImpl"), newMachineXml);
+        
+        // Rebind again, with the re-written persisted state.
+        TestApplication app3 = rebind();
+        
+        JcloudsLocation loc3 = (JcloudsLocation) app3.getManagementContext().getLocationManager().getLocation("fKc0Ofyn");
+        JcloudsWinRmMachineLocation machine3 = (JcloudsWinRmMachineLocation) app3.getManagementContext().getLocationManager().getLocation("KYSryzW8");
+        assertEquals(ImmutableSet.copyOf(loc3.getChildren()), ImmutableSet.of(machine3));
+        
+        errmsg = "loc="+loc3.toVerboseString()+"; machine="+machine3.toVerboseString();
+        assertEquals(machine3.getId(), "KYSryzW8", errmsg);
+        assertEquals(machine3.getJcloudsId(), "eu-central-1/i-372eda8a", errmsg);
+        assertEquals(machine3.getAddress().getHostAddress(), "52.28.153.46", errmsg);
+        assertEquals(machine3.getPort(), 5985, errmsg);
+        assertEquals(machine3.getPrivateAddresses(), ImmutableSet.of("172.31.18.175"), errmsg);
+        assertEquals(machine3.getPublicAddresses(), ImmutableSet.of("52.28.153.46"), errmsg);
+        assertEquals(machine3.getPrivateAddress(), Optional.of("172.31.18.175"), errmsg);
+        assertEquals(machine3.getHostname(), "ip-172-31-18-175", errmsg); // TODO would prefer the hostname that works inside and out
+        assertNull(machine2.getOsDetails(), errmsg); // JcloudsWinRmMachineLocation never had OsDetails
+    }
+
+    private void assertMachineEquals(JcloudsSshMachineLocation actual, JcloudsSshMachineLocation expected, boolean expectNoOsDetails) {
         String errmsg = "actual="+actual.toVerboseString()+"; expected="+expected.toVerboseString();
         assertEquals(actual.getId(), expected.getId(), errmsg);
         assertEquals(actual.getJcloudsId(), expected.getJcloudsId(), errmsg);
-        assertOsDetailEquals(actual.getOsDetails(), expected.getOsDetails());
+        if (expectNoOsDetails) {
+            assertOsDetailEquals(actual.getOptionalOsDetails(), Optional.<OsDetails>absent());
+        } else {
+            assertOsDetailEquals(actual.getOptionalOsDetails(), expected.getOptionalOsDetails());
+        }
         assertEquals(actual.getSshHostAndPort(), expected.getSshHostAndPort());
         assertEquals(actual.getPrivateAddress(), expected.getPrivateAddress());
         assertConfigBagEquals(actual.config().getBag(), expected.config().getBag(), errmsg);
     }
 
-    private void assertOsDetailEquals(OsDetails actual, OsDetails expected) {
+    private void assertOsDetailEquals(Optional<OsDetails> actual, Optional<OsDetails> expected) {
         String errmsg = "actual="+actual+"; expected="+expected;
-        if (actual == null) assertNull(expected, errmsg);
-        assertEquals(actual.isWindows(), expected.isWindows());
-        assertEquals(actual.isLinux(), expected.isLinux());
-        assertEquals(actual.isMac(), expected.isMac());
-        assertEquals(actual.getName(), expected.getName());
-        assertEquals(actual.getArch(), expected.getArch());
-        assertEquals(actual.getVersion(), expected.getVersion());
-        assertEquals(actual.is64bit(), expected.is64bit());
+        if (actual.isPresent()) {
+            assertEquals(actual.get().isWindows(), expected.get().isWindows());
+            assertEquals(actual.get().isLinux(), expected.get().isLinux());
+            assertEquals(actual.get().isMac(), expected.get().isMac());
+            assertEquals(actual.get().getName(), expected.get().getName());
+            assertEquals(actual.get().getArch(), expected.get().getArch());
+            assertEquals(actual.get().getVersion(), expected.get().getVersion());
+            assertEquals(actual.get().is64bit(), expected.get().is64bit());
+        } else {
+            assertFalse(expected.isPresent(), errmsg);
+        }
     }
 
     private void assertJcloudsLocationEquals(JcloudsLocation actual, JcloudsLocation expected) {
@@ -143,7 +314,13 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
     }
     
     private TestApplication rebind() throws Exception {
+        return rebind(RebindOptions.create()
+                .mementoDir(mementoDir)
+                .classLoader(classLoader));
+    }
+    
+    private TestApplication rebind(RebindOptions options) throws Exception {
         RebindTestUtils.waitForPersisted(origApp);
-        return (TestApplication) RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());
+        return (TestApplication) RebindTestUtils.rebind(options);
     }
 }

--- a/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-machine-aKEcbxKN
+++ b/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-machine-aKEcbxKN
@@ -1,0 +1,329 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<location>
+  <brooklynVersion>0.9.0-20151120.1523</brooklynVersion>
+  <type>org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation</type>
+  <id>aKEcbxKN</id>
+  <displayName>ec2-54-254-23-53.ap-southeast-1.compute.amazonaws.com</displayName>
+  <parent>lCYB3mTb</parent>
+  <locationConfig>
+    <displayName>ec2-54-254-23-53.ap-southeast-1.compute.amazonaws.com</displayName>
+    <address>
+      <java.net.Inet4Address>ec2-54-254-23-53.ap-southeast-1.compute.amazonaws.com/54.254.23.53</java.net.Inet4Address>
+    </address>
+    <user>amp</user>
+    <privateKeyData>-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</privateKeyData>
+    <config>
+      <java.util.Collections_-UnmodifiableMap>
+        <m class="MutableMap">
+          <privateKeyData>-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</privateKeyData>
+        </m>
+      </java.util.Collections_-UnmodifiableMap>
+    </config>
+    <jcloudsParent>
+      <locationProxy>lCYB3mTb</locationProxy>
+    </jcloudsParent>
+    <node>
+      <org.jclouds.compute.domain.internal.NodeMetadataImpl>
+        <providerId>i-56fd53f2</providerId>
+        <name>brooklyn-nv6pd3-amp-auto-qa-post-un67-postgresql-ryhi-b87c</name>
+        <location class="org.jclouds.domain.internal.LocationImpl">
+          <scope>ZONE</scope>
+          <id>ap-southeast-1a</id>
+          <description>ap-southeast-1a</description>
+          <parent class="org.jclouds.domain.internal.LocationImpl">
+            <scope>REGION</scope>
+            <id>ap-southeast-1</id>
+            <description>ap-southeast-1</description>
+            <parent class="org.jclouds.domain.internal.LocationImpl">
+              <scope>PROVIDER</scope>
+              <id>aws-ec2</id>
+              <description>https://ec2.us-east-1.amazonaws.com</description>
+              <iso3166Codes class="com.google.common.collect.RegularImmutableSet">
+                <string>US-VA</string>
+                <string>US-CA</string>
+                <string>US-OR</string>
+                <string>BR-SP</string>
+                <string>IE</string>
+                <string>DE-HE</string>
+                <string>SG</string>
+                <string>AU-NSW</string>
+                <string>JP-13</string>
+              </iso3166Codes>
+              <metadata class="com.google.common.collect.EmptyImmutableBiMap"/>
+            </parent>
+            <iso3166Codes class="com.google.common.collect.SingletonImmutableSet">
+              <string>SG</string>
+            </iso3166Codes>
+            <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../parent/metadata"/>
+          </parent>
+          <iso3166Codes class="com.google.common.collect.SingletonImmutableSet" reference="../parent/iso3166Codes"/>
+          <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../parent/parent/metadata"/>
+        </location>
+        <userMetadata>
+          <Name>brooklyn-nv6pd3-amp-auto-qa-post-un67-postgresql-ryhi-b87c</Name>
+          <entry key="brooklyn-user">amp</entry>
+          <entry key="brooklyn-app-id">Un679FS8</entry>
+          <entry key="brooklyn-app-name">(auto-qa) postgres @ AWS Singapore</entry>
+          <entry key="brooklyn-entity-id">RyHiwukc</entry>
+          <entry key="brooklyn-entity-name">PostgreSQL Server</entry>
+          <entry key="brooklyn-server-creation-date">2015-09-24-1456</entry>
+        </userMetadata>
+        <id>ap-southeast-1/i-56fd53f2</id>
+        <type>NODE</type>
+        <tags class="com.google.common.collect.EmptyImmutableSet"/>
+        <status>RUNNING</status>
+        <backendStatus>running</backendStatus>
+        <loginPort>22</loginPort>
+        <publicAddresses class="com.google.common.collect.SingletonImmutableSet">
+          <string>54.254.23.53</string>
+        </publicAddresses>
+        <privateAddresses class="com.google.common.collect.SingletonImmutableSet">
+          <string>10.144.66.5</string>
+        </privateAddresses>
+        <credentials>
+          <identity>amp</identity>
+          <credential>-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</credential>
+          <authenticateSudo>false</authenticateSudo>
+          <password class="com.google.common.base.Absent"/>
+          <privateKey class="com.google.common.base.Present">
+            <reference class="string">-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</reference>
+          </privateKey>
+        </credentials>
+        <group>brooklyn-nv6pd3-amp-auto-qa-post-un67-postgresql-ryhi</group>
+        <imageId>ap-southeast-1/ami-42bfe910</imageId>
+        <hardware class="org.jclouds.compute.domain.internal.HardwareImpl">
+          <providerId>m1.medium</providerId>
+          <userMetadata/>
+          <id>m1.medium</id>
+          <type>HARDWARE</type>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../tags"/>
+          <processors class="ImmutableList">
+            <org.jclouds.compute.domain.Processor>
+              <cores>1.0</cores>
+              <speed>2.0</speed>
+            </org.jclouds.compute.domain.Processor>
+          </processors>
+          <ram>3750</ram>
+          <volumes class="ImmutableList">
+            <org.jclouds.compute.domain.internal.VolumeImpl>
+              <type>LOCAL</type>
+              <size>420.0</size>
+              <device>/dev/sdb</device>
+              <bootDevice>false</bootDevice>
+              <durable>false</durable>
+            </org.jclouds.compute.domain.internal.VolumeImpl>
+            <org.jclouds.compute.domain.internal.VolumeImpl>
+              <type>LOCAL</type>
+              <size>420.0</size>
+              <device>/dev/sdc</device>
+              <bootDevice>false</bootDevice>
+              <durable>false</durable>
+            </org.jclouds.compute.domain.internal.VolumeImpl>
+            <org.jclouds.compute.domain.internal.VolumeImpl>
+              <id>vol-7e244896</id>
+              <type>SAN</type>
+              <device>/dev/sda1</device>
+              <bootDevice>true</bootDevice>
+              <durable>true</durable>
+            </org.jclouds.compute.domain.internal.VolumeImpl>
+          </volumes>
+          <supportsImage class="com.google.common.base.Predicates$AndPredicate">
+            <components>
+              <com.google.common.base.Predicates_-ObjectPredicate>ALWAYS_TRUE</com.google.common.base.Predicates_-ObjectPredicate>
+              <org.jclouds.ec2.compute.domain.EC2HardwareBuilder_-RequiresVirtualizationType>
+                <type>PARAVIRTUAL</type>
+              </org.jclouds.ec2.compute.domain.EC2HardwareBuilder_-RequiresVirtualizationType>
+              <com.google.common.base.Predicates_-ObjectPredicate>ALWAYS_TRUE</com.google.common.base.Predicates_-ObjectPredicate>
+              <com.google.common.base.Predicates_-ObjectPredicate>ALWAYS_TRUE</com.google.common.base.Predicates_-ObjectPredicate>
+            </components>
+          </supportsImage>
+          <hypervisor>xen</hypervisor>
+          <deprecated>false</deprecated>
+        </hardware>
+        <os>
+          <family>CENTOS</family>
+          <arch>paravirtual</arch>
+          <version>6.5</version>
+          <description>411009282317/RightImage_CentOS_6.5_x64_v13.5.2.2_EBS</description>
+          <is64Bit>true</is64Bit>
+        </os>
+        <hostname>ip-10-144-66-5</hostname>
+      </org.jclouds.compute.domain.internal.NodeMetadataImpl>
+    </node>
+    <brooklyn.ssh.config.port type="int">22</brooklyn.ssh.config.port>
+    <availabilityZone>ap-southeast-1a</availabilityZone>
+    <region>ap-southeast-1</region>
+    <callerContext>
+      <null/>
+    </callerContext>
+    <detectMachineDetails type="boolean">true</detectMachineDetails>
+    <portforwarding.enabled type="boolean">false</portforwarding.enabled>
+    <template>
+      <org.jclouds.compute.domain.internal.TemplateImpl>
+        <image class="org.jclouds.compute.domain.internal.ImageImpl">
+          <providerId>ami-42bfe910</providerId>
+          <name>RightImage_CentOS_6.5_x64_v13.5.2.2_EBS</name>
+          <location class="org.jclouds.domain.internal.LocationImpl" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/location/parent"/>
+          <userMetadata>
+            <owner>411009282317</owner>
+            <rootDeviceType>ebs</rootDeviceType>
+            <virtualizationType>paravirtual</virtualizationType>
+            <hypervisor>xen</hypervisor>
+          </userMetadata>
+          <id>ap-southeast-1/ami-42bfe910</id>
+          <type>IMAGE</type>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <operatingSystem reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/os"/>
+          <status>AVAILABLE</status>
+          <backendStatus>available</backendStatus>
+          <version>13.5.2.2_EBS</version>
+          <description>RightImage_CentOS_6.5_x64_v13.5.2.2_EBS</description>
+          <defaultCredentials>
+            <identity>root</identity>
+            <authenticateSudo>false</authenticateSudo>
+            <password class="com.google.common.base.Absent" reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+            <privateKey class="com.google.common.base.Absent" reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+          </defaultCredentials>
+        </image>
+        <hardware class="org.jclouds.compute.domain.internal.HardwareImpl">
+          <providerId>m1.medium</providerId>
+          <userMetadata/>
+          <id>m1.medium</id>
+          <type>HARDWARE</type>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <processors class="ImmutableList" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/hardware/processors"/>
+          <ram>3750</ram>
+          <volumes class="ImmutableList">
+            <org.jclouds.compute.domain.internal.VolumeImpl>
+              <type>LOCAL</type>
+              <size>10.0</size>
+              <device>/dev/sda1</device>
+              <bootDevice>true</bootDevice>
+              <durable>false</durable>
+            </org.jclouds.compute.domain.internal.VolumeImpl>
+            <org.jclouds.compute.domain.internal.VolumeImpl reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/hardware/volumes/org.jclouds.compute.domain.internal.VolumeImpl"/>
+            <org.jclouds.compute.domain.internal.VolumeImpl reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/hardware/volumes/org.jclouds.compute.domain.internal.VolumeImpl[2]"/>
+          </volumes>
+          <supportsImage class="com.google.common.base.Predicates$AndPredicate" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/hardware/supportsImage"/>
+          <deprecated>true</deprecated>
+        </hardware>
+        <location class="org.jclouds.domain.internal.LocationImpl" reference="../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/location/parent"/>
+        <options class="org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions">
+          <port>-1</port>
+          <seconds>-1</seconds>
+          <runAsRoot>true</runAsRoot>
+          <blockOnComplete>true</blockOnComplete>
+          <wrapInInitScript>true</wrapInInitScript>
+          <inboundPorts class="com.google.common.collect.RegularImmutableSet">
+            <int>22</int>
+            <int>5432</int>
+          </inboundPorts>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <securityGroups class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <blockUntilRunning>true</blockUntilRunning>
+          <userMetadata>
+            <Name>brooklyn-nv6pd3-amp-auto-qa-post-un67-postgresql-ryhi-b87c</Name>
+            <entry key="brooklyn-user">amp</entry>
+            <entry key="brooklyn-app-id">Un679FS8</entry>
+            <entry key="brooklyn-app-name">(auto-qa) postgres @ AWS Singapore</entry>
+            <entry key="brooklyn-entity-id">RyHiwukc</entry>
+            <entry key="brooklyn-entity-name">PostgreSQL Server</entry>
+            <entry key="brooklyn-server-creation-date">2015-09-24-1456</entry>
+          </userMetadata>
+          <nodeNames class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <networks class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <groupNames class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <noKeyPair>false</noKeyPair>
+          <userData class="com.google.common.primitives.Bytes$ByteArrayAsList">
+            <array>I2Nsb3VkLWNvbmZpZwpyZXBvX3VwZ3JhZGU6IG5vbmUK</array>
+            <start>0</start>
+            <end>33</end>
+          </userData>
+          <blockDeviceMappings>
+            <contents>
+              <null/>
+              <null/>
+              <null/>
+              <null/>
+            </contents>
+            <size>0</size>
+          </blockDeviceMappings>
+          <monitoringEnabled>false</monitoringEnabled>
+          <noPlacementGroup>false</noPlacementGroup>
+          <spotOptions>
+            <formParameters class="com.google.common.collect.LinkedHashMultimap" serialization="custom">
+              <unserializable-parents/>
+              <com.google.common.collect.LinkedHashMultimap>
+                <default/>
+                <int>2</int>
+                <int>0</int>
+                <int>0</int>
+              </com.google.common.collect.LinkedHashMultimap>
+            </formParameters>
+            <queryParameters class="com.google.common.collect.LinkedHashMultimap" serialization="custom">
+              <unserializable-parents/>
+              <com.google.common.collect.LinkedHashMultimap>
+                <default/>
+                <int>2</int>
+                <int>0</int>
+                <int>0</int>
+              </com.google.common.collect.LinkedHashMultimap>
+            </queryParameters>
+            <headers class="com.google.common.collect.LinkedHashMultimap" serialization="custom">
+              <unserializable-parents/>
+              <com.google.common.collect.LinkedHashMultimap>
+                <default/>
+                <int>2</int>
+                <int>0</int>
+                <int>0</int>
+              </com.google.common.collect.LinkedHashMultimap>
+            </headers>
+          </spotOptions>
+          <groupIds class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+        </options>
+      </org.jclouds.compute.domain.internal.TemplateImpl>
+    </template>
+    <usedPorts>
+      <set/>
+    </usedPorts>
+    <tags>
+      <set/>
+    </tags>
+  </locationConfig>
+  <locationConfigUnused>
+    <string>displayName</string>
+    <string>config</string>
+    <string>availabilityZone</string>
+    <string>region</string>
+    <string>portforwarding.enabled</string>
+  </locationConfigUnused>
+</location>

--- a/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-parent-lCYB3mTb
+++ b/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-parent-lCYB3mTb
@@ -1,0 +1,78 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<location>
+  <brooklynVersion>0.9.0-20151120.1523</brooklynVersion>
+  <type>org.apache.brooklyn.location.jclouds.JcloudsLocation</type>
+  <id>lCYB3mTb</id>
+  <displayName>AWS Singapore (ap-southeast-1)</displayName>
+  <children>
+    <string>aKEcbxKN</string>
+  </children>
+  <locationConfig>
+    <provider>aws-ec2</provider>
+    <minRam>2048</minRam>
+    <useJcloudsSshInit>false</useJcloudsSshInit>
+    <identity>myidentity</identity>
+    <openIptables>true</openIptables>
+    <credential>mycredential</credential>
+    <machineCreateAttempts>2</machineCreateAttempts>
+    <latitude>1.3000</latitude>
+    <streetAddress>Singapore</streetAddress>
+    <defaultImageId>ap-southeast-1/ami-21c2bd73</defaultImageId>
+    <iso3166>
+      <com.google.common.collect.SingletonImmutableSet>
+        <string>SG</string>
+      </com.google.common.collect.SingletonImmutableSet>
+    </iso3166>
+    <displayName>AWS Singapore (ap-southeast-1)</displayName>
+    <longitude>103.8000</longitude>
+    <hardwareId>m1.medium</hardwareId>
+    <imageId>ap-southeast-1/ami-42bfe910</imageId>
+    <spec.named.name>AWS Singapore</spec.named.name>
+    <spec.original>AWS Singapore</spec.original>
+    <region>ap-southeast-1</region>
+    <spec.final>jclouds:aws-ec2:ap-southeast-1</spec.final>
+    <machineCreationSemaphore>
+      <java.util.concurrent.Semaphore>
+        <sync class="java.util.concurrent.Semaphore$FairSync">
+          <state>2147483647</state>
+        </sync>
+      </java.util.concurrent.Semaphore>
+    </machineCreationSemaphore>
+    <vmInstanceIds>
+      <map>
+        <entry>
+          <locationProxy>aKEcbxKN</locationProxy>
+          <string>ap-southeast-1/i-56fd53f2</string>
+        </entry>
+      </map>
+    </vmInstanceIds>
+    <tags>
+      <set/>
+    </tags>
+  </locationConfig>
+  <locationConfigUnused>
+    <string>latitude</string>
+    <string>streetAddress</string>
+    <string>iso3166</string>
+    <string>displayName</string>
+    <string>longitude</string>
+  </locationConfigUnused>
+  <locationConfigDescription>aws-ec2:ap-southeast-1</locationConfigDescription>
+</location>

--- a/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-winrm-machine-KYSryzW8
+++ b/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-winrm-machine-KYSryzW8
@@ -1,0 +1,184 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<location>
+  <brooklynVersion>0.9.0-P20151204.1943</brooklynVersion>
+  <type>org.apache.brooklyn.location.jclouds.JcloudsWinRmMachineLocation</type>
+  <id>KYSryzW8</id>
+  <displayName>52.28.153.46</displayName>
+  <parent>fKc0Ofyn</parent>
+  <locationConfig>
+    <jcloudsParent>
+      <locationProxy>fKc0Ofyn</locationProxy>
+    </jcloudsParent>
+    <displayName>52.28.153.46</displayName>
+    <address>52.28.153.46</address>
+    <user>Administrator</user>
+    <node>
+      <org.jclouds.compute.domain.internal.NodeMetadataImpl>
+        <providerId>i-372eda8a</providerId>
+        <name>brooklyn-nxlv9n-amp-myentity-i9fh-myentity-ms-sql-tccu-wgax</name>
+        <location class="org.jclouds.domain.internal.LocationImpl">
+          <scope>ZONE</scope>
+          <id>eu-central-1a</id>
+          <description>eu-central-1a</description>
+          <parent class="org.jclouds.domain.internal.LocationImpl">
+            <scope>REGION</scope>
+            <id>eu-central-1</id>
+            <description>eu-central-1</description>
+            <parent class="org.jclouds.domain.internal.LocationImpl">
+              <scope>PROVIDER</scope>
+              <id>aws-ec2</id>
+              <description>https://ec2.us-east-1.amazonaws.com</description>
+              <iso3166Codes class="com.google.common.collect.RegularImmutableSet">
+                <string>US-VA</string>
+                <string>US-CA</string>
+                <string>US-OR</string>
+                <string>BR-SP</string>
+                <string>IE</string>
+                <string>DE-HE</string>
+                <string>SG</string>
+                <string>AU-NSW</string>
+                <string>JP-13</string>
+              </iso3166Codes>
+              <metadata class="com.google.common.collect.EmptyImmutableBiMap"/>
+            </parent>
+            <iso3166Codes class="com.google.common.collect.SingletonImmutableSet">
+              <string>DE-HE</string>
+            </iso3166Codes>
+            <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../parent/metadata"/>
+          </parent>
+          <iso3166Codes class="com.google.common.collect.SingletonImmutableSet" reference="../parent/iso3166Codes"/>
+          <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../parent/parent/metadata"/>
+        </location>
+        <userMetadata>
+          <Name>brooklyn-nxlv9n-amp-myentity-i9fh-myentity-ms-sql-tccu-wgax</Name>
+          <entry key="brooklyn-user">amp</entry>
+          <entry key="brooklyn-app-id">I9fhRJIh</entry>
+          <entry key="brooklyn-app-name">MyApp</entry>
+          <entry key="brooklyn-entity-id">tCcU6QL0</entry>
+          <entry key="brooklyn-entity-name">My Entity</entry>
+          <entry key="brooklyn-server-creation-date">2015-11-10-1539</entry>
+        </userMetadata>
+        <id>eu-central-1/i-372eda8a</id>
+        <type>NODE</type>
+        <tags class="com.google.common.collect.EmptyImmutableSet"/>
+        <status>RUNNING</status>
+        <backendStatus>running</backendStatus>
+        <loginPort>5985</loginPort>
+        <publicAddresses class="com.google.common.collect.SingletonImmutableSet">
+          <string>52.28.153.46</string>
+        </publicAddresses>
+        <privateAddresses class="com.google.common.collect.SingletonImmutableSet">
+          <string>172.31.18.175</string>
+        </privateAddresses>
+        <credentials>
+          <identity>Administrator</identity>
+          <credential>mypassword</credential>
+          <authenticateSudo>false</authenticateSudo>
+          <password class="com.google.common.base.Present">
+            <reference class="string">mypassword</reference>
+          </password>
+          <privateKey class="com.google.common.base.Absent"/>
+        </credentials>
+        <group>brooklyn-nxlv9n-amp-myentity-i9fh-myentity-ms-sql-tccu</group>
+        <imageId>eu-central-1/ami-f2f5f9ef</imageId>
+        <hardware class="org.jclouds.compute.domain.internal.HardwareImpl">
+          <providerId>m3.large</providerId>
+          <userMetadata/>
+          <id>m3.large</id>
+          <type>HARDWARE</type>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../tags"/>
+          <processors class="ImmutableList">
+            <org.jclouds.compute.domain.Processor>
+              <cores>2.0</cores>
+              <speed>3.25</speed>
+            </org.jclouds.compute.domain.Processor>
+          </processors>
+          <ram>7680</ram>
+          <volumes class="ImmutableList">
+            <org.jclouds.compute.domain.internal.VolumeImpl>
+              <type>LOCAL</type>
+              <size>32.0</size>
+              <device>/dev/sdb</device>
+              <bootDevice>false</bootDevice>
+              <durable>false</durable>
+            </org.jclouds.compute.domain.internal.VolumeImpl>
+            <org.jclouds.compute.domain.internal.VolumeImpl>
+              <id>vol-1f1b72c6</id>
+              <type>SAN</type>
+              <device>/dev/sda1</device>
+              <bootDevice>true</bootDevice>
+              <durable>true</durable>
+            </org.jclouds.compute.domain.internal.VolumeImpl>
+          </volumes>
+          <supportsImage class="com.google.common.base.Predicates$AndPredicate">
+            <components>
+              <com.google.common.base.Predicates_-ObjectPredicate>ALWAYS_TRUE</com.google.common.base.Predicates_-ObjectPredicate>
+              <com.google.common.base.Predicates_-OrPredicate>
+                <components>
+                  <org.jclouds.ec2.compute.domain.EC2HardwareBuilder_-RequiresVirtualizationType>
+                    <type>HVM</type>
+                  </org.jclouds.ec2.compute.domain.EC2HardwareBuilder_-RequiresVirtualizationType>
+                  <org.jclouds.ec2.compute.domain.EC2HardwareBuilder_-RequiresVirtualizationType>
+                    <type>PARAVIRTUAL</type>
+                  </org.jclouds.ec2.compute.domain.EC2HardwareBuilder_-RequiresVirtualizationType>
+                </components>
+              </com.google.common.base.Predicates_-OrPredicate>
+              <com.google.common.base.Predicates_-ObjectPredicate>ALWAYS_TRUE</com.google.common.base.Predicates_-ObjectPredicate>
+              <com.google.common.base.Predicates_-ObjectPredicate>ALWAYS_TRUE</com.google.common.base.Predicates_-ObjectPredicate>
+            </components>
+          </supportsImage>
+          <hypervisor>xen</hypervisor>
+          <deprecated>false</deprecated>
+        </hardware>
+        <os>
+          <family>WINDOWS</family>
+          <arch>hvm</arch>
+          <version></version>
+          <description>amazon/Windows_Server-2012-R2_RTM-English-64Bit-Base-2015.10.26</description>
+          <is64Bit>true</is64Bit>
+        </os>
+        <hostname>ip-172-31-18-175</hostname>
+      </org.jclouds.compute.domain.internal.NodeMetadataImpl>
+    </node>
+    <port type="int">5985</port>
+    <password>mypassword</password>
+    <availabilityZone>eu-central-1a</availabilityZone>
+    <region>eu-central-1</region>
+    <callerContext>
+      <null/>
+    </callerContext>
+    <detectMachineDetails type="boolean">true</detectMachineDetails>
+    <portforwarding.enabled type="boolean">false</portforwarding.enabled>
+    <template>
+      <null/>
+    </template>
+    <tags>
+      <set/>
+    </tags>
+  </locationConfig>
+  <locationConfigUnused>
+    <string>displayName</string>
+    <string>availabilityZone</string>
+    <string>region</string>
+    <string>callerContext</string>
+    <string>detectMachineDetails</string>
+    <string>portforwarding.enabled</string>
+  </locationConfigUnused>
+</location>

--- a/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-winrm-parent-fKc0Ofyn
+++ b/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-aws-winrm-parent-fKc0Ofyn
@@ -1,0 +1,75 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<location>
+  <brooklynVersion>0.9.0-P20151204.1943</brooklynVersion>
+  <type>org.apache.brooklyn.location.jclouds.JcloudsLocation</type>
+  <id>fKc0Ofyn</id>
+  <displayName>aws-ec2:eu-central-1</displayName>
+  <children>
+    <string>KYSryzW8</string>
+  </children>
+  <locationConfig>
+    <provider>aws-ec2</provider>
+    <minRam>2048</minRam>
+    <useJcloudsSshInit type="boolean">false</useJcloudsSshInit>
+    <identity>myidentity</identity>
+    <openIptables>true</openIptables>
+    <credential>mycredential</credential>
+    <machineCreateAttempts>2</machineCreateAttempts>
+    <imageNameRegex>Windows_Server-2012-R2_RTM-English-64Bit-Base</imageNameRegex>
+    <hardwareId>m3.large</hardwareId>
+    <templateOptions>
+      <com.google.common.collect.SingletonImmutableBiMap>
+        <entry>
+          <string>mapNewVolumeToDeviceName</string>
+          <ImmutableList>
+            <string>/dev/sda1</string>
+            <int>100</int>
+            <boolean>true</boolean>
+          </ImmutableList>
+        </entry>
+      </com.google.common.collect.SingletonImmutableBiMap>
+    </templateOptions>
+    <region>eu-central-1</region>
+    <spec.final>jclouds:aws-ec2:eu-central-1</spec.final>
+    <spec.original>jclouds:aws-ec2:eu-central-1</spec.original>
+    <machineCreationSemaphore>
+      <java.util.concurrent.Semaphore>
+        <sync class="java.util.concurrent.Semaphore$FairSync">
+          <state>2147483647</state>
+        </sync>
+      </java.util.concurrent.Semaphore>
+    </machineCreationSemaphore>
+    <vmInstanceIds>
+      <map>
+        <entry>
+          <locationProxy>KYSryzW8</locationProxy>
+          <string>eu-central-1/i-372eda8a</string>
+        </entry>
+      </map>
+    </vmInstanceIds>
+    <tags>
+      <set/>
+    </tags>
+  </locationConfig>
+  <locationConfigUnused>
+    <string>machineCreationSemaphore</string>
+  </locationConfigUnused>
+  <locationConfigDescription>aws-ec2:eu-central-1</locationConfigDescription>
+</location>

--- a/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-azure-machine-VNapYjwp
+++ b/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-azure-machine-VNapYjwp
@@ -1,0 +1,271 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<location>
+  <brooklynVersion>0.9.0-20151120.1523</brooklynVersion>
+  <type>org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation</type>
+  <id>VNapYjwp</id>
+  <displayName>40.118.22.49</displayName>
+  <parent>briByOel</parent>
+  <locationConfig>
+    <displayName>40.118.22.49</displayName>
+    <address>
+      <java.net.Inet4Address>40.118.22.49/40.118.22.49</java.net.Inet4Address>
+    </address>
+    <user>amp</user>
+    <privateKeyData>myPrivateKey-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</privateKeyData>
+    <config>
+      <java.util.Collections_-UnmodifiableMap>
+        <m class="MutableMap">
+          <privateKeyData>-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</privateKeyData>
+        </m>
+      </java.util.Collections_-UnmodifiableMap>
+    </config>
+    <jcloudsParent>
+      <locationProxy>briByOel</locationProxy>
+    </jcloudsParent>
+    <node>
+      <org.jclouds.compute.domain.internal.NodeMetadataImpl>
+        <providerId>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g-ddd</providerId>
+        <name>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g-ddd</name>
+        <location class="org.jclouds.domain.internal.LocationImpl">
+          <scope>REGION</scope>
+          <id>West Europe</id>
+          <description>West Europe</description>
+          <parent class="org.jclouds.domain.internal.LocationImpl">
+            <scope>PROVIDER</scope>
+            <id>azurecompute</id>
+            <description>https://management.core.windows.net/341751b0-f348-45ce-9498-41cc68b4b45f</description>
+            <iso3166Codes class="com.google.common.collect.RegularImmutableSet">
+              <string>US-IA</string>
+              <string>US-VA</string>
+              <string>US-IL</string>
+              <string>US-TX</string>
+              <string>US-CA</string>
+              <string>IE</string>
+              <string>NL</string>
+              <string>HK</string>
+              <string>SG</string>
+              <string>JP-11</string>
+              <string>JP-27</string>
+              <string>BR</string>
+              <string>AU-NSW</string>
+              <string>AU-VIC</string>
+            </iso3166Codes>
+            <metadata class="com.google.common.collect.EmptyImmutableBiMap"/>
+          </parent>
+          <iso3166Codes class="com.google.common.collect.SingletonImmutableSet">
+            <string>NL</string>
+          </iso3166Codes>
+          <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../parent/metadata"/>
+        </location>
+        <userMetadata/>
+        <id>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g-ddd</id>
+        <type>NODE</type>
+        <tags class="com.google.common.collect.EmptyImmutableSet"/>
+        <status>RUNNING</status>
+        <loginPort>22</loginPort>
+        <publicAddresses class="com.google.common.collect.SingletonImmutableSet">
+          <string>40.118.22.49</string>
+        </publicAddresses>
+        <privateAddresses class="com.google.common.collect.SingletonImmutableSet">
+          <string>10.0.0.4</string>
+        </privateAddresses>
+        <credentials>
+          <identity>amp</identity>
+          <credential>-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</credential>
+          <authenticateSudo>false</authenticateSudo>
+          <password class="com.google.common.base.Absent"/>
+          <privateKey class="com.google.common.base.Present">
+            <reference class="string">-----BEGIN RSA PRIVATE KEY-----
+myPrivateKey
+-----END RSA PRIVATE KEY-----
+</reference>
+          </privateKey>
+        </credentials>
+        <group>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g</group>
+        <hostname>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g-ddd</hostname>
+      </org.jclouds.compute.domain.internal.NodeMetadataImpl>
+    </node>
+    <brooklyn.ssh.config.port type="int">22</brooklyn.ssh.config.port>
+    <region>West Europe</region>
+    <callerContext>
+      <null/>
+    </callerContext>
+    <detectMachineDetails type="boolean">true</detectMachineDetails>
+    <portforwarding.enabled type="boolean">false</portforwarding.enabled>
+    <port type="int">22</port>
+    <template>
+      <org.jclouds.compute.domain.internal.TemplateImpl>
+        <image class="org.jclouds.compute.domain.internal.ImageImpl">
+          <providerId>b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_1-LTS-amd64-server-20150123-en-us-30GB</providerId>
+          <name>Ubuntu Server 14.04.1 LTS</name>
+          <userMetadata/>
+          <id>b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_1-LTS-amd64-server-20150123-en-us-30GB</id>
+          <type>IMAGE</type>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <operatingSystem>
+            <family>UBUNTU</family>
+            <version>14.04.1 LTS</version>
+            <description>Ubuntu Server 14.04.1 LTS (amd64 20150123) for Microsoft Azure. Ubuntu Server is the world&apos;s most popular Linux for cloud environments. Updates and patches for Ubuntu 14.04.1 LTS will be available until 2019-04-17.  Ubuntu Server is the perfect platform for all workloads from web applications to NoSQL databases and Hadoop. For more information see [Ubuntu Cloud|http://www.ubuntu.com/cloud|_blank] and [using Juju to deploy your workloads|http://juju.ubuntu.com|_blank].</description>
+            <is64Bit>true</is64Bit>
+          </operatingSystem>
+          <status>AVAILABLE</status>
+          <description>Ubuntu Server 14.04.1 LTS (amd64 20150123) for Microsoft Azure. Ubuntu Server is the world&apos;s most popular Linux for cloud environments. Updates and patches for Ubuntu 14.04.1 LTS will be available until 2019-04-17.  Ubuntu Server is the perfect platform for all workloads from web applications to NoSQL databases and Hadoop. For more information see [Ubuntu Cloud|http://www.ubuntu.com/cloud|_blank] and [using Juju to deploy your workloads|http://juju.ubuntu.com|_blank].</description>
+          <defaultCredentials>
+            <identity>root</identity>
+            <authenticateSudo>false</authenticateSudo>
+            <password class="com.google.common.base.Absent" reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+            <privateKey class="com.google.common.base.Absent" reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+          </defaultCredentials>
+        </image>
+        <hardware class="org.jclouds.compute.domain.internal.HardwareImpl">
+          <providerId>BASIC_A2</providerId>
+          <name>BASIC_A2</name>
+          <userMetadata/>
+          <id>BASIC_A2</id>
+          <type>HARDWARE</type>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <processors class="ImmutableList">
+            <org.jclouds.compute.domain.Processor>
+              <cores>2.0</cores>
+              <speed>2.0</speed>
+            </org.jclouds.compute.domain.Processor>
+          </processors>
+          <ram>3584</ram>
+          <volumes class="ImmutableList"/>
+          <supportsImage class="com.google.common.base.Predicates$ObjectPredicate">ALWAYS_TRUE</supportsImage>
+          <hypervisor>Hyper-V</hypervisor>
+          <deprecated>false</deprecated>
+        </hardware>
+        <location class="org.jclouds.domain.internal.LocationImpl">
+          <scope>REGION</scope>
+          <id>West Europe</id>
+          <description>West Europe</description>
+          <parent class="org.jclouds.domain.internal.LocationImpl">
+            <scope>PROVIDER</scope>
+            <id>azurecompute</id>
+            <description>https://management.core.windows.net/341751b0-f348-45ce-9498-41cc68b4b45f</description>
+            <iso3166Codes class="com.google.common.collect.RegularImmutableSet" reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/location/parent/iso3166Codes"/>
+            <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/location/parent/metadata"/>
+          </parent>
+          <iso3166Codes class="com.google.common.collect.SingletonImmutableSet">
+            <string>NL</string>
+          </iso3166Codes>
+          <metadata class="com.google.common.collect.EmptyImmutableBiMap" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/location/parent/metadata"/>
+        </location>
+        <options class="org.jclouds.azurecompute.options.AzureComputeTemplateOptions">
+          <port>-1</port>
+          <seconds>-1</seconds>
+          <taskName>bootstrap</taskName>
+          <runAsRoot>true</runAsRoot>
+          <blockOnComplete>true</blockOnComplete>
+          <wrapInInitScript>true</wrapInInitScript>
+          <inboundPorts class="com.google.common.collect.RegularImmutableSet">
+            <int>22</int>
+            <int>31880</int>
+            <int>31001</int>
+            <int>8080</int>
+            <int>1099</int>
+            <int>8443</int>
+          </inboundPorts>
+          <script class="org.jclouds.scriptbuilder.domain.StatementList">
+            <statements class="ImmutableList">
+              <org.jclouds.scriptbuilder.statements.login.AdminAccess>
+                <config>
+                  <adminUsername>amp</adminUsername>
+                  <adminFullName>amp</adminFullName>
+                  <adminPublicKey>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAyRJ8h3uGrGOPo4fe2Fxd47bKE4I7aTwDvs3zkMNDGQZFzVPrldpDLcXG6E9jjAOomhchP7+PKc/FLa3pkv9eA5gX0m8GwYiVzmwYP6k2dvX+hyVD9m68xGMPYdjnu4ytTnnJLaDDqdd7ta/sJLWFbPkup1L6iHgHzJ9Zy1238yAtd7ypmlpvFLUltlqq614dpZq4C3ZuHhylL9gnNKPDYiX1a6XxX8WDkl5QLDMpU+pVp/XtyWvsBJ2j+aIghGSUtYB4kZYKRg9Vw/SskUg2a9NNnGxhox6D5MEw48eYpWoFk1A5qQrfPv5iwhEvbKWq3N600GvcfDwVgqJIK9VksQ== amp@AMP
+</adminPublicKey>
+                  <adminPrivateKey>pa55w0rd</adminPrivateKey>
+                  <adminPassword>pa55w0rd</adminPassword>
+                  <loginPassword>pa55w0rd</loginPassword>
+                  <grantSudoToAdminUser>true</grantSudoToAdminUser>
+                  <installAdminPrivateKey>false</installAdminPrivateKey>
+                  <resetLoginPassword>true</resetLoginPassword>
+                  <cryptFunction class="org.jclouds.compute.functions.Sha512Crypt$Function">INSTANCE</cryptFunction>
+                  <adminCredentials>
+                    <identity>amp</identity>
+                    <credential>c6KeIH4QNmOs-ignored</credential>
+                  </adminCredentials>
+                  <authorizeAdminPublicKey>true</authorizeAdminPublicKey>
+                  <lockSsh>true</lockSsh>
+                </config>
+              </org.jclouds.scriptbuilder.statements.login.AdminAccess>
+            </statements>
+          </script>
+          <tags class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <securityGroups class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <blockUntilRunning>true</blockUntilRunning>
+          <userMetadata>
+            <Name>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g-pnds</Name>
+            <entry key="brooklyn-user">amp</entry>
+            <entry key="brooklyn-app-id">Q9kDQQ1s</entry>
+            <entry key="brooklyn-app-name">Tomcat Azure EU West</entry>
+            <entry key="brooklyn-entity-id">tg0gDGp0</entry>
+            <entry key="brooklyn-entity-name">Tomcat Server</entry>
+            <entry key="brooklyn-server-creation-date">2015-10-21-1404</entry>
+          </userMetadata>
+          <nodeNames class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <networks class="com.google.common.collect.EmptyImmutableSet" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/tags"/>
+          <virtualNetworkName class="com.google.common.base.Present">
+            <reference class="string">jclouds-virtual-network</reference>
+          </virtualNetworkName>
+          <addressSpaceAddressPrefix class="com.google.common.base.Absent" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+          <subnetName class="com.google.common.base.Present">
+            <reference class="string">jclouds-1</reference>
+          </subnetName>
+          <subnetAddressPrefix class="com.google.common.base.Absent" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+          <storageAccountName class="com.google.common.base.Present">
+            <reference class="string">jcloudsbchsfqegxc</reference>
+          </storageAccountName>
+          <storageAccountType class="com.google.common.base.Absent" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+          <networkSecurityGroupName class="com.google.common.base.Absent" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+          <reservedIPName class="com.google.common.base.Absent" reference="../../../../node/org.jclouds.compute.domain.internal.NodeMetadataImpl/credentials/password"/>
+        </options>
+      </org.jclouds.compute.domain.internal.TemplateImpl>
+    </template>
+    <usedPorts>
+      <set>
+        <int>31880</int>
+        <int>8443</int>
+        <int>8080</int>
+        <int>31001</int>
+        <int>1099</int>
+      </set>
+    </usedPorts>
+    <tags>
+      <set/>
+    </tags>
+  </locationConfig>
+  <locationConfigUnused>
+    <string>displayName</string>
+    <string>config</string>
+    <string>region</string>
+    <string>portforwarding.enabled</string>
+  </locationConfigUnused>
+</location>

--- a/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-azure-parent-briByOel
+++ b/locations/jclouds/src/test/resources/org/apache/brooklyn/location/jclouds/persisted-azure-parent-briByOel
@@ -1,0 +1,65 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<location>
+  <brooklynVersion>0.9.0-20151120.1523</brooklynVersion>
+  <type>org.apache.brooklyn.location.jclouds.JcloudsLocation</type>
+  <id>briByOel</id>
+  <displayName>Microsoft Azure West Europe</displayName>
+  <children>
+    <string>VNapYjwp</string>
+  </children>
+  <locationConfig>
+    <provider>azurecompute</provider>
+    <endpoint>https://management.core.windows.net/341751b0-f348-45ce-9498-41cc68b4b45f</endpoint>
+    <identity>/home/amp/.amp/azure.p12</identity>
+    <jclouds.azurecompute.operation.timeout>120000</jclouds.azurecompute.operation.timeout>
+    <credential>pa55w0rd</credential>
+    <vmNameMaxLength>45</vmNameMaxLength>
+    <displayName>Microsoft Azure West Europe</displayName>
+    <imageId>b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_1-LTS-amd64-server-20150123-en-us-30GB</imageId>
+    <hardwareId>BASIC_A2</hardwareId>
+    <spec.named.name>azure-euwest</spec.named.name>
+    <spec.original>azure-euwest</spec.original>
+    <region>West Europe</region>
+    <spec.final>jclouds:azurecompute:West Europe</spec.final>
+    <machineCreationSemaphore>
+      <java.util.concurrent.Semaphore>
+        <sync class="java.util.concurrent.Semaphore$FairSync">
+          <state>2147483647</state>
+        </sync>
+      </java.util.concurrent.Semaphore>
+    </machineCreationSemaphore>
+    <vmInstanceIds>
+      <map>
+        <entry>
+          <locationProxy>VNapYjwp</locationProxy>
+          <string>brookly-nwkmys-amp-tomca-q9kd-tomca-tg0g-ddd</string>
+        </entry>
+      </map>
+    </vmInstanceIds>
+    <tags>
+      <set/>
+    </tags>
+  </locationConfig>
+  <locationConfigUnused>
+    <string>jclouds.azurecompute.operation.timeout</string>
+    <string>displayName</string>
+  </locationConfigUnused>
+  <locationConfigDescription>azurecompute:West Europe:https://management.core.windows.net/341751b0-f348-45ce-9498-41cc68b4b45f</locationConfigDescription>
+</location>


### PR DESCRIPTION
Work in progress:
* requires the same to be done for `JcloudsWinrmMachineLocation`
* requires more testing for backwards compatibility (see the unit test included here; but needs tested in the wild).

Previously JcloudsSshMachineLocation would persist the `NodeMetadata` and the `Template`, which pulled in lots of jclouds stuff. This was very brittle: if the NodeMetadata fields changed, or something like `AzureComputeTemplateOptions` fields changed, then rebind could fail.

This changes `JcloudsSshMachineLocation` to not persist node and template. Instead it persists the nodeId + imageId + privateAddresses + publicAddresses + hostname (i.e. the things in NodeMetadata that are most important).

For backwards compatibility, if on rebind it finds the node in the persisted state then it extracts the fields we need, sets those, and then sets the `node` field to null. Same for the `template` field.