### PR TITLE
Generate Swagger API Specification using a maven plugin

### DIFF
--- a/usage/rest-api/pom.xml
+++ b/usage/rest-api/pom.xml
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -97,5 +97,47 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.kongchen</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <apiSources>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+                            <locations>org.apache.brooklyn.rest.api</locations>
+                            <schemes>http,https</schemes>
+                            <info>
+                                <title>Swagger API Specification for Brooklyn REST server</title>
+                                <version>v1</version>
+                                <description>
+                                    Swagger API Specification for Brooklyn REST server
+                                </description>
+                                <termsOfService>
+                                    http://www.github.com/apache/incubator-brooklyn
+                                </termsOfService>
+                                <license>
+                                    <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                                    <name>Apache 2.0</name>
+                                </license>
+                            </info>
+                            <swaggerDirectory>${project.build.directory}/generated/swagger-api-spec</swaggerDirectory>
+                        </apiSource>
+                    </apiSources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
- combined with https://github.com/swagger-api/swagger-codegen, it can generate rest bindings for multiple languages