### PR TITLE
support for external config in BrooklynProperties

### DIFF
--- a/camp/camp-base/src/main/java/org/apache/brooklyn/camp/spi/resolve/PdpProcessor.java
+++ b/camp/camp-base/src/main/java/org/apache/brooklyn/camp/spi/resolve/PdpProcessor.java
@@ -177,7 +177,7 @@ public class PdpProcessor {
      * essentially a post-parse processing step before matching */
     @SuppressWarnings("unchecked")
     @VisibleForTesting
-    public Map<String, Object> applyInterpreters(Map<String, Object> originalDeploymentPlan) {
+    public Map<String, Object> applyInterpreters(Map<String, ?> originalDeploymentPlan) {
         PlanInterpretationNode interpretation = new PlanInterpretationNode(
                 new PlanInterpretationContext(originalDeploymentPlan, interpreters));
         return (Map<String, Object>) interpretation.getNewValue();

--- a/camp/camp-base/src/main/java/org/apache/brooklyn/camp/spi/resolve/interpret/PlanInterpretationContext.java
+++ b/camp/camp-base/src/main/java/org/apache/brooklyn/camp/spi/resolve/interpret/PlanInterpretationContext.java
@@ -32,7 +32,7 @@ public class PlanInterpretationContext {
     private final List<PlanInterpreter> interpreters;
     private final PlanInterpreter allInterpreter;
 
-    public PlanInterpretationContext(Map<String,Object> originalDeploymentPlan, List<PlanInterpreter> interpreters) {
+    public PlanInterpretationContext(Map<String,?> originalDeploymentPlan, List<PlanInterpreter> interpreters) {
         super();
         this.originalDeploymentPlan = ImmutableMap.copyOf(originalDeploymentPlan);
         this.interpreters = ImmutableList.copyOf(interpreters);

--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynPropertiesImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynPropertiesImpl.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import groovy.lang.Closure;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.config.BasicConfigKey;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.StringFunctions;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+
+/**
+ * TODO methods in this class are not thread safe.
+ * intention is that they are set during startup and not modified thereafter.
+ */
+@SuppressWarnings("rawtypes")
+public class BrooklynPropertiesImpl extends LinkedHashMap implements BrooklynProperties {
+
+    private static final long serialVersionUID = -945875483083108978L;
+    private static final Logger LOG = LoggerFactory.getLogger(BrooklynPropertiesImpl.class);
+
+    public static class Factory {
+        /** creates a new empty {@link BrooklynPropertiesImpl} */
+        public static BrooklynPropertiesImpl newEmpty() {
+            return new BrooklynPropertiesImpl();
+        }
+
+        /** creates a new {@link BrooklynPropertiesImpl} with contents loaded 
+         * from the usual places, including *.properties files and environment variables */
+        public static BrooklynPropertiesImpl newDefault() {
+            return new Builder(true).build();
+        }
+
+        public static Builder builderDefault() {
+            return new Builder(true);
+        }
+
+        public static Builder builderEmpty() {
+            return new Builder(false);
+        }
+
+        public static class Builder {
+            private String defaultLocationMetadataUrl;
+            private String globalLocationMetadataFile = null;
+            private String globalPropertiesFile = null;
+            private String localPropertiesFile = null;
+            private BrooklynPropertiesImpl originalProperties = null;
+            
+            /** @deprecated since 0.7.0 use static methods in {@link Factory} to create */
+            public Builder() {
+                this(true);
+            }
+            
+            private Builder(boolean setGlobalFileDefaults) {
+                resetDefaultLocationMetadataUrl();
+                if (setGlobalFileDefaults) {
+                    resetGlobalFiles();
+                }
+            }
+            
+            public Builder resetDefaultLocationMetadataUrl() {
+                defaultLocationMetadataUrl = "classpath://brooklyn/location-metadata.properties";
+                return this;
+            }
+            public Builder resetGlobalFiles() {
+                defaultLocationMetadataUrl = "classpath://brooklyn/location-metadata.properties";
+                globalLocationMetadataFile = Os.mergePaths(Os.home(), ".brooklyn", "location-metadata.properties");
+                globalPropertiesFile = Os.mergePaths(Os.home(), ".brooklyn", "brooklyn.properties");
+                return this;
+            }
+            
+            /**
+             * Creates a Builder that when built, will return the BrooklynProperties passed to this constructor
+             */
+            private Builder(BrooklynPropertiesImpl originalProperties) {
+                this.originalProperties = new BrooklynPropertiesImpl().addFromMap(originalProperties);
+            }
+            
+            /**
+             * The URL of a default location-metadata.properties (for meta-data about different locations, such as iso3166 and global lat/lon). 
+             * Defaults to classpath://brooklyn/location-metadata.properties
+             */
+            public Builder defaultLocationMetadataUrl(String val) {
+                defaultLocationMetadataUrl = checkNotNull(val, "file");
+                return this;
+            }
+            
+            /**
+             * The URL of a location-metadata.properties file that appends to and overwrites values in the locationMetadataUrl. 
+             * Defaults to ~/.brooklyn/location-metadata.properties
+             */
+            public Builder globalLocationMetadataFile(String val) {
+                globalLocationMetadataFile = checkNotNull(val, "file");
+                return this;
+            }
+            
+            /**
+             * The URL of a shared brooklyn.properties file. Defaults to ~/.brooklyn/brooklyn.properties.
+             * Can be null to disable.
+             */
+            public Builder globalPropertiesFile(String val) {
+                globalPropertiesFile = val;
+                return this;
+            }
+            
+            @Beta
+            public boolean hasDelegateOriginalProperties() {
+                return this.originalProperties==null;
+            }
+            
+            /**
+             * The URL of a brooklyn.properties file specific to this launch. Appends to and overwrites values in globalPropertiesFile.
+             */
+            public Builder localPropertiesFile(String val) {
+                localPropertiesFile = val;
+                return this;
+            }
+            
+            public BrooklynPropertiesImpl build() {
+                if (originalProperties != null) 
+                    return new BrooklynPropertiesImpl().addFromMap(originalProperties);
+                
+                BrooklynPropertiesImpl properties = new BrooklynPropertiesImpl();
+
+                // TODO Could also read from http://brooklyn.io, for up-to-date values?
+                // But might that make unit tests run very badly when developer is offline?
+                addPropertiesFromUrl(properties, defaultLocationMetadataUrl, false);
+                
+                addPropertiesFromFile(properties, globalLocationMetadataFile);
+                addPropertiesFromFile(properties, globalPropertiesFile);
+                addPropertiesFromFile(properties, localPropertiesFile);
+                
+                properties.addEnvironmentVars();
+                properties.addSystemProperties();
+
+                return properties;
+            }
+
+            public static Builder fromProperties(BrooklynPropertiesImpl brooklynProperties) {
+                return new Builder(brooklynProperties);
+            }
+
+            @Override
+            public String toString() {
+                return Objects.toStringHelper(this)
+                        .omitNullValues()
+                        .add("originalProperties", originalProperties)
+                        .add("defaultLocationMetadataUrl", defaultLocationMetadataUrl)
+                        .add("globalLocationMetadataUrl", globalLocationMetadataFile)
+                        .add("globalPropertiesFile", globalPropertiesFile)
+                        .add("localPropertiesFile", localPropertiesFile)
+                        .toString();
+            }
+        }
+        
+        private static void addPropertiesFromUrl(BrooklynPropertiesImpl p, String url, boolean warnIfNotFound) {
+            if (url==null) return;
+            
+            try {
+                p.addFrom(ResourceUtils.create(BrooklynPropertiesImpl.class).getResourceFromUrl(url));
+            } catch (Exception e) {
+                if (warnIfNotFound)
+                    LOG.warn("Could not load {}; continuing", url);
+                if (LOG.isTraceEnabled()) LOG.trace("Could not load "+url+"; continuing", e);
+            }
+        }
+        
+        private static void addPropertiesFromFile(BrooklynPropertiesImpl p, String file) {
+            if (file==null) return;
+            
+            String fileTidied = Os.tidyPath(file);
+            File f = new File(fileTidied);
+
+            if (f.exists()) {
+                p.addFrom(f);
+            }
+        }
+    }
+
+    protected BrooklynPropertiesImpl() {
+    }
+
+    public BrooklynPropertiesImpl addEnvironmentVars() {
+        addFrom(System.getenv());
+        return this;
+    }
+
+    public BrooklynPropertiesImpl addSystemProperties() {
+        addFrom(System.getProperties());
+        return this;
+    }
+
+    public BrooklynPropertiesImpl addFrom(ConfigBag cfg) {
+        addFrom(cfg.getAllConfig());
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public BrooklynPropertiesImpl addFrom(Map map) {
+        putAll(Maps.transformValues(map, StringFunctions.trim()));
+        return this;
+    }
+
+    public BrooklynPropertiesImpl addFrom(InputStream i) {
+        // Ugly way to load them in order, but Properties is a Hashtable so loses order otherwise.
+        @SuppressWarnings({ "serial" })
+        Properties p = new Properties() {
+            @Override
+            public synchronized Object put(Object key, Object value) {
+                // Trim the string values to remove leading and trailing spaces
+                String s = (String) value;
+                if (Strings.isBlank(s)) {
+                    s = Strings.EMPTY;
+                } else {
+                    s = CharMatcher.BREAKING_WHITESPACE.trimFrom(s);
+                }
+                return BrooklynPropertiesImpl.this.put(key, s);
+            }
+        };
+        try {
+            p.load(i);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+        return this;
+    }
+    
+    public BrooklynPropertiesImpl addFrom(File f) {
+        if (!f.exists()) {
+            LOG.warn("Unable to find file '"+f.getAbsolutePath()+"' when loading properties; ignoring");
+            return this;
+        } else {
+            try {
+                return addFrom(new FileInputStream(f));
+            } catch (FileNotFoundException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+    }
+    public BrooklynPropertiesImpl addFrom(URL u) {
+        try {
+            return addFrom(u.openStream());
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading properties from "+u+": "+e, e);
+        }
+    }
+    /**
+     * @see ResourceUtils#getResourceFromUrl(String)
+     *
+     * of the form form file:///home/... or http:// or classpath://xx ;
+     * for convenience if not starting with xxx: it is treated as a classpath reference or a file;
+     * throws if not found (but does nothing if argument is null)
+     */
+    public BrooklynPropertiesImpl addFromUrl(String url) {
+        try {
+            if (url==null) return this;
+            return addFrom(ResourceUtils.create(this).getResourceFromUrl(url));
+        } catch (Exception e) {
+            throw new RuntimeException("Error reading properties from "+url+": "+e, e);
+        }
+    }
+
+    /** expects a property already set in scope, whose value is acceptable to {@link #addFromUrl(String)};
+     * if property not set, does nothing */
+    public BrooklynPropertiesImpl addFromUrlProperty(String urlProperty) {
+        String url = (String) get(urlProperty);
+        if (url==null) addFromUrl(url);
+        return this;
+    }
+
+    /**
+    * adds the indicated properties
+    */
+    public BrooklynPropertiesImpl addFromMap(Map properties) {
+        putAll(properties);
+        return this;
+    }
+
+    /** inserts the value under the given key, if it was not present */
+    public boolean putIfAbsent(String key, Object value) {
+        if (containsKey(key)) return false;
+        put(key, value);
+        return true;
+    }
+
+   /** @deprecated attempts to call get with this syntax are probably mistakes; get(key, defaultValue) is fine but
+    * Map is unlikely the key, much more likely they meant getFirst(flags, key).
+    */
+   @Deprecated
+   public String get(Map flags, String key) {
+       LOG.warn("Discouraged use of 'BrooklynProperties.get(Map,String)' (ambiguous); use getFirst(Map,String) or get(String) -- assuming the former");
+       LOG.debug("Trace for discouraged use of 'BrooklynProperties.get(Map,String)'",
+           new Throwable("Arguments: "+flags+" "+key));
+       return getFirst(flags, key);
+   }
+
+    /** returns the value of the first key which is defined
+     * <p>
+     * takes the following flags:
+     * 'warnIfNone', 'failIfNone' (both taking a boolean (to use default message) or a string (which is the message));
+     * and 'defaultIfNone' (a default value to return if there is no such property); defaults to no warning and null response */
+    @Override
+    public String getFirst(String ...keys) {
+       return getFirst(MutableMap.of(), keys);
+    }
+    @Override
+    public String getFirst(Map flags, String ...keys) {
+        for (String k: keys) {
+            if (k!=null && containsKey(k)) return (String) get(k);
+        }
+        if (flags.get("warnIfNone")!=null && !Boolean.FALSE.equals(flags.get("warnIfNone"))) {
+            if (Boolean.TRUE.equals(flags.get("warnIfNone")))
+                LOG.warn("Unable to find Brooklyn property "+keys);
+            else
+                LOG.warn(""+flags.get("warnIfNone"));
+        }
+        if (flags.get("failIfNone")!=null && !Boolean.FALSE.equals(flags.get("failIfNone"))) {
+            Object f = flags.get("failIfNone");
+            if (f instanceof Closure)
+                ((Closure)f).call((Object[])keys);
+            if (Boolean.TRUE.equals(f))
+                throw new NoSuchElementException("Brooklyn unable to find mandatory property "+keys[0]+
+                    (keys.length>1 ? " (or "+(keys.length-1)+" other possible names, full list is "+Arrays.asList(keys)+")" : "") );
+            else
+                throw new NoSuchElementException(""+f);
+        }
+        if (flags.get("defaultIfNone")!=null) {
+            return (String) flags.get("defaultIfNone");
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "BrooklynProperties["+size()+"]";
+    }
+
+    /** like normal map.put, except config keys are dereferenced on the way in */
+    @SuppressWarnings("unchecked")
+    public Object put(Object key, Object value) {
+        if (key instanceof HasConfigKey) key = ((HasConfigKey)key).getConfigKey().getName();
+        if (key instanceof ConfigKey) key = ((ConfigKey)key).getName();
+        return super.put(key, value);
+    }
+
+    /** like normal map.putAll, except config keys are dereferenced on the way in */
+    @Override
+    public void putAll(Map vals) {
+        for (Map.Entry<?,?> entry : ((Map<?,?>)vals).entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    public <T> Object put(HasConfigKey<T> key, T value) {
+        return super.put(key.getConfigKey().getName(), value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Object put(ConfigKey<T> key, T value) {
+        return super.put(key.getName(), value);
+    }
+    
+    public <T> boolean putIfAbsent(ConfigKey<T> key, T value) {
+        return putIfAbsent(key.getName(), value);
+    }
+    
+    @Override
+    public <T> T getConfig(ConfigKey<T> key) {
+        return getConfig(key, null);
+    }
+
+    @Override
+    public <T> T getConfig(HasConfigKey<T> key) {
+        return getConfig(key.getConfigKey(), null);
+    }
+
+    @Override
+    public <T> T getConfig(HasConfigKey<T> key, T defaultValue) {
+        return getConfig(key.getConfigKey(), defaultValue);
+    }
+
+    @Override
+    public <T> T getConfig(ConfigKey<T> key, T defaultValue) {
+        // TODO does not support MapConfigKey etc where entries use subkey notation; for now, access using submap
+        if (!containsKey(key.getName())) {
+            if (defaultValue!=null) return defaultValue;
+            return key.getDefaultValue();
+        }
+        Object value = get(key.getName());
+        if (value==null) return null;
+        // no evaluation / key extraction here
+        return TypeCoercions.coerce(value, key.getTypeToken());
+    }
+
+    @Override
+    public Object getRawConfig(ConfigKey<?> key) {
+        return get(key.getName());
+    }
+    
+    @Override
+    public Maybe<Object> getConfigRaw(ConfigKey<?> key, boolean includeInherited) {
+        if (containsKey(key.getName())) return Maybe.of(get(key.getName()));
+        return Maybe.absent();
+    }
+
+    @Override
+    public Map<ConfigKey<?>, Object> getAllConfig() {
+        Map<ConfigKey<?>, Object> result = new LinkedHashMap<ConfigKey<?>, Object>();
+        for (Object entry: entrySet())
+            result.put(new BasicConfigKey<Object>(Object.class, ""+((Map.Entry)entry).getKey()), ((Map.Entry)entry).getValue());
+        return result;
+    }
+
+    @Override
+    public BrooklynPropertiesImpl submap(Predicate<ConfigKey<?>> filter) {
+        BrooklynPropertiesImpl result = Factory.newEmpty();
+        for (Object entry: entrySet()) {
+            ConfigKey<?> k = new BasicConfigKey<Object>(Object.class, ""+((Map.Entry)entry).getKey());
+            if (filter.apply(k))
+                result.put(((Map.Entry)entry).getKey(), ((Map.Entry)entry).getValue());
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Object> asMapWithStringKeys() {
+        return this;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.config.ConfigPredicates;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.mgmt.internal.LocalLocationManager;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.typereg.RegisteredTypePredicates;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -494,6 +495,11 @@ public class BasicLocationRegistry implements LocationRegistry {
     }
 
     @VisibleForTesting
+    public void putProperties(Map<String, ?> vals) {
+        ((ManagementContextInternal)mgmt).getBrooklynProperties().putAll(vals);
+    }
+
+    @VisibleForTesting
     public static void setupLocationRegistryForTesting(ManagementContext mgmt) {
         // ensure localhost is added (even on windows)
         LocationDefinition l = mgmt.getLocationRegistry().getDefinedLocationByName("localhost");
@@ -502,5 +508,4 @@ public class BasicLocationRegistry implements LocationRegistry {
         
         ((BasicLocationRegistry)mgmt.getLocationRegistry()).disablePersistence();
     }
-
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -151,7 +151,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
 
     private final AtomicLong totalEffectorInvocationCount = new AtomicLong();
 
-    protected BrooklynProperties configMap;
+    protected DeferredBrooklynProperties configMap;
     protected BasicLocationRegistry locationRegistry;
     protected final BasicBrooklynCatalog catalog;
     protected final BrooklynTypeRegistry typeRegistry;
@@ -184,7 +184,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     }
 
     public AbstractManagementContext(BrooklynProperties brooklynProperties, DataGridFactory datagridFactory) {
-        this.configMap = brooklynProperties;
+        this.configMap = new DeferredBrooklynProperties(brooklynProperties, this);
         this.entityDriverManager = new BasicEntityDriverManager();
         this.downloadsManager = BasicDownloadsManager.newDefault(configMap);
         if (datagridFactory == null) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/CampYamlParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/CampYamlParser.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.internal;
+
+import java.util.Map;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+
+public interface CampYamlParser {
+
+    ConfigKey<CampYamlParser> YAML_PARSER_KEY = ConfigKeys.newConfigKey(CampYamlParser.class, "brooklyn.camp.yamlParser");
+
+    Map<String, Object> parse(Map<String, Object> map);
+    
+    Object parse(String val);
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/DeferredBrooklynProperties.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/DeferredBrooklynProperties.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
+
+/**
+ * Delegates to another {@link BrooklynProperties} implementation, but intercepts all calls to get.
+ * The results are transformed: if they are in the external-config format then they are 
+ * automatically converted to {@link DeferredSupplier}.
+ * 
+ * The external-config format is that same as that for camp-yaml blueprints (i.e. 
+ * {@code $brooklyn:external("myprovider", "mykey")}.
+ */
+public class DeferredBrooklynProperties implements BrooklynProperties {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeferredBrooklynProperties.class);
+
+    private static final String BROOKLYN_YAML_PREFIX = "$brooklyn:";
+    
+    private final BrooklynProperties delegate;
+    private final ManagementContextInternal mgmt;
+
+    public DeferredBrooklynProperties(BrooklynProperties delegate, ManagementContextInternal mgmt) {
+        this.delegate = checkNotNull(delegate, "delegate");
+        this.mgmt = checkNotNull(mgmt, "mgmt");
+    }
+    
+    private Object transform(ConfigKey<?> key, Object value) {
+        if (value instanceof CharSequence) {
+            String raw = value.toString();
+            if (raw.startsWith(BROOKLYN_YAML_PREFIX)) {
+                CampYamlParser parser = mgmt.getConfig().getConfig(CampYamlParser.YAML_PARSER_KEY);
+                if (parser == null) {
+                    // TODO Should we fail or return the untransformed value?
+                    // Problem is this gets called during initialisation, e.g. by BrooklynFeatureEnablement calling asMapWithStringKeys()
+                    // throw new IllegalStateException("Cannot parse external-config for "+key+" because no camp-yaml parser available");
+                    LOG.debug("Not transforming external-config {}, as no camp-yaml parser available", key);
+                    return value;
+                }
+                return parser.parse(raw);
+            }
+        }
+        return value;
+    }
+    
+    private <T> T resolve(ConfigKey<T> key, Object value) {
+        Object transformed = transform(key, value);
+
+        Object result;
+        if (transformed instanceof DeferredSupplier) {
+            ExecutionContext exec = mgmt.getServerExecutionContext();
+            try {
+                result = Tasks.resolveValue(transformed, key.getType(), exec);
+            } catch (ExecutionException | InterruptedException e) {
+                throw Exceptions.propagate(e);
+            }
+        } else {
+            result = transformed;
+        }
+
+        return TypeCoercions.coerce(result, key.getTypeToken());
+    }
+    
+    @Override
+    public <T> T getConfig(ConfigKey<T> key) {
+        T raw = delegate.getConfig(key);
+        return resolve(key, raw);
+    }
+
+    @Override
+    public <T> T getConfig(HasConfigKey<T> key) {
+        T raw = delegate.getConfig(key);
+        return resolve(key.getConfigKey(), raw);
+    }
+
+    @Override
+    public <T> T getConfig(HasConfigKey<T> key, T defaultValue) {
+        T raw = delegate.getConfig(key, defaultValue);
+        return resolve(key.getConfigKey(), raw);
+    }
+
+    @Override
+    public <T> T getConfig(ConfigKey<T> key, T defaultValue) {
+        T raw = delegate.getConfig(key, defaultValue);
+        return resolve(key, raw);
+    }
+
+    @Deprecated
+    @Override
+    public Object getRawConfig(ConfigKey<?> key) {
+        return transform(key, delegate.getRawConfig(key));
+    }
+    
+    @Override
+    public Maybe<Object> getConfigRaw(ConfigKey<?> key, boolean includeInherited) {
+        Maybe<Object> result = delegate.getConfigRaw(key, includeInherited);
+        return (result.isPresent()) ? Maybe.of(transform(key, result.get())) : Maybe.absent();
+    }
+
+    @Override
+    public Map<ConfigKey<?>, Object> getAllConfig() {
+        Map<ConfigKey<?>, Object> raw = delegate.getAllConfig();
+        Map<ConfigKey<?>, Object> result = Maps.newLinkedHashMap();
+        for (Map.Entry<ConfigKey<?>, Object> entry : raw.entrySet()) {
+            result.put(entry.getKey(), transform(entry.getKey(), entry.getValue()));
+        }
+        return result;
+    }
+
+    @Override
+    public Map<String, Object> asMapWithStringKeys() {
+        Map<ConfigKey<?>, Object> raw = delegate.getAllConfig();
+        Map<String, Object> result = Maps.newLinkedHashMap();
+        for (Map.Entry<ConfigKey<?>, Object> entry : raw.entrySet()) {
+            result.put(entry.getKey().getName(), transform(entry.getKey(), entry.getValue()));
+        }
+        return result;
+    }
+
+    /**
+     * Discouraged; returns the String so if it is external config, it will be the 
+     * {@code $brooklyn:external(...)} format.
+     */
+    @Override
+    @SuppressWarnings("rawtypes")
+    @Deprecated
+    public String get(Map flags, String key) {
+        return delegate.get(flags, key);
+    }
+
+    /**
+     * Discouraged; returns the String so if it is external config, it will be the 
+     * {@code $brooklyn:external(...)} format.
+     */
+    @Override
+    public String getFirst(String ...keys) {
+        return delegate.getFirst(keys);
+    }
+    
+    /**
+     * Discouraged; returns the String so if it is external config, it will be the 
+     * {@code $brooklyn:external(...)} format.
+     */
+    @Override
+    @SuppressWarnings("rawtypes")
+    public String getFirst(Map flags, String ...keys) {
+        return delegate.getFirst(flags, keys);
+    }
+
+    @Override
+    public BrooklynProperties submap(Predicate<ConfigKey<?>> filter) {
+        BrooklynProperties submap = delegate.submap(filter);
+        return new DeferredBrooklynProperties(submap, mgmt);
+    }
+
+    @Override
+    public BrooklynProperties addEnvironmentVars() {
+        delegate.addEnvironmentVars();
+        return this;
+    }
+
+    @Override
+    public BrooklynProperties addSystemProperties() {
+        delegate.addSystemProperties();
+        return this;
+    }
+
+    @Override
+    public BrooklynProperties addFrom(ConfigBag cfg) {
+        delegate.addFrom(cfg);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public BrooklynProperties addFrom(Map map) {
+        delegate.addFrom(map);
+        return this;
+    }
+
+    @Override
+    public BrooklynProperties addFrom(InputStream i) {
+        delegate.addFrom(i);
+        return this;
+    }
+    
+    @Override
+    public BrooklynProperties addFrom(File f) {
+        delegate.addFrom(f);
+        return this;
+    }
+    
+    @Override
+    public BrooklynProperties addFrom(URL u) {
+        delegate.addFrom(u);
+        return this;
+    }
+
+    @Override
+    public BrooklynProperties addFromUrl(String url) {
+        delegate.addFromUrl(url);
+        return this;
+    }
+
+    @Override
+    public BrooklynProperties addFromUrlProperty(String urlProperty) {
+        delegate.addFromUrlProperty(urlProperty);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public BrooklynProperties addFromMap(Map properties) {
+        delegate.addFromMap(properties);
+        return this;
+    }
+
+    @Override
+    public boolean putIfAbsent(String key, Object value) {
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    @Override
+    public Object put(Object key, Object value) {
+        return delegate.put(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void putAll(Map vals) {
+        delegate.putAll(vals);
+    }
+    
+    @Override
+    public <T> Object put(HasConfigKey<T> key, T value) {
+        return delegate.put(key, value);
+    }
+
+    @Override
+    public <T> Object put(ConfigKey<T> key, T value) {
+        return delegate.put(key, value);
+    }
+    
+    @Override
+    public <T> boolean putIfAbsent(ConfigKey<T> key, T value) {
+        return delegate.putIfAbsent(key, value);
+    }
+    
+    
+    //////////////////////////////////////////////////////////////////////////////////
+    // Methods below from java.util.LinkedHashMap, which BrooklynProperties extends //
+    //////////////////////////////////////////////////////////////////////////////////
+    
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public Object get(Object key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public Object remove(Object key) {
+        return delegate.remove(key);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Set keySet() {
+        return delegate.keySet();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Collection values() {
+        return delegate.values();
+    }
+    
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Set<Map.Entry> entrySet() {
+        return delegate.entrySet();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return delegate.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+    
+    // put(Object, Object) already overridden
+    //@Override
+    //public Object put(Object key, Object value) {
+
+    // putAll(Map) already overridden
+    //@Override
+    //public void putAll(Map m) {
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
@@ -380,7 +380,7 @@ public class LocalManagementContext extends AbstractManagementContext {
             log.warn("When reloading, mgmt context "+this+" properties are fixed, so reload will be of limited utility");
         
         BrooklynProperties properties = builder.build();
-        configMap = properties;
+        configMap = new DeferredBrooklynProperties(properties, this);
         if (brooklynAdditionalProperties != null) {
             log.info("Reloading additional brooklyn properties from " + brooklynAdditionalProperties);
             configMap.addFromMap(brooklynAdditionalProperties);

--- a/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
@@ -243,7 +243,7 @@ public class ByonLocationResolverTest {
     @Test
     public void testResolvesUserArg3() throws Exception {
         String spec = "byon(hosts=\"1.1.1.1\")";
-        managementContext.getLocationRegistry().getProperties().putAll(MutableMap.of(
+        ((BasicLocationRegistry)managementContext.getLocationRegistry()).putProperties(MutableMap.of(
                 "brooklyn.location.named.foo", spec,
                 "brooklyn.location.named.foo.user", "bob"));
         ((BasicLocationRegistry)managementContext.getLocationRegistry()).updateDefinedLocations();
@@ -267,7 +267,7 @@ public class ByonLocationResolverTest {
     /** private key should be inherited, so confirm that happens correctly */
     public void testResolvesPrivateKeyArgInheritance() throws Exception {
         String spec = "byon(hosts=\"1.1.1.1\")";
-        managementContext.getLocationRegistry().getProperties().putAll(MutableMap.of(
+        ((BasicLocationRegistry)managementContext.getLocationRegistry()).putProperties(MutableMap.of(
                 "brooklyn.location.named.foo", spec,
                 "brooklyn.location.named.foo.user", "bob",
                 "brooklyn.location.named.foo.privateKeyFile", "/tmp/x"));

--- a/docs/guide/ops/brooklyn_properties.md
+++ b/docs/guide/ops/brooklyn_properties.md
@@ -52,6 +52,28 @@ brooklyn.webconsole.security.https.required=true
 More information, including setting up a certificate, is described [further below](#https-configuration).
 
 
+## Camp YAML Expressions
+
+Values in `brooklyn.properties` can use the Camp YAML syntax. Any value starting `$brooklyn:` is 
+parsed as a Camp YAML expression.
+
+This allows [externalized configuration](externalized-configuration.html) to be used from 
+brooklyn.properties. For example:
+
+{% highlight properties %}
+brooklyn.location.jclouds.aws-ec2.identity=$brooklyn:external("vault", "aws-identity")
+brooklyn.location.jclouds.aws-ec2.credential=$brooklyn:external("vault", "aws-credential")
+{% endhighlight %}
+
+If for some reason one requires a literal value that really does start with `$brooklyn:` (i.e.
+for the value to not be parsed), then this can be achieved by using the syntax below. This 
+example returns the property value `$brooklyn:myexample`:
+
+{% highlight properties %}
+example.property=$brooklyn:literal("$brooklyn:myexample")
+{% endhighlight %}
+
+
 ## Locations
 
 Information on defining locations in the `brooklyn.properties` file is available [here](locations/).
@@ -83,6 +105,7 @@ brooklyn.webconsole.security.user.admin.sha256=91e16f94509fa8e3dd21c43d69cadfd7d
 The `users` line should contain a comma-separated list. The special value `*` is accepted to permit all users.
 
 To generate this, the brooklyn CLI can be used:
+
 {% highlight bash %}
 brooklyn generate-password --user admin
 

--- a/docs/guide/ops/externalized-configuration.md
+++ b/docs/guide/ops/externalized-configuration.md
@@ -111,6 +111,17 @@ brooklyn.config:
   example: $brooklyn:formatString("%s", external("supplier", "key"))
 {% endhighlight %}
 
+
+## Referring to External Configuration in brooklyn.properties
+
+The same blueprint language DSL can be used from `brooklyn.properties`. For example:
+
+{% highlight properties %}
+brooklyn.location.jclouds.aws-ec2.identity=$brooklyn:external("mysupplier", "aws-identity")
+brooklyn.location.jclouds.aws-ec2.credential=$brooklyn:external("mysupplier", "aws-credential")
+{% endhighlight %}
+
+
 ## Suppliers available with Brooklyn
 
 Brooklyn ships with a number of external configuration suppliers ready to use.

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/LocalBrooklynNodeImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/LocalBrooklynNodeImpl.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.entity.brooklynnode;
 
 import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.text.Strings;
 
 public class LocalBrooklynNodeImpl extends BrooklynNodeImpl implements LocalBrooklynNode {
@@ -29,7 +30,8 @@ public class LocalBrooklynNodeImpl extends BrooklynNodeImpl implements LocalBroo
     @Override
     protected void connectSensors() {
         // Override management username and password from brooklyn.properties
-        BrooklynProperties properties = (BrooklynProperties) getManagementContext().getConfig();
+        // TODO Why use BrooklynProperties, rather than StringConfigMap returned by mgmt.getConfig()?
+        BrooklynProperties properties = ((ManagementContextInternal)getManagementContext()).getBrooklynProperties();
         String user = (String) properties.get(String.format(LOCAL_BROOKLYN_NODE_KEY, "user"));
         String password = (String) properties.get(String.format(LOCAL_BROOKLYN_NODE_KEY, "password"));
         if (Strings.isBlank(password)) {

--- a/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/BrooklynCampPlatform.java
+++ b/usage/camp/src/main/java/org/apache/brooklyn/camp/brooklyn/BrooklynCampPlatform.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.camp.brooklyn.spi.platform.BrooklynImmutableCampPlatf
 import org.apache.brooklyn.camp.spi.PlatformRootSummary;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.HasBrooklynManagementContext;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 
 /** {@link CampPlatform} implementation which includes Brooklyn entities 
  * (via {@link BrooklynImmutableCampPlatform})
@@ -70,7 +71,8 @@ public class BrooklynCampPlatform extends AggregatingCampPlatform implements Has
     }
 
     public BrooklynCampPlatform setConfigKeyAtManagmentContext() {
-        ((BrooklynProperties)bmc.getConfig()).put(BrooklynCampConstants.CAMP_PLATFORM, this);
+        
+        ((ManagementContextInternal)bmc).getBrooklynProperties().put(BrooklynCampConstants.CAMP_PLATFORM, this);
         return this;
     }
 

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigBrooklynPropertiesTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigBrooklynPropertiesTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
+import org.apache.brooklyn.camp.brooklyn.ExternalConfigYamlTest.MyExternalConfigSupplier;
+import org.apache.brooklyn.camp.brooklyn.ExternalConfigYamlTest.MyExternalConfigSupplierWithoutMapArg;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.ConfigPredicates;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+@Test
+public class ExternalConfigBrooklynPropertiesTest extends AbstractYamlTest {
+
+    @Override
+    protected LocalManagementContext newTestManagementContext() {
+        BrooklynProperties props = BrooklynProperties.Factory.newEmpty();
+        props.put("brooklyn.external.myprovider", MyExternalConfigSupplier.class.getName());
+        props.put("brooklyn.external.myprovider.mykey", "myval");
+        props.put("brooklyn.external.myprovider.mykey2", "myval2");
+        props.put("brooklyn.external.myproviderWithoutMapArg", MyExternalConfigSupplierWithoutMapArg.class.getName());
+        props.put("myproperty", "$brooklyn:external(\"myprovider\", \"mykey\")");
+
+        return LocalManagementContextForTests.builder(true)
+                .useProperties(props)
+                .build();
+    }
+
+    // Yaml parsing support is more generic than just external-config.
+    // Test other parsing here, even though it's not directly related to external-config.
+    @Test
+    public void testYamlLiteralFromPropertiesInLocation() throws Exception {
+        ((ManagementContextInternal)mgmt()).getBrooklynProperties().put(
+                ConfigKeys.newStringConfigKey("myDynamicProperty"), "$brooklyn:literal(\"myliteral\")");
+        
+        String val = mgmt().getConfig().getConfig(ConfigKeys.newStringConfigKey("myDynamicProperty"));
+        assertEquals(val, "myliteral");
+    }
+
+    @Test
+    public void testInvalidYamlExpression() throws Exception {
+        ((ManagementContextInternal)mgmt()).getBrooklynProperties().put(
+                ConfigKeys.newStringConfigKey("myInvalidExternal"), "$brooklyn:external");
+        
+        try {
+            String val = mgmt().getConfig().getConfig(ConfigKeys.newStringConfigKey("myInvalidExternal"));
+            Asserts.shouldHaveFailedPreviously("val="+val);
+        } catch (IllegalArgumentException e) {
+            Asserts.expectedFailureContains(e, "Error evaluating node");
+        }
+    }
+
+    @Test
+    public void testExternalisedConfigFromPropertiesInLocation() throws Exception {
+        BrooklynProperties props = ((ManagementContextInternal)mgmt()).getBrooklynProperties();
+        props.put("brooklyn.location.jclouds.aws-ec2.identity", "$brooklyn:external(\"myprovider\", \"mykey\")");
+        props.put("brooklyn.location.jclouds.aws-ec2.credential", "$brooklyn:external(\"myprovider\", \"mykey2\")");
+        
+        JcloudsLocation loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve("jclouds:aws-ec2:us-east-1");
+        assertEquals(loc.getIdentity(), "myval");
+        assertEquals(loc.getCredential(), "myval2");
+    }
+
+    @Test
+    public void testExternalisedConfigInProperties() throws Exception {
+        runExternalisedConfigGetters("myproperty", "myval");
+    }
+    
+    @Test
+    public void testExternalisedConfigInAddedStringProperty() throws Exception {
+        ((ManagementContextInternal)mgmt()).getBrooklynProperties().put(
+                "myDynamicProperty", "$brooklyn:external(\"myprovider\", \"mykey\")");
+        runExternalisedConfigGetters("myDynamicProperty", "myval");
+    }
+    
+    @Test
+    public void testExternalisedConfigInAddedKeyProperty() throws Exception {
+        ((ManagementContextInternal)mgmt()).getBrooklynProperties().put(
+                ConfigKeys.newStringConfigKey("myDynamicProperty"), "$brooklyn:external(\"myprovider\", \"mykey\")");
+        runExternalisedConfigGetters("myDynamicProperty", "myval");
+    }
+    
+    @Test
+    public void testExternalisedConfigInAddedMapProperty() throws Exception {
+        ((ManagementContextInternal)mgmt()).getBrooklynProperties().addFromMap(
+                ImmutableMap.of("myDynamicProperty", "$brooklyn:external(\"myprovider\", \"mykey\")"));
+        runExternalisedConfigGetters("myDynamicProperty", "myval");
+    }
+
+    protected void runExternalisedConfigGetters(String property, String expectedVal) throws Exception {
+        runExternalisedConfigGetters(((ManagementContextInternal)mgmt()).getBrooklynProperties(), property, expectedVal, true);
+    }
+    
+    protected void runExternalisedConfigGetters(BrooklynProperties props, String property, String expectedVal, boolean testSubMap) throws Exception {
+        ExecutionContext exec = mgmt().getServerExecutionContext();
+
+        String val1 = props.getConfig(ConfigKeys.newStringConfigKey(property));
+        assertEquals(val1, expectedVal);
+        
+        DeferredSupplier<?> val2 = (DeferredSupplier<?>) props.getRawConfig(ConfigKeys.newStringConfigKey(property));
+        assertEquals(Tasks.resolveValue(val2, String.class, exec), expectedVal);
+        
+        DeferredSupplier<?> val3 = (DeferredSupplier<?>) props.getConfigRaw(ConfigKeys.newStringConfigKey(property), false).get();
+        assertEquals(Tasks.resolveValue(val3, String.class, exec), expectedVal);
+
+        DeferredSupplier<?> val4 = (DeferredSupplier<?>) props.getAllConfig().get(ConfigKeys.newStringConfigKey(property));
+        assertEquals(Tasks.resolveValue(val4, String.class, exec), expectedVal);
+        
+        String val5 = props.getFirst(property);
+        assertTrue(val5.startsWith("$brooklyn:external"), "val="+val5);
+        
+        if (testSubMap) {
+            BrooklynProperties submap = props.submap(ConfigPredicates.nameEqualTo(property));
+            runExternalisedConfigGetters(submap, property, expectedVal, false);
+        }
+    }
+}

--- a/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
+++ b/usage/camp/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
@@ -26,17 +26,22 @@ import java.util.Map;
 
 import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.external.AbstractExternalConfigSupplier;
 import org.apache.brooklyn.core.config.external.ExternalConfigSupplier;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.core.mgmt.internal.CampYamlParser;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +63,17 @@ public class ExternalConfigYamlTest extends AbstractYamlTest {
         return LocalManagementContextForTests.builder(true)
                 .useProperties(props)
                 .build();
+    }
+
+    @Test
+    public void testCampYamlParserHandlesExternalisedConfig() throws Exception {
+        CampYamlParser parser = mgmt().getConfig().getConfig(CampYamlParser.YAML_PARSER_KEY);
+        
+        DeferredSupplier<?> supplier = (DeferredSupplier<?>) parser.parse("$brooklyn:external(\"myprovider\", \"mykey\")");
+        
+        ExecutionContext exec = mgmt().getServerExecutionContext();
+        String result = Tasks.resolveValue(supplier, String.class, exec);
+        assertEquals(result, "myval");
     }
 
     @Test

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
 import org.apache.brooklyn.util.text.Strings;
 
@@ -115,7 +116,7 @@ public class DelegatingSecurityProvider implements SecurityProvider {
             delegate = new BlackholeSecurityProvider();
         }
         
-        ((BrooklynProperties)mgmt.getConfig()).put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, delegate);
+        ((ManagementContextInternal)mgmt).getBrooklynProperties().put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, delegate);
         
         return delegate;
     }

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
 import org.apache.brooklyn.rest.security.PasswordHasher;
 
@@ -91,7 +92,7 @@ public class ExplicitUsersSecurityProvider extends AbstractSecurityProvider impl
      * expect password (or SHA-256 + SALT thereof) defined as brooklyn properties.
      */
     public static boolean checkExplicitUserPassword(ManagementContext mgmt, String user, String password) {
-        BrooklynProperties properties = (BrooklynProperties) mgmt.getConfig();
+        BrooklynProperties properties = ((ManagementContextInternal)mgmt).getBrooklynProperties();
         String expectedPassword = properties.getConfig(BrooklynWebConfig.PASSWORD_FOR_USER(user));
         String salt = properties.getConfig(BrooklynWebConfig.SALT_FOR_USER(user));
         String expectedSha256 = properties.getConfig(BrooklynWebConfig.SHA256_FOR_USER(user));

--- a/usage/rest-server/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
+++ b/usage/rest-server/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
@@ -27,6 +27,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
 import org.apache.brooklyn.rest.util.OsgiCompat;
 import org.codehaus.jackson.Version;
@@ -106,7 +107,7 @@ public class BrooklynJacksonJsonProvider extends JacksonJsonProvider implements 
 
                 mapper = newPrivateObjectMapper(mgmt);
                 log.debug("Storing new ObjectMapper against "+mgmt+" because no ServletContext available: "+mapper);
-                ((BrooklynProperties)mgmt.getConfig()).put(key, mapper);
+                ((ManagementContextInternal)mgmt).getBrooklynProperties().put(key, mapper);
                 return mapper;
             }
         }


### PR DESCRIPTION
An alternative implementation to https://github.com/apache/incubator-brooklyn/pull/1018 (i.e. replaces that PR).