### PR TITLE
Republish request count sensors on poll failure

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAsserts.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAsserts.java
@@ -191,8 +191,6 @@ public class EntityAsserts {
         });
     }
 
-
-
     /**
      * Assert that the given attribute of an entity does not take any of the disallowed values during a given period.
      *

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityFunctions.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityFunctions.java
@@ -51,7 +51,7 @@ public class EntityFunctions {
             @Override public T apply(Entity input) {
                 return (input == null) ? null : input.getAttribute(attribute);
             }
-        };
+        }
         return new GetEntityAttributeFunction();
     }
     
@@ -63,7 +63,7 @@ public class EntityFunctions {
             @Override public T apply(Entity input) {
                 return (input == null) ? null : input.getConfig(key);
             }
-        };
+        }
         return new GetEntityConfigFunction();
     }
     
@@ -75,7 +75,7 @@ public class EntityFunctions {
             @Override public String apply(Entity input) {
                 return (input == null) ? null : input.getDisplayName();
             }
-        };
+        }
         return new GetEntityDisplayName();
     }
     
@@ -87,7 +87,7 @@ public class EntityFunctions {
             @Override public String apply(Identifiable input) {
                 return (input == null) ? null : input.getId();
             }
-        };
+        }
         return new GetIdFunction();
     }
 
@@ -154,7 +154,7 @@ public class EntityFunctions {
         @Override public T apply(Entity input) {
             return (input == null) ? null : input.getAttribute(attribute);
         }
-    };
+    }
 
     public static <T> Function<Object, T> attribute(Entity entity, AttributeSensor<T> attribute) {
         return new GetFixedEntityAttributeFunction<>(entity, attribute);
@@ -186,7 +186,7 @@ public class EntityFunctions {
         @Override public T apply(Entity input) {
             return (input == null) ? null : input.getConfig(key);
         }
-    };
+    }
 
     public static Function<Entity, String> displayName() {
         return GetEntityDisplayName.INSTANCE;
@@ -197,7 +197,7 @@ public class EntityFunctions {
         @Override public String apply(Entity input) {
             return (input == null) ? null : input.getDisplayName();
         }
-    };
+    }
 
     public static Function<Identifiable, String> id() {
         return GetIdFunction.INSTANCE;
@@ -208,7 +208,7 @@ public class EntityFunctions {
         @Override public String apply(Identifiable input) {
             return (input == null) ? null : input.getId();
         }
-    };
+    }
 
 
     /** returns a function which sets the given sensors on the entity passed in,

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityFunctions.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityFunctions.java
@@ -156,6 +156,22 @@ public class EntityFunctions {
         }
     };
 
+    public static <T> Function<Object, T> attribute(Entity entity, AttributeSensor<T> attribute) {
+        return new GetFixedEntityAttributeFunction<>(entity, attribute);
+    }
+
+    protected static class GetFixedEntityAttributeFunction<T> implements Function<Object, T> {
+        private final Entity entity;
+        private final AttributeSensor<T> attribute;
+        protected GetFixedEntityAttributeFunction(Entity entity, AttributeSensor<T> attribute) {
+            this.entity = entity;
+            this.attribute = attribute;
+        }
+        @Override public T apply(Object input) {
+            return entity.getAttribute(attribute);
+        }
+    }
+
     public static <T> Function<Entity, T> config(ConfigKey<T> key) {
         return new GetEntityConfigFunction<T>(checkNotNull(key, "key"));
     }

--- a/core/src/main/java/org/apache/brooklyn/core/feed/FeedConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/FeedConfig.java
@@ -122,6 +122,7 @@ public class FeedConfig<V, T, F extends FeedConfig<V, T, F>> {
     public F checkSuccess(final Function<? super V,Boolean> val) {
         return checkSuccess(Functionals.predicate(val));
     }
+
     @SuppressWarnings("unused")
     /** @deprecated since 0.7.0, kept for rebind */ @Deprecated
     private F checkSuccessLegacy(final Function<? super V,Boolean> val) {
@@ -137,53 +138,63 @@ public class FeedConfig<V, T, F extends FeedConfig<V, T, F>> {
         this.onsuccess = checkNotNull(val, "onSuccess");
         return self();
     }
-    
+
     public F setOnSuccess(T val) {
         return onSuccess(Functions.constant(val));
     }
-    
-    /** a failure is when the connection is fine (no exception) but the other end returns a result object V 
-     * which the feed can tell indicates a failure (e.g. HTTP code 404) */
+
+    /**
+     * A failure is when the connection is fine (no exception) but the other end returns a result object V
+     * which the feed can tell indicates a failure (e.g. HTTP code 404)
+     */
     public F onFailure(Function<? super V,T> val) {
         this.onfailure = checkNotNull(val, "onFailure");
         return self();
     }
 
+    /** @see #onFailure(Function) */
     public F setOnFailure(T val) {
         return onFailure(Functions.constant(val));
     }
 
-    /** registers a callback to be used {@link #onSuccess(Function)} and {@link #onFailure(Function)}, 
-     * i.e. whenever a result comes back, but not in case of exceptions being thrown (ie problems communicating) */
+    /**
+     * Registers a callback to be used by {@link #onSuccess(Function)} and {@link #onFailure(Function)},
+     * i.e. whenever a result comes back, but not in case of exceptions being thrown (ie problems communicating)
+     */
     public F onResult(Function<? super V, T> val) {
         onSuccess(val);
         return onFailure(val);
     }
 
+    /** @see #onResult(Function) */
     public F setOnResult(T val) {
         return onResult(Functions.constant(val));
     }
 
-    /** an exception is when there is an error in the communication */
+    /**
+     * An exception is when there is an error in the communication
+     */
     public F onException(Function<? super Exception,T> val) {
         this.onexception = checkNotNull(val, "onException");
         return self();
     }
-    
+
+    /** @see #onException(Function) */
     public F setOnException(T val) {
         return onException(Functions.constant(val));
     }
 
-    /** convenience for indicating a behaviour to occur for both
-     * {@link #onException(Function)}
-     * (error connecting) and 
-     * {@link #onFailure(Function)} 
-     * (successful communication but failure report from remote end) */
+    /**
+     * A convenience for indicating a behaviour to occur for both {@link #onException(Function)}
+     * (error connecting) and {@link #onFailure(Function)} (successful communication but failure
+     * report from remote end)
+     */
     public F onFailureOrException(Function<Object,T> val) {
         onFailure(val);
         return onException(val);
     }
-    
+
+    /** @see #onFailureOrException(Function) */
     public F setOnFailureOrException(T val) {
         return onFailureOrException(Functions.constant(val));
     }
@@ -192,7 +203,7 @@ public class FeedConfig<V, T, F extends FeedConfig<V, T, F>> {
         suppressDuplicates = val;
         return self();
     }
-    
+
     /**
      * Whether this feed is enabled (defaulting to true).
      */
@@ -200,7 +211,7 @@ public class FeedConfig<V, T, F extends FeedConfig<V, T, F>> {
         enabled = val;
         return self();
     }
-    
+
     public boolean hasSuccessHandler() {
         return this.onsuccess != null;
     }
@@ -216,7 +227,6 @@ public class FeedConfig<V, T, F extends FeedConfig<V, T, F>> {
     public boolean hasCheckSuccessHandler() {
         return this.checkSuccess != null;
     }
-
     
     @Override
     public String toString() {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityFunctionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityFunctionsTest.java
@@ -51,6 +51,12 @@ public class EntityFunctionsTest extends BrooklynAppUnitTestSupport {
         assertEquals(EntityFunctions.attribute(TestEntity.NAME).apply(entity), "myname");
         assertNull(EntityFunctions.attribute(TestEntity.SEQUENCE).apply(entity));
     }
+
+    @Test
+    public void testEntityAttributeTest() {
+        entity.sensors().set(TestEntity.NAME, "myname");
+        assertEquals(EntityFunctions.attribute(entity, TestEntity.NAME).apply(new Object()), "myname");
+    }
     
     @Test
     public void testConfig() throws Exception {

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcessImpl;
 import org.apache.brooklyn.entity.webapp.WebAppServiceMethods;
@@ -71,7 +72,7 @@ public class CouchDBNodeImpl extends SoftwareProcessImpl implements CouchDBNode 
                 .baseUri(String.format("http://%s:%d/_stats", getAttribute(HOSTNAME), getHttpPort()))
                 .poll(new HttpPollConfig<Integer>(REQUEST_COUNT)
                         .onSuccess(HttpValueFunctions.jsonContents(new String[] { "httpd", "requests", "count" }, Integer.class))
-                        .onFailureOrException(Functions.constant(-1))
+                        .onFailureOrException(EntityFunctions.attribute(this, REQUEST_COUNT))
                         .enabled(retrieveUsageMetrics))
                 .poll(new HttpPollConfig<Integer>(ERROR_COUNT)
                         .onSuccess(HttpValueFunctions.jsonContents(new String[] { "httpd_status_codes", "404", "count" }, Integer.class))

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6ServerImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.entity.java.UsesJmx;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcessImpl;
 import org.apache.brooklyn.feed.jmx.JmxAttributePollConfig;
@@ -81,6 +82,7 @@ public class JBoss6ServerImpl extends JavaWebAppSoftwareProcessImpl implements J
                     .pollAttribute(new JmxAttributePollConfig<Integer>(REQUEST_COUNT)
                             .objectName(requestProcessorMbeanName)
                             .attributeName("requestCount")
+                            .onFailureOrException(EntityFunctions.attribute(this, REQUEST_COUNT))
                             .enabled(retrieveUsageMetrics))
                     .pollAttribute(new JmxAttributePollConfig<Integer>(TOTAL_PROCESSING_TIME)
                             .objectName(requestProcessorMbeanName)

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.location.access.BrooklynAccessUtils;
 import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcessImpl;
@@ -100,6 +101,7 @@ public class JBoss7ServerImpl extends JavaWebAppSoftwareProcessImpl implements J
                     .poll(new HttpPollConfig<Integer>(REQUEST_COUNT)
                             .vars(includeRuntimeUriVars)
                             .onSuccess(HttpValueFunctions.jsonContents("requestCount", Integer.class))
+                            .onFailureOrException(EntityFunctions.attribute(this, REQUEST_COUNT))
                             .enabled(retrieveUsageMetrics))
                     .poll(new HttpPollConfig<Integer>(ERROR_COUNT)
                             .vars(includeRuntimeUriVars)

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jetty/Jetty6ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jetty/Jetty6ServerImpl.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.entity.webapp.jetty;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.entity.java.JavaAppUtils;
@@ -60,7 +61,8 @@ public class Jetty6ServerImpl extends JavaWebAppSoftwareProcessImpl implements J
                             .setOnFailureOrException(false))
                     .pollAttribute(new JmxAttributePollConfig<Integer>(REQUEST_COUNT)
                             .objectName(statsMbeanName)
-                            .attributeName("requests"))
+                            .attributeName("requests")
+                            .onFailureOrException(EntityFunctions.attribute(this, REQUEST_COUNT)))
                     .pollAttribute(new JmxAttributePollConfig<Integer>(RESPONSES_4XX_COUNT)
                             .objectName(statsMbeanName)
                             .attributeName("responses4xx"))

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerImpl.java
@@ -22,6 +22,10 @@ import static java.lang.String.format;
 
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.entity.java.JavaAppUtils;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcessImpl;
 import org.apache.brooklyn.feed.jmx.JmxAttributePollConfig;
@@ -29,6 +33,7 @@ import org.apache.brooklyn.feed.jmx.JmxFeed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Predicates;
 
@@ -79,7 +84,8 @@ public class TomcatServerImpl extends JavaWebAppSoftwareProcessImpl implements T
                     .pollAttribute(new JmxAttributePollConfig<Integer>(REQUEST_COUNT)
                             .objectName(requestProcessorMbeanName)
                             .attributeName("requestCount")
-                            .enabled(retrieveUsageMetrics))
+                            .enabled(retrieveUsageMetrics)
+                            .onFailureOrException(EntityFunctions.attribute(this, REQUEST_COUNT)))
                     .pollAttribute(new JmxAttributePollConfig<Integer>(TOTAL_PROCESSING_TIME)
                             .objectName(requestProcessorMbeanName)
                             .attributeName("processingTime")

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jetty/JettyWebAppFixtureIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jetty/JettyWebAppFixtureIntegrationTest.java
@@ -55,13 +55,5 @@ public class JettyWebAppFixtureIntegrationTest extends AbstractWebAppFixtureInte
             String urlSubPathToPageToQuery) {
         super.testWarDeployAndUndeploy(entity, war, urlSubPathToWebApp, urlSubPathToPageToQuery);
     }
-    
-    public static void main(String ...args) throws Exception {
-        JettyWebAppFixtureIntegrationTest t = new JettyWebAppFixtureIntegrationTest();
-        t.setUp();
-        t.canStartAndStop((SoftwareProcess) t.basicEntities()[0][0]);
-        t.shutdownApp();
-        t.shutdownMgmt();
-    }
 
 }

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerWebAppFixtureIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerWebAppFixtureIntegrationTest.java
@@ -84,13 +84,13 @@ public class TomcatServerWebAppFixtureIntegrationTest extends AbstractWebAppFixt
     public void canStartAndStop(final SoftwareProcess entity) {
         super.canStartAndStop(entity);
     }
+
     @Test(groups = "Integration", dataProvider = "basicEntities")
     public void testReportsServiceDownWhenKilled(final SoftwareProcess entity) throws Exception {
         super.testReportsServiceDownWhenKilled(entity);
     }
 
     @Override
-    // as parent, but with spring travel
     @DataProvider(name = "entitiesWithWarAndURL")
     public Object[][] entitiesWithWar() {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/hello-world.war");
@@ -104,19 +104,6 @@ public class TomcatServerWebAppFixtureIntegrationTest extends AbstractWebAppFixt
                     "" // no sub-page path
                     });
         }
-
-        // TODO would be nice to test against spring web framework stock booking example
-        // but we'd need an external URL for that (we removed the binary from here for apache compliance reasons)
-//        TestApplication tomcatApp = newTestApplication();
-//        TomcatServer tomcat = tomcatApp.createAndManageChild(EntitySpec.create(TomcatServer.class)
-//                .configure(TomcatServer.HTTP_PORT, PortRanges.fromString(DEFAULT_HTTP_PORT)));
-//        result.add(new Object[] {
-//                tomcat,
-//                "swf-booking-mvc.war",
-//                "swf-booking-mvc/",
-//                "spring/intro",
-//               });
-        
         return result.toArray(new Object[][] {});
     }
 
@@ -147,14 +134,7 @@ public class TomcatServerWebAppFixtureIntegrationTest extends AbstractWebAppFixt
                     .limitIterationsTo(25)
                     .run();
             
-            if (socketClosed == false) {
-//                log.error("WebApp did not shut down - this is a failure of the last test run");
-//                log.warn("I'm sending a message to the shutdown port {}", shutdownPort);
-//                OutputStreamWriter writer = new OutputStreamWriter(shutdownSocket.getOutputStream());
-//                writer.write("SHUTDOWN\r\n");
-//                writer.flush();
-//                writer.close();
-//                shutdownSocket.close();
+            if (!socketClosed) {
                 throw new Exception("Last test run did not shut down WebApp entity "+entity+" (port "+shutdownPort+")");
             }
         } else {

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -669,8 +669,6 @@ public class Asserts {
         assertEquals(actual, expected, null);
     }
 
-
-
     /**
      * Asserts that a condition is true. If it isn't, an AssertionError is thrown.
      * @param condition the condition to evaluate


### PR DESCRIPTION
Entities that use `org.apache.brooklyn.entity.webapp.WebAppServiceMetrics#REQUEST_COUNT` are configured to republish the existing sensor value when a poll fails.

**Context**

The webapp entities (for Tomcat, JBoss, etc.) publish a request count sensor. `WebAppServiceMethods#connectWebAppServerPolicies(EntityLocal)` is used by `JavaWebAppSoftwareProcess` (among others) to enrich the sensor into values for `REQUESTS_PER_SECOND_LAST` and `REQUESTS_PER_SECOND_IN_WINDOW` sensors.

The clustered varieties of these entities (`DynamicWebAppCluster` and co.) enrich the enriched values into cluster-wide aggregates.

Enrichers are only updated when a value for the source sensor (request count) is published.

If an entity's process fails then the poll for the request count sensor fails and no value is published. As such, no values for the enriched sensors are published either and their values must be considered incorrect. This then means that policies act on stale data rather than the true state of the system.

The change in this pull request configures the handful of entities that use the `REQUEST_COUNT` sensor to republish the current value when a poll fails. Whether this is an appropriate thing to do depends on whether you think a sensor's value represents a communique that Brooklyn has learned something of the recent history of the system being monitored or that it represents something that was true in the past. (I generally assume the latter since there is no notion of timeliness when calling `sensors().get(key)`.)

An alternative approach would be to adjust the aggregating enrichers to indicate that entities whose status is not `RUNNING` should not be considered. The current design of the aggregating enrichers does not make this as straightforward as the changes in this PR.

Another would be to change `RollingTimeWindowMeanEnricher` to decay values outwith the sensor event framework.

I think this change is sufficient for the near future - it is much better than the status quo - and that long term we should choose one of the alternatives (and also that I'm probably overthinking this).