### PR TITLE
GeoDns improvements

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1301,6 +1301,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
+                        <version>2.6</version>
                         <configuration>
                             <archive>
                                 <manifestFile> ${project.build.outputDirectory}/META-INF/MANIFEST.MF </manifestFile>

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsService.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsService.java
@@ -48,6 +48,11 @@ public interface AbstractGeoDnsService extends Entity {
     ConfigKey<Group> ENTITY_PROVIDER = ConfigKeys.newConfigKey(Group.class,
             "geodns.entityProvider", "The group whose members should be tracked");
 
+    /** @see Lifecycle#RUNNING */
+    @SetFromFlag("filterForRunning")
+    ConfigKey<Boolean> FILTER_FOR_RUNNING = ConfigKeys.newBooleanConfigKey(
+            "geodns.filterForRunning", "Whether to only track targets whose status is \"RUNNING\"", true);
+
     AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
     AttributeSensor<Boolean> SERVICE_UP = Startable.SERVICE_UP;
     AttributeSensor<String> HOSTNAME = Attributes.HOSTNAME;

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsService.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsService.java
@@ -30,17 +30,24 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.geo.HostGeoInfo;
 import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 import com.google.common.reflect.TypeToken;
 
 public interface AbstractGeoDnsService extends Entity {
     
+    @SetFromFlag("includeHomelessEntities")
     ConfigKey<Boolean> INCLUDE_HOMELESS_ENTITIES = ConfigKeys.newBooleanConfigKey(
             "geodns.includeHomeless", "Whether to include entities whose geo-coordinates cannot be inferred", false);
 
+    @SetFromFlag("useHostnames")
     ConfigKey<Boolean> USE_HOSTNAMES = ConfigKeys.newBooleanConfigKey(
             "geodns.useHostnames", "Whether to use the hostname for the returned value for routing, rather than IP address (defaults to true)", true);
-    
+
+    @SetFromFlag("provider")
+    ConfigKey<Group> ENTITY_PROVIDER = ConfigKeys.newConfigKey(Group.class,
+            "geodns.entityProvider", "The group whose members should be tracked");
+
     AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
     AttributeSensor<Boolean> SERVICE_UP = Startable.SERVICE_UP;
     AttributeSensor<String> HOSTNAME = Attributes.HOSTNAME;

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsService.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsService.java
@@ -29,31 +29,34 @@ import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.geo.HostGeoInfo;
-import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
+import org.apache.brooklyn.core.sensor.Sensors;
 
 import com.google.common.reflect.TypeToken;
 
 public interface AbstractGeoDnsService extends Entity {
     
-    public static final ConfigKey<Boolean> INCLUDE_HOMELESS_ENTITIES = ConfigKeys.newBooleanConfigKey("geodns.includeHomeless", "Whether to include entities whose geo-coordinates cannot be inferred", false);
-    public static final ConfigKey<Boolean> USE_HOSTNAMES = ConfigKeys.newBooleanConfigKey("geodns.useHostnames", "Whether to use the hostname for the returned value for routing, rather than IP address (defaults to true)", true);
-    
-    public static final AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
-    public static final AttributeSensor<Boolean> SERVICE_UP = Startable.SERVICE_UP;
-    public static final AttributeSensor<String> HOSTNAME = Attributes.HOSTNAME;
-    public static final AttributeSensor<String> ADDRESS = Attributes.ADDRESS;
-    @SuppressWarnings("serial")
-    public static final AttributeSensor<Map<String,String>> TARGETS = new BasicAttributeSensor<Map<String,String>>(
-            new TypeToken<Map<String,String>>() {}, "geodns.targets", "Map of targets currently being managed (entity ID to URL)");
+    ConfigKey<Boolean> INCLUDE_HOMELESS_ENTITIES = ConfigKeys.newBooleanConfigKey(
+            "geodns.includeHomeless", "Whether to include entities whose geo-coordinates cannot be inferred", false);
 
-    public void setServiceState(Lifecycle state);
+    ConfigKey<Boolean> USE_HOSTNAMES = ConfigKeys.newBooleanConfigKey(
+            "geodns.useHostnames", "Whether to use the hostname for the returned value for routing, rather than IP address (defaults to true)", true);
+    
+    AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
+    AttributeSensor<Boolean> SERVICE_UP = Startable.SERVICE_UP;
+    AttributeSensor<String> HOSTNAME = Attributes.HOSTNAME;
+    AttributeSensor<String> ADDRESS = Attributes.ADDRESS;
+
+    AttributeSensor<Map<String,String>> TARGETS = Sensors.newSensor(new TypeToken<Map<String, String>>() {},
+            "geodns.targets", "Map of targets currently being managed (entity ID to URL)");
+
+    void setServiceState(Lifecycle state);
     
     /** sets target to be a group whose *members* will be searched (non-Group items not supported) */
     // prior to 0.7.0 the API accepted non-group items, but did not handle them correctly
-    public void setTargetEntityProvider(final Group entityProvider);
+    void setTargetEntityProvider(final Group entityProvider);
     
     /** should return the hostname which this DNS service is configuring */
-    public String getHostname();
+    String getHostname();
     
-    public Map<Entity, HostGeoInfo> getTargetHosts();
+    Map<Entity, HostGeoInfo> getTargetHosts();
 }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceImpl.java
@@ -83,6 +83,15 @@ public abstract class AbstractGeoDnsServiceImpl extends AbstractEntity implement
     }
     
     @Override
+    public void init() {
+        super.init();
+        Group initialProvider = config().get(ENTITY_PROVIDER);
+        if (initialProvider != null) {
+            setTargetEntityProvider(initialProvider);
+        }
+    }
+
+    @Override
     public Map<Entity, HostGeoInfo> getTargetHosts() {
         return targetHosts;
     }
@@ -174,14 +183,13 @@ public abstract class AbstractGeoDnsServiceImpl extends AbstractEntity implement
             }
             // anything left in previousOnes is no longer applicable
             for (Entity e: previousOnes) {
-                changed = true;
-                removeTargetHost(e, false);
+                changed |= removeTargetHost(e, false);
             }
             
             // do a periodic full update hourly once we are active (the latter is probably not needed)
-            if (changed || (lastUpdate>0 && Time.hasElapsedSince(lastUpdate, Duration.ONE_HOUR)))
+            if (changed || (lastUpdate > 0 && Time.hasElapsedSince(lastUpdate, Duration.ONE_HOUR))) {
                 update();
-            
+            }
         } catch (Exception e) {
             log.error("Problem refreshing group membership: "+e, e);
         }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingDnsService.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingDnsService.java
@@ -23,10 +23,9 @@ import java.net.URI;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
+import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.dns.AbstractGeoDnsService;
 import org.apache.brooklyn.entity.webapp.WebAppServiceConstants;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
@@ -35,36 +34,45 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface GeoscalingDnsService extends AbstractGeoDnsService {
     
     @SetFromFlag("sslTrustAll")
-    public static final ConfigKey<Boolean> SSL_TRUST_ALL = ConfigKeys.newBooleanConfigKey(
+    ConfigKey<Boolean> SSL_TRUST_ALL = ConfigKeys.newBooleanConfigKey(
             "ssl.trustAll",
             "Whether to trust all certificates, or to fail with 'peer not authenticated' if untrusted (default false)",
             false);
+
     @SetFromFlag("randomizeSubdomainName")
-    public static final ConfigKey<Boolean> RANDOMIZE_SUBDOMAIN_NAME = new BasicConfigKey<Boolean>(
-            Boolean.class, "randomize.subdomain.name");
+    ConfigKey<Boolean> RANDOMIZE_SUBDOMAIN_NAME = ConfigKeys.newBooleanConfigKey(
+            "randomize.subdomain.name");
+
     @SetFromFlag("username")
-    public static final ConfigKey<String> GEOSCALING_USERNAME = new BasicConfigKey<String>(
-            String.class, "geoscaling.username");
+    ConfigKey<String> GEOSCALING_USERNAME = ConfigKeys.newStringConfigKey(
+            "geoscaling.username");
+
     @SetFromFlag("password")
-    public static final ConfigKey<String> GEOSCALING_PASSWORD = new BasicConfigKey<String>(
-            String.class, "geoscaling.password");
+    ConfigKey<String> GEOSCALING_PASSWORD = ConfigKeys.newStringConfigKey(
+            "geoscaling.password");
+
     @SetFromFlag("primaryDomainName")
-    public static final ConfigKey<String> GEOSCALING_PRIMARY_DOMAIN_NAME = new BasicConfigKey<String>(
-            String.class, "geoscaling.primary.domain.name");
+    ConfigKey<String> GEOSCALING_PRIMARY_DOMAIN_NAME = ConfigKeys.newStringConfigKey(
+            "geoscaling.primary.domain.name");
+
     @SetFromFlag("smartSubdomainName")
-    public static final ConfigKey<String> GEOSCALING_SMART_SUBDOMAIN_NAME = new BasicConfigKey<String>(
-            String.class, "geoscaling.smart.subdomain.name");
+    ConfigKey<String> GEOSCALING_SMART_SUBDOMAIN_NAME = ConfigKeys.newStringConfigKey(
+            "geoscaling.smart.subdomain.name");
     
-    public static final AttributeSensor<String> GEOSCALING_ACCOUNT = new BasicAttributeSensor<String>(
-            String.class, "geoscaling.account", "Active user account for the GeoScaling.com service");
-    public static final AttributeSensor<URI> MAIN_URI = Attributes.MAIN_URI;
-    public static final AttributeSensor<String> ROOT_URL = WebAppServiceConstants.ROOT_URL;
-    public static final AttributeSensor<String> MANAGED_DOMAIN = new BasicAttributeSensor<String>(
-            String.class, "geoscaling.managed.domain", "Fully qualified domain name that will be geo-redirected; " +
+    AttributeSensor<String> GEOSCALING_ACCOUNT = Sensors.newStringSensor(
+            "geoscaling.account", "Active user account for the GeoScaling.com service");
+
+    AttributeSensor<URI> MAIN_URI = Attributes.MAIN_URI;
+
+    AttributeSensor<String> ROOT_URL = WebAppServiceConstants.ROOT_URL;
+
+    AttributeSensor<String> MANAGED_DOMAIN = Sensors.newStringSensor(
+            "geoscaling.managed.domain",
+            "Fully qualified domain name that will be geo-redirected; " +
                     "this will be the same as "+ROOT_URL.getName()+" but the latter will only be set when the domain has active targets");
     
-    public void applyConfig();
+    void applyConfig();
     
     /** minimum/default TTL here is 300s = 5m */
-    public long getTimeToLiveSeconds();
+    long getTimeToLiveSeconds();
 }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingDnsService.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingDnsService.java
@@ -30,6 +30,14 @@ import org.apache.brooklyn.entity.dns.AbstractGeoDnsService;
 import org.apache.brooklyn.entity.webapp.WebAppServiceConstants;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
+/**
+ * A geo-DNS service using geoscaling.com.
+ * <p>
+ * AWS users should note that if the Brooklyn server managing this entity is in the same
+ * region as the server being geoscaled then they must set {@link #INCLUDE_HOMELESS_ENTITIES}
+ * to true, as IP lookups of the server will resolve the private address and it will be
+ * ignored by default.
+ */
 @ImplementedBy(GeoscalingDnsServiceImpl.class)
 public interface GeoscalingDnsService extends AbstractGeoDnsService {
     

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingDnsServiceImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingDnsServiceImpl.java
@@ -61,9 +61,11 @@ public class GeoscalingDnsServiceImpl extends AbstractGeoDnsServiceImpl implemen
         super.init();
         
         // defaulting to randomized subdomains makes deploying multiple applications easier
-        if (getConfig(RANDOMIZE_SUBDOMAIN_NAME)==null) config().set(RANDOMIZE_SUBDOMAIN_NAME, true); 
-        
-        Boolean trustAll = getConfig(SSL_TRUST_ALL);
+        if (config().get(RANDOMIZE_SUBDOMAIN_NAME) == null) {
+            config().set(RANDOMIZE_SUBDOMAIN_NAME, true);
+        }
+
+        Boolean trustAll = config().get(SSL_TRUST_ALL);
         if (Boolean.TRUE.equals(trustAll)) {
             webClient = new GeoscalingWebClient(HttpTool.httpClientBuilder().trustAll().build());
         } else {
@@ -88,11 +90,11 @@ public class GeoscalingDnsServiceImpl extends AbstractGeoDnsServiceImpl implemen
     boolean isConfigured = false;
     
     public synchronized void applyConfig() {        
-        randomizeSmartSubdomainName = getConfig(RANDOMIZE_SUBDOMAIN_NAME);
-        username = getConfig(GEOSCALING_USERNAME);
-        password = getConfig(GEOSCALING_PASSWORD);
-        primaryDomainName = getConfig(GEOSCALING_PRIMARY_DOMAIN_NAME);
-        smartSubdomainName = getConfig(GEOSCALING_SMART_SUBDOMAIN_NAME);
+        randomizeSmartSubdomainName = config().get(RANDOMIZE_SUBDOMAIN_NAME);
+        username = config().get(GEOSCALING_USERNAME);
+        password = config().get(GEOSCALING_PASSWORD);
+        primaryDomainName = config().get(GEOSCALING_PRIMARY_DOMAIN_NAME);
+        smartSubdomainName = config().get(GEOSCALING_SMART_SUBDOMAIN_NAME);
 
         // Ensure all mandatory configuration is provided.
         checkNotNull(username, "The GeoScaling username is not specified");

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.entity.dns;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Collection;
@@ -35,31 +36,23 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.EntityInternal;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.location.BasicLocationRegistry;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.location.geo.HostGeoInfo;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.entity.dns.AbstractGeoDnsService;
-import org.apache.brooklyn.entity.dns.AbstractGeoDnsServiceImpl;
-import org.apache.brooklyn.entity.dns.AbstractGeoDnsServiceTest;
 import org.apache.brooklyn.entity.group.DynamicFabric;
 import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.entity.group.DynamicRegionsFabric;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
@@ -69,7 +62,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
-public class AbstractGeoDnsServiceTest {
+public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
+
     public static final Logger log = LoggerFactory.getLogger(AbstractGeoDnsServiceTest.class);
 
     private static final String WEST_IP = "100.0.0.1";
@@ -79,8 +73,6 @@ public class AbstractGeoDnsServiceTest {
     
     private static final String NORTH_IP = "10.0.0.1";
     private static final double NORTH_LATITUDE = 60, NORTH_LONGITUDE = 0;
-    
-    private ManagementContext managementContext;
     
     private Location westParent;
     private Location westChild;
@@ -92,16 +84,15 @@ public class AbstractGeoDnsServiceTest {
     private Location northParent;
     private Location northChildWithLocation; 
 
-    private TestApplication app;
     private DynamicRegionsFabric fabric;
     private DynamicGroup testEntities;
     private GeoDnsTestService geoDns;
     
-
+    @Override
     @BeforeMethod(alwaysRun=true)
-    public void setup() {
-        managementContext = new LocalManagementContext();
-        
+    public void setUp() throws Exception {
+        super.setUp();
+
         westParent = newSimulatedLocation("West parent", WEST_LATITUDE, WEST_LONGITUDE);
         
         // west uses public IP for name, so is always picked up
@@ -116,7 +107,7 @@ public class AbstractGeoDnsServiceTest {
         // north has a private IP and private hostname so should not be picked up when we turn off ADD_ANYTHING
         northParent = newSimulatedLocation("North parent", NORTH_LATITUDE, NORTH_LONGITUDE);
         northChildWithLocation = newSshMachineLocation("North child", "localhost", NORTH_IP, northParent, NORTH_LATITUDE, NORTH_LONGITUDE);
-        ((BasicLocationRegistry)managementContext.getLocationRegistry()).registerResolver(new LocationResolver() {
+        ((BasicLocationRegistry) mgmt.getLocationRegistry()).registerResolver(new LocationResolver() {
             @Override
             public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
                 if (!spec.equals("test:north")) throw new IllegalStateException("unsupported");
@@ -135,41 +126,36 @@ public class AbstractGeoDnsServiceTest {
             }
         });
 
-        Locations.manage(westParent, managementContext);
-        Locations.manage(eastParent, managementContext);
-        Locations.manage(northParent, managementContext);
+        Locations.manage(westParent, mgmt);
+        Locations.manage(eastParent, mgmt);
+        Locations.manage(northParent, mgmt);
         
-        app = ApplicationBuilder.newManagedApp(TestApplication.class, managementContext);
         fabric = app.createAndManageChild(EntitySpec.create(DynamicRegionsFabric.class)
             .configure(DynamicFabric.MEMBER_SPEC, EntitySpec.create(TestEntity.class)));
-        
+
         testEntities = app.createAndManageChild(EntitySpec.create(DynamicGroup.class)
             .configure(DynamicGroup.ENTITY_FILTER, Predicates.instanceOf(TestEntity.class)));
-        geoDns = app.createAndManageChild(EntitySpec.create(GeoDnsTestService.class));
-        geoDns.setTargetEntityProvider(testEntities);
-    }
 
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        if (app != null) Entities.destroyAll(app.getManagementContext());
+        geoDns = app.createAndManageChild(EntitySpec.create(GeoDnsTestService.class)
+            .configure(AbstractGeoDnsService.ENTITY_PROVIDER, testEntities));
     }
 
     private SimulatedLocation newSimulatedLocation(String name, double lat, double lon) {
-        return managementContext.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class)
+        return mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class)
                 .displayName(name)
                 .configure("latitude", lat)
                 .configure("longitude", lon));
     }
     
     private Location newSshMachineLocation(String name, String address, Location parent) {
-        return managementContext.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+        return mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .parent(parent)
                 .displayName(name)
                 .configure("address", address));
     }
     
     private Location newSshMachineLocation(String name, String hostname, String address, Location parent, double lat, double lon) {
-        return managementContext.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+        return mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .parent(parent)
                 .displayName(name)
                 .configure("hostname", hostname)
@@ -183,85 +169,92 @@ public class AbstractGeoDnsServiceTest {
         app.start( ImmutableList.of(westChildWithLocation, eastChildWithLocationAndWithPrivateHostname) );
         publishSensors(2, true, true, true);
         
-        EntityTestUtils.assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
-        assertTrue(geoDns.getTargetHostsByName().containsKey("West child with location"), "targets="+geoDns.getTargetHostsByName());
-        assertTrue(geoDns.getTargetHostsByName().containsKey("East child with location"), "targets="+geoDns.getTargetHostsByName());
+        assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
+        assertIsTarget("West child with location");
+        assertIsTarget("East child with location");
     }
-    
+
     @Test
     public void testGeoInfoOnParentLocation() {
         app.start( ImmutableList.of(westChild, eastChild) );
         publishSensors(2, true, false, false);
-        
-        EntityTestUtils.assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
-        assertTrue(geoDns.getTargetHostsByName().containsKey("West child"), "targets="+geoDns.getTargetHostsByName());
-        assertTrue(geoDns.getTargetHostsByName().containsKey("East child"), "targets="+geoDns.getTargetHostsByName());
+
+        assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
+        assertIsTarget("West child");
+        assertIsTarget("East child");
     }
 
     @Test
     public void testSubscribesToHostname() {
-        ((EntityInternal)geoDns).config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
+        geoDns.config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname) );
         Assert.assertEquals(geoDns.getTargetHostsByName().size(), 0);
         publishSensors(2, true, true, true);
-        
-        EntityTestUtils.assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
+
+        assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
         Assert.assertEquals(geoDns.getTargetHostsByName().size(), 2);
-        assertTrue(geoDns.getTargetHostsByName().containsKey("West child"), "targets="+geoDns.getTargetHostsByName());
-        assertTrue(geoDns.getTargetHostsByName().containsKey("East child with location"), "targets="+geoDns.getTargetHostsByName());
+        assertIsTarget("West child");
+        assertIsTarget("East child with location");
     }
 
     protected void publishSensors(int expectedSize, boolean includeServiceUp, boolean includeHostname, boolean includeAddress) {
         // First wait for the right size of group; the dynamic group gets notified asynchronously
         // of nodes added/removed, so if we don't wait then might not set value for all members.
-        EntityTestUtils.assertGroupSizeEqualsEventually(testEntities, expectedSize);
-        
+        EntityAsserts.assertGroupSizeEqualsEventually(testEntities, expectedSize);
+
         for (Entity e: testEntities.getMembers()) {
             if (includeServiceUp)
-                ((EntityInternal)e).sensors().set(Attributes.SERVICE_UP, true);
-            
+                e.sensors().set(Attributes.SERVICE_UP, true);
+
             SshMachineLocation l = Machines.findUniqueMachineLocation(e.getLocations(), SshMachineLocation.class).get();
             if (includeAddress)
-                ((EntityInternal)e).sensors().set(Attributes.ADDRESS, l.getAddress().getHostAddress());
+                e.sensors().set(Attributes.ADDRESS, l.getAddress().getHostAddress());
             String h = (String) l.config().getBag().getStringKey("hostname");
             if (h==null) h = l.getAddress().getHostName();
             if (includeHostname)
-                ((EntityInternal)e).sensors().set(Attributes.HOSTNAME, h);
+                e.sensors().set(Attributes.HOSTNAME, h);
         }
     }
-    
+
     @Test
     public void testChildAddedLate() {
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname) );
         publishSensors(2, true, false, false);
-        EntityTestUtils.assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
-        
+        assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
+
         String id3 = fabric.addRegion("test:north");
         publishSensors(3, true, false, false);
         try {
-            EntityTestUtils.assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(3));
+            assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(3));
         } catch (Throwable e) {
             log.warn("Did not pick up third entity, targets are "+geoDns.getAttribute(AbstractGeoDnsService.TARGETS)+" (rethrowing): "+e);
             Exceptions.propagate(e);
         }
-        assertTrue(geoDns.getTargetHostsByName().containsKey("North child"), "targets="+geoDns.getTargetHostsByName());
-        
-        log.info("targets: "+geoDns.getTargetHostsByName());
-    }    
+        assertIsTarget("North child");
 
+        log.info("targets: "+geoDns.getTargetHostsByName());
+    }
 
     @Test
     public void testFiltersEntirelyPrivate() {
-        ((EntityInternal)geoDns).config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
+        geoDns.config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname, northChildWithLocation) );
         Assert.assertEquals(geoDns.getTargetHostsByName().size(), 0);
         publishSensors(3, true, true, true);
-        
-        EntityTestUtils.assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
+
+        assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
         Assert.assertEquals(geoDns.getTargetHostsByName().size(), 2);
-        assertTrue(geoDns.getTargetHostsByName().containsKey("West child"), "targets="+geoDns.getTargetHostsByName());
-        assertTrue(geoDns.getTargetHostsByName().containsKey("East child with location"), "targets="+geoDns.getTargetHostsByName());
-        assertTrue(!geoDns.getTargetHostsByName().containsKey("North child"), "targets="+geoDns.getTargetHostsByName());
+        assertIsTarget("West child");
+        assertIsTarget("East child with location");
+        assertIsNotTarget("North child");
+    }
+
+    private void assertIsTarget(String target) {
+        assertTrue(geoDns.getTargetHostsByName().containsKey(target), "targets=" + geoDns.getTargetHostsByName());
+    }
+
+    private void assertIsNotTarget(String target) {
+        assertFalse(geoDns.getTargetHostsByName().containsKey(target), "targets=" + geoDns.getTargetHostsByName());
     }
 
     @ImplementedBy(GeoDnsTestServiceImpl.class)

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -110,13 +110,13 @@ public abstract class AbstractYamlTest {
         return createAndStartApplication(joinLines(multiLineYaml));
     }
     
-    protected Entity createAndStartApplication(String input) throws Exception {
-        return createAndStartApplication(new StringReader(input));
+    protected Entity createAndStartApplication(Reader input) throws Exception {
+        return createAndStartApplication(Streams.readFully(input));
     }
 
-    protected Entity createAndStartApplication(Reader input) throws Exception {
+    protected Entity createAndStartApplication(String input) throws Exception {
         EntitySpec<?> spec = 
-            mgmt().getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, Streams.readFully(input), RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
+            mgmt().getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, input, RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
         final Entity app = brooklynMgmt.getEntityManager().createEntity(spec);
         // start the app (happens automatically if we use camp to instantiate, but not if we use crate spec approach)
         app.invoke(Startable.START, MutableMap.<String,String>of()).get();
@@ -126,9 +126,7 @@ public abstract class AbstractYamlTest {
     protected Entity createStartWaitAndLogApplication(Reader input) throws Exception {
         Entity app = createAndStartApplication(input);
         waitForApplicationTasks(app);
-
         getLogger().info("App started: "+app);
-        
         return app;
     }
 

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/GeoDnsServiceYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/GeoDnsServiceYamlTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
+import org.apache.brooklyn.entity.dns.AbstractGeoDnsService;
+import org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService;
+import org.apache.brooklyn.entity.group.DynamicFabric;
+import org.apache.brooklyn.util.stream.Streams;
+import org.testng.annotations.Test;
+
+public class GeoDnsServiceYamlTest extends AbstractYamlTest {
+
+    @Test
+    public void testTargetGroupCanBeSetInYaml() throws Exception {
+        final String resourceName = "classpath:/" + getClass().getPackage().getName().replace('.', '/') + "/geodns.yaml";
+        final String blueprint = Streams.readFully(loadYaml(resourceName));
+        Application app = EntityManagementUtils.createUnstarted(mgmt(), blueprint);
+        GeoscalingDnsService geodns = Entities.descendants(app, GeoscalingDnsService.class).iterator().next();
+        DynamicFabric fabric = Entities.descendants(app, DynamicFabric.class).iterator().next();
+        assertEquals(geodns.config().get(AbstractGeoDnsService.ENTITY_PROVIDER), fabric);
+    }
+
+}

--- a/usage/camp/src/test/resources/org/apache/brooklyn/camp/brooklyn/geodns.yaml
+++ b/usage/camp/src/test/resources/org/apache/brooklyn/camp/brooklyn/geodns.yaml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+services:
+
+- name: Web cluster
+  type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
+  id: web-fabric
+
+  # Location required but test should not do any provisioning.
+  locations:
+  - localhost
+
+  memberSpec:
+    $brooklyn:entitySpec:
+      type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+      brooklyn.config:
+        initialSize: 0
+
+- name: Geo DNS
+  type: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+  brooklyn.config:
+    provider: $brooklyn:component("web-fabric")
+    username: madeUp
+    password: madeUp
+    primaryDomainName: example.com
+    smartSubdomainName: test


### PR DESCRIPTION
A variety of improvements to the geo-DNS entities. In particular:
* Entities whose service state is not `RUNNING` are automatically excluded from the pool of targets. This can be disabled to maintain existing behaviour.
* The group to be tracked by `AbstractGeoDnsService` can be given in a config key, which means users don't need to call `setTargetEntityProvider` and thus that the service can be used from yaml.