### PR TITLE
Fix/deferred location config

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 
 /**
  * Stores config in such a way that usage can be tracked.
@@ -345,6 +347,16 @@ public class ConfigBag {
         return get(key, true);
     }
 
+    public <T> T get(String key, Class<T> targetType) {
+        return get(key, TypeToken.of(targetType));
+    }
+
+    public <T> T get(String key, TypeToken<T> targetType) {
+        markUsed(key);
+        Object rawValue = config.get(key);
+        return TypeCoercions.coerce(rawValue, targetType);
+    }
+
     /** gets a value from a string-valued key or null; ConfigKey is preferred, but this is useful in some contexts (e.g. setting from flags) */
     public Object getStringKey(String key) {
         return getStringKeyMaybe(key).orNull();
@@ -460,9 +472,14 @@ public class ConfigBag {
 
     /** returns the first non-null value to be the type indicated by the key, or the keys default value if no non-null values are supplied */
     public static <T> T coerceFirstNonNullKeyValue(ConfigKey<T> key, Object ...values) {
-        for (Object o: values)
-            if (o!=null) return TypeCoercions.coerce(o, key.getTypeToken());
-        return TypeCoercions.coerce(key.getDefaultValue(), key.getTypeToken());
+        Object rawValue = key.getDefaultValue();
+        for (Object o: values) {
+            if (o != null) {
+                rawValue = o;
+                break;
+            }
+        }
+        return TypeCoercions.coerce(rawValue, key.getTypeToken());
     }
 
     protected Object getStringKey(String key, boolean markUsed) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -55,6 +55,7 @@ import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.collections.QuorumCheck;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -137,6 +138,10 @@ public class TypeCoercions {
     public static <T> T coerce(Object value, TypeToken<T> targetTypeToken) {
         if (value==null) return null;
         Class<? super T> targetType = targetTypeToken.getRawType();
+
+        if (value instanceof DeferredSupplier<?>) {
+            value = ((DeferredSupplier<?>) value).get();
+        }
 
         //recursive coercion of parameterized collections and map entries
         if (targetTypeToken.getType() instanceof ParameterizedType) {

--- a/core/src/test/java/org/apache/brooklyn/core/location/LocationExtensionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/LocationExtensionsTest.java
@@ -29,6 +29,8 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -164,21 +166,24 @@ public class LocationExtensionsTest {
         try {
             Location loc = createConcrete(MyExtension.class, "not an extension");
             fail("loc="+loc);
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
+            assertTrue(Exceptions.getFirstInteresting(e) instanceof IllegalArgumentException);
             // success
         }
         
         try {
             Location loc = createConcrete(MyExtension.class, null);
             fail("loc="+loc);
-        } catch (NullPointerException e) {
+        } catch (Exception e) {
+            assertTrue(Exceptions.getFirstInteresting(e) instanceof NullPointerException);
             // success
         }
         
         try {
             Location loc = createConcrete(null, extension);
             fail("loc="+loc);
-        } catch (NullPointerException e) {
+        } catch (Exception e) {
+            assertTrue(Exceptions.getFirstInteresting(e) instanceof NullPointerException);
             // success
         }
     }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2067,9 +2067,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         final String rawRegion;
 
         public RebindToMachinePredicate(ConfigBag config) {
-            rawId = (String) config.getStringKey("id");
-            rawHostname = (String) config.getStringKey("hostname");
-            rawRegion = (String) config.getStringKey("region");
+            rawId = config.get("id", String.class);
+            rawHostname = config.get("hostname", String.class);
+            rawRegion = config.get("region", String.class);
         }
 
         @Override


### PR DESCRIPTION
Resolves issues with `$brooklyn:external()` in location config:
* `TypeCoercions` resolves `DeferredSupplier` values
* locations constructed within a new execution context on `LocalLocationManager` so that relevant context objects can be retrieved in a consistent way