### PR TITLE
[DISCUSSION] Sequential Entity Stop Order

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/Effectors.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/Effectors.java
@@ -181,6 +181,12 @@ public class Effectors {
         return Tasks.parallel("invoking "+eff+" on "+tasks.size()+" node"+(Strings.s(tasks.size())), tasks.toArray(new TaskAdaptable[tasks.size()]));
     }
 
+    public static TaskAdaptable<List<?>> invocationSequential(Effector<?> eff, Map<?,?> params, Iterable<? extends Entity> entities) {
+        List<TaskAdaptable<?>> tasks = new ArrayList<TaskAdaptable<?>>();
+        for (Entity e: entities) tasks.add(invocation(e, eff, params));
+        return Tasks.sequential("invoking "+eff+" on "+tasks.size()+" node"+(Strings.s(tasks.size())), tasks.toArray(new TaskAdaptable[tasks.size()]));
+    }
+
     /** returns an unsubmitted task which will invoke the given effector on the given entities
      * (this form of method is a convenience for {@link #invocation(Effector, Map, Iterable)}) */
     public static TaskAdaptable<List<?>> invocation(Effector<?> eff, MutableMap<?, ?> params, Entity ...entities) {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -179,6 +179,9 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
     AttributeSensor<Entity> CLUSTER = Sensors.newSensor(Entity.class,
             "cluster.entity", "The cluster an entity is a member of");
 
+    AttributeSensor<Boolean> ALL_MEMBERS_UP = Sensors.newBooleanSensor(
+            "all.members.up", "True if all members' service.isUp is true");
+
     /**
      * Changes the cluster size by the given number.
      *

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -146,6 +146,9 @@ public interface SoftwareProcess extends Entity, Startable {
             "modify the machine so that a tty is not subsequently required.",
             false);
     
+    public static final ConfigKey<Integer> STOP_SEQUENCE_POSITION = ConfigKeys.newConfigKey(Integer.class, "stop.sequence.position",
+            "The numerical position in the order of entities to stop, starting with 1 and increasing sequentially.");
+
     /**
      * Files to be copied to the server before pre-install.
      * <p>


### PR DESCRIPTION
This adds a `stop.sequence.position` config value which enables YAML blueprints to explicitly specify a stop order.  This can prevent the problem of entities hanging infinitely on stop when they attempt to resolve dependent values of already-stopped entities.

Discussion points:
-Does this seem like a valid approach overall?
-Is the config value named intuitively?

Areas of improvement:
-Validation of config values (ensure values start at 1 and proceed sequentially)
-Allow multiple entities to share a value (e.g. 1, 2, 2, 3, 4 -- the 2s would stop in parallel)

IGNORE commit `Add all.members.up sensor to DynamicCluster` -- this was needed for testing.