### PR TITLE
Proper ordering of catalog config

### DIFF
--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.rest.transform;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType;
@@ -73,8 +74,9 @@ public class CatalogTransformer {
             EntityDynamicType typeMap = BrooklynTypes.getDefinedEntityType(spec.getType());
             EntityType type = typeMap.getSnapshot();
 
+            AtomicInteger paramPriorityCnt = new AtomicInteger();
             for (SpecParameter<?> input: spec.getParameters())
-                config.add(EntityTransformer.entityConfigSummary(input));
+                config.add(EntityTransformer.entityConfigSummary(input, paramPriorityCnt));
             for (Sensor<?> x: type.getSensors())
                 sensors.add(SensorTransformer.sensorSummaryForCatalog(x));
             for (Effector<?> x: type.getEffectors())

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/EntityTransformer.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/transform/EntityTransformer.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Application;
@@ -153,8 +154,11 @@ public class EntityTransformer {
         return entityConfigSummary(config, label, priority, null);
     }
 
-    public static EntityConfigSummary entityConfigSummary(SpecParameter<?> input) {
-        Double priority = input.isPinned() ? Double.valueOf(1d) : null;
+    public static EntityConfigSummary entityConfigSummary(SpecParameter<?> input, AtomicInteger paramPriorityCnt) {
+        // Increment the priority because the config container is a set. Server-side we are using an ordered set
+        // which results in correctly ordered items on the wire (as a list). Clients which use the java bindings
+        // though will push the items in an unordered set - so give them means to recover the correct order.
+        Double priority = input.isPinned() ? Double.valueOf(paramPriorityCnt.incrementAndGet()) : null;
         return entityConfigSummary(input.getType(), input.getLabel(), priority, null);
     }
 


### PR DESCRIPTION
Increment the priority because the config container is a `Set`. Server-side we are using an ordered set which results in correctly ordered items on the wire (as a list). Clients which use the java bindings though will push the items in an unordered set - so give them means to recover the correct order.