### PR TITLE
replaced jython imports with guava equivalents

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -929,7 +929,7 @@
                             </module>
                             <module name="TreeWalker">
                                 <module name="IllegalImport">
-                                    <property name="illegalPkgs" value="com.google.api.client.repackaged"/>
+                                    <property name="illegalPkgs" value="com.google.api.client.repackaged,org.python.google"/>
                                 </module>
                             </module>
                         </module>

--- a/usage/camp/pom.xml
+++ b/usage/camp/pom.xml
@@ -195,9 +195,6 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Export-Package>org.apache.brooklyn.*</Export-Package>
-                        <Import-Package>
-                            *
-                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/usage/camp/pom.xml
+++ b/usage/camp/pom.xml
@@ -196,7 +196,6 @@
                     <instructions>
                         <Export-Package>org.apache.brooklyn.*</Export-Package>
                         <Import-Package>
-                            !org.python.google.common.collect
                             *
                         </Import-Package>
                     </instructions>

--- a/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampResolver.java
+++ b/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampResolver.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.camp.brooklyn.spi.creation;
 
 import java.util.Set;
 
+import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -39,7 +40,6 @@ import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.text.Strings;
-import org.python.google.common.collect.Iterables;
 
 import com.google.common.collect.ImmutableSet;
 

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.fail;
 import java.io.StringReader;
 import java.util.Map;
 
+import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
@@ -37,7 +38,6 @@ import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.python.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;

--- a/usage/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
+++ b/usage/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.launcher.blueprints;
 
 import java.io.StringReader;
 
+import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.core.entity.Entities;
@@ -28,7 +29,6 @@ import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture
 import org.apache.brooklyn.location.winrm.AdvertiseWinrmLoginPolicy;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.text.Strings;
-import org.python.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;

--- a/usage/rest-server/src/test/java/org/apache/brooklyn/rest/resources/ApidocResourceTest.java
+++ b/usage/rest-server/src/test/java/org/apache/brooklyn/rest/resources/ApidocResourceTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.rest.resources;
 
 
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
@@ -53,7 +54,6 @@ import org.apache.brooklyn.rest.api.EffectorApi;
 import org.apache.brooklyn.rest.api.EntityApi;
 import org.apache.brooklyn.rest.filter.SwaggerFilter;
 import org.apache.brooklyn.rest.util.ShutdownHandlerProvider;
-import org.python.google.common.base.Joiner;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 

--- a/usage/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestFrameworkAssertionsTest.java
+++ b/usage/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestFrameworkAssertionsTest.java
@@ -19,10 +19,10 @@
 package org.apache.brooklyn.test.framework;
 
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.time.Duration;
-import org.python.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;


### PR DESCRIPTION
encountered the following apparently unnecessary jython imports while looking at building the proposed split brooklyn-server repo, have replaced with guava equivalents.