### PR TITLE
Misc MySQL 5.5.x and 5.6.x fixes

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNode.java
@@ -50,7 +50,7 @@ public interface MySqlNode extends SoftwareProcess, HasShortName, DatastoreCommo
     //http://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.26-linux-glibc2.5-x86_64.tar.gz
     @SetFromFlag("downloadUrl")
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new StringAttributeSensorAndConfigKey(
-            Attributes.DOWNLOAD_URL, "http://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-${version}-${driver.osTag}.tar.gz");
+            Attributes.DOWNLOAD_URL, "http://dev.mysql.com/get/Downloads/MySQL-${driver.majorVersion}/mysql-${version}-${driver.osTag}.tar.gz");
 
     @SetFromFlag("port")
     PortAttributeSensorAndConfigKey MYSQL_PORT = new PortAttributeSensorAndConfigKey("mysql.port", "MySQL port", PortRanges.fromString("3306, 13306+"));

--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeImpl.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeImpl.java
@@ -135,8 +135,8 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
     public int getPort() {
         return getAttribute(MYSQL_PORT);
     }
-    
-    public String getSocketUid() {
+
+    public synchronized String getSocketUid() {
         String result = getAttribute(MySqlNode.SOCKET_UID);
         if (Strings.isBlank(result)) {
             result = Identifiers.makeRandomId(6);

--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlSshDriver.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlSshDriver.java
@@ -111,6 +111,11 @@ public class MySqlSshDriver extends AbstractSoftwareProcessSshDriver implements 
         return "mymysql.cnf";
     }
 
+    // Only invoked to determine the default download URL form the specified version.
+    public String getMajorVersion() {
+        return getEntity().config().get(MySqlNode.SUGGESTED_VERSION).replaceAll("(\\d+\\.\\d+)\\.\\d+", "$1");
+    }
+
     public String getDefaultUnpackedDirectoryName() {
         return Strings.removeAllFromEnd(resolver.getFilename(), ".tar.gz");
     }

--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlSshDriver.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlSshDriver.java
@@ -111,14 +111,15 @@ public class MySqlSshDriver extends AbstractSoftwareProcessSshDriver implements 
         return "mymysql.cnf";
     }
 
-    public String getInstallFilename() {
-        return String.format("mysql-%s-%s.tar.gz", getVersion(), getOsTag());
+    public String getDefaultUnpackedDirectoryName() {
+        return Strings.removeAllFromEnd(resolver.getFilename(), ".tar.gz");
     }
 
     @Override
     public void preInstall() {
-        resolver = Entities.newDownloader(this, ImmutableMap.of("filename", getInstallFilename()));
-        setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(format("mysql-%s-%s", getVersion(), getOsTag()))));
+        resolver = Entities.newDownloader(this);
+        String unpackedDirectoryName = resolver.getUnpackedDirectoryName(getDefaultUnpackedDirectoryName());
+        setExpandedInstallDir(Os.mergePaths(getInstallDir(), unpackedDirectoryName));
     }
 
     @Override


### PR DESCRIPTION
Remaining issues:
* 5.7.x introduces breaking changes in certain command/script behaviours, notably `mysql_install_db`, which is invoked during `customize`
* 5.5.x and 5.6.x working on Ubuntu but failing on RHEL / Centos / Amazon Linux due to missing perl dependencies

Will address these in subsequent PR.