### PR TITLE
Rebind NPE fixes

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -136,7 +136,12 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
 
     /** A list of configuration options that the entity supports. */
     public final List<SpecParameter<?>> getParameters() {
-        return ImmutableList.copyOf(parameters);
+        //Could be null after rebind
+        if (parameters != null) {
+            return ImmutableList.copyOf(parameters);
+        } else {
+            return ImmutableList.of();
+        }
     }
 
     // TODO Duplicates method in BasicEntityTypeRegistry and InternalEntityFactory.isNewStyleEntity

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -217,7 +217,12 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     /** @see ConfigKey#getConstraint() */
     @Override @Nonnull
     public Predicate<? super T> getConstraint() {
-        return constraint;
+        // Could be null after rebinding
+        if (constraint != null) {
+            return constraint;
+        } else {
+            return Predicates.alwaysTrue();
+        }
     }
 
     /** @see ConfigKey#isValueValid(T) */


### PR DESCRIPTION
The logic in some of the places assumes that the field is always non-null, initialized in the constructor. The assumption is broken when rebinding from an old state, because constructors are not called.