### PR TITLE
JcloudsLocation: fix waitForWinRm, for alternate WinRmTool

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshAbstractTool.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshAbstractTool.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.os.Os;
 
 import com.google.common.collect.Iterables;
@@ -166,6 +167,7 @@ public abstract class SshAbstractTool extends ShellAbstractTool implements SshTo
     }
 
     protected SshException propagate(Exception e, String message) throws SshException {
+        Exceptions.propagateIfFatal(e);
         throw new SshException("(" + toString() + ") " + message + ": " + e.getMessage(), e);
     }
     

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2743,7 +2743,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         Stopwatch stopwatch = Stopwatch.createStarted();
 
         ReferenceWithError<Boolean> reachable = new Repeater()
-                .every(1,SECONDS)
+                .backoff(Duration.ONE_SECOND, 2, Duration.TEN_SECONDS) // exponential backoff, to 10 seconds
                 .until(checker)
                 .limitTimeTo(timeout)
                 .runKeepingError();

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -73,6 +73,7 @@ import org.apache.brooklyn.core.location.cloud.AbstractCloudMachineProvisioningL
 import org.apache.brooklyn.core.location.cloud.AvailabilityZoneExtension;
 import org.apache.brooklyn.core.location.cloud.names.AbstractCloudMachineNamer;
 import org.apache.brooklyn.core.location.cloud.names.CloudMachineNamer;
+import org.apache.brooklyn.core.mgmt.internal.LocalLocationManager;
 import org.apache.brooklyn.core.mgmt.persist.LocationWithObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.jclouds.JcloudsBlobStoreBasedObjectStore;
@@ -1591,6 +1592,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         sshProps.put("address", hostAndPort.getHostText());
         sshProps.put("port", hostAndPort.getPort());
         sshProps.put(AbstractLocation.TEMPORARY_LOCATION.getName(), true);
+        sshProps.put(LocalLocationManager.CREATE_UNMANAGED.getName(), true);
         sshProps.remove("password");
         sshProps.remove("privateKeyData");
         sshProps.remove("privateKeyFile");
@@ -1620,6 +1622,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         winrmProps.put("address", hostAndPort.getHostText());
         winrmProps.put("port", hostAndPort.getPort());
         winrmProps.put(AbstractLocation.TEMPORARY_LOCATION.getName(), true);
+        winrmProps.put(LocalLocationManager.CREATE_UNMANAGED.getName(), true);
         winrmProps.remove("password");
         winrmProps.remove("privateKeyData");
         winrmProps.remove("privateKeyFile");

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmException.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.internal.winrm;
+
+public class WinRmException extends RuntimeException {
+
+    private static final long serialVersionUID = -5690230838066860965L;
+
+    public WinRmException(String msg) {
+        super(msg);
+    }
+    
+    public WinRmException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/pywinrm/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/pywinrm/Winrm4jTool.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
-import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -157,7 +155,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
                         + ", this attempt failed after "+Duration.of(failTimestamp).toStringRounded()
                         + (connectTimestamp != null ? ", connected in "+Duration.of(connectTimestamp).toStringRounded() : "");
                 
-                if (i == (execTries+1)) {
+                if ((i + 1) == execTries) {
                     LOG.info("Propagating exception - WinRM failed on "+user+"@"+host+":"+port+" "
                             + (logCredentials ? "password=" + password : "")
                             + "; (attempt "+(i+1)+" of "+execTries+"; "+timeMsg+")", e);


### PR DESCRIPTION
Previously JcloudsLocation was hard-coded to use the winrm4j directly,
in waitForWinrmAvailable. Now it follows the same pattern as for 
ssh: it calls createTemporaryWinRmMachineLocation, and uses that for
the health check. This means any special config for an alternative
WinRmTool implementation will be respected.