### PR TITLE
QA Updates for Clocker

### DIFF
--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCase.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.framework;
+
+import com.google.common.reflect.TypeToken;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.StartableApplication;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+
+/**
+ * Created by graememiller on 04/12/2015.
+ */
+@ImplementedBy(value = InfrastructureDeploymentTestCaseImpl.class)
+public interface InfrastructureDeploymentTestCase extends TestCase {
+
+    /**
+     * Entity spec to deploy. This will be deployed second, after the INFRASTRUCTURE_SPEC has been deployed. This will be deployed to the DEPLOYMENT_LOCATION.
+     * All children will be deployed after this
+     */
+    ConfigKey<EntitySpec<SoftwareProcess>> ENTITY_SPEC_TO_DEPLOY = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<SoftwareProcess>>(){}, "infrastructure.deployment.entity.spec", "Entity spec to deploy to infrastructure");
+
+
+    /**
+     * Infrastructure to deploy. This will be deployed first, then the ENTITY_SPEC_TO_DEPLOY will be deployed, then any children
+     */
+    ConfigKey<EntitySpec<StartableApplication>> INFRASTRUCTURE_SPEC = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<StartableApplication>>(){}, "infrastructure.deployment.spec", "Infrastructure to deploy");
+
+
+    /**
+     * The The location to deploy ENTITY_SPEC_TO_DEPLOY.
+     */
+    ConfigKey<String> DEPLOYMENT_LOCATION_SENSOR_NAME = ConfigKeys.newStringConfigKey("infrastructure.deployment.location.sensor", "Name of the sensor of INFRASTRUCTURE_SPEC to retrieve the Location to deploy the entity to");
+
+
+}

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCaseImpl.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCaseImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.framework;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.annotation.EffectorParam;
+import org.apache.brooklyn.core.entity.StartableApplication;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+
+import java.util.Collection;
+
+/**
+ * Created by graememiller on 04/12/2015.
+ */
+public class InfrastructureDeploymentTestCaseImpl extends TestCaseImpl implements InfrastructureDeploymentTestCase {
+
+    @Override
+    public void start(@EffectorParam(name = "locations") Collection<? extends Location> locations) {
+        //Create the infrastructure
+        EntitySpec<StartableApplication> infrastructureSpec = config().get(INFRASTRUCTURE_SPEC);
+        StartableApplication infrastructure = this.addChild(infrastructureSpec);
+        infrastructure.start(locations);
+
+        //Get the location
+        String deploymentLocationSensorName = config().get(DEPLOYMENT_LOCATION_SENSOR_NAME);
+        Location locationToDeployTo = infrastructure.sensors().get(Sensors.newSensor(Location.class, deploymentLocationSensorName));
+
+
+        //Start the child entity
+        EntitySpec<SoftwareProcess> entityToDeploySpec = config().get(ENTITY_SPEC_TO_DEPLOY);
+        SoftwareProcess entityToDeploy = this.addChild(entityToDeploySpec);
+        entityToDeploy.start(ImmutableList.of(locationToDeployTo));
+
+
+        //Defer to super class to start children
+        super.start(locations);
+    }
+}

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestCase.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestCase.java
@@ -18,7 +18,9 @@
  */
 package org.apache.brooklyn.test.framework;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.core.entity.trait.Startable;
 
 /**
  * Entity that logically groups other test entities
@@ -26,5 +28,5 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
  * @author m4rkmckenna
  */
 @ImplementedBy(value = TestCaseImpl.class)
-public interface TestCase extends BaseTest {
+public interface TestCase extends Entity, Startable {
 }


### PR DESCRIPTION
TestCase no longer extends BaseTest, but rather extends Entity directly. Added check in TestCaseImpl to ensure that only non-started children are startable. Added InfrastructureDeploymentTestCase