### PR TITLE
fixed byon syntax for catalog template examples

### DIFF
--- a/docs/guide/dev/env/ide/eclipse.include.md
+++ b/docs/guide/dev/env/ide/eclipse.include.md
@@ -1,6 +1,6 @@
 - Groovy Plugin: GRECLIPSE from
   [dist.springsource.org/snapshot/GRECLIPSE/e4.5/](http://dist.springsource.org/snapshot/GRECLIPSE/e4.5/);
   Be sure to include Groovy 2.3 compiler support and Maven-Eclipse (m2e) support.
-  More details including download sites for other versions can be found at the [Groovy Eclipse Plugin site](http://groovy.codehaus.org/Eclipse+Plugin).
+  More details including download sites for other versions can be found at the [Groovy Eclipse Plugin site](http://docs.groovy-lang.org/latest/html/documentation/#section-groovyeclipse).
 
 - TestNG Plugin: beust TestNG from [beust.com/eclipse](http://beust.com/eclipse)

--- a/docs/guide/yaml/example_yaml/simple-appserver-with-location-byon.yaml
+++ b/docs/guide/yaml/example_yaml/simple-appserver-with-location-byon.yaml
@@ -9,4 +9,4 @@ location:
 services:
 - type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
   location:
-    byon: { hosts: [ 127.0.0.1 ] }
+    byon:(hosts="127.0.0.1")

--- a/usage/cli/src/main/resources/brooklyn/default.catalog.bom
+++ b/usage/cli/src/main/resources/brooklyn/default.catalog.bom
@@ -60,7 +60,7 @@ brooklyn.catalog:
         name:           My VM
       
       # location can be e.g. `softlayer` or `jclouds:openstack-nova:https://9.9.9.9:9999/v2.0/`,
-      # or `localhost` or `byon: { nodes: [ 10.0.0.1, 10.0.0.2, 10.0.1.{1,2} ] }` 
+      # or `localhost` or `byon:(hosts="10.9.1.1,10.9.1.2,produser2@10.9.2.{10,11,20-29}")` 
       location:
         jclouds:aws-ec2:
           # edit these to use your credential (or delete if credentials specified in brooklyn.properties)      


### PR DESCRIPTION
The byon syntax in the examples didn't work so these very minor changes modify the syntax to match https://brooklyn.apache.org/v/latest/ops/locations/#byon
