### PR TITLE
Downstream-parent / OSGi

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -50,9 +50,9 @@ import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 
 public class CatalogUtils {
@@ -287,7 +287,7 @@ public class CatalogUtils {
     /** @deprecated since it was introduced in 0.9.0; TBD where this should live */
     public static void setDeprecated(ManagementContext mgmt, String symbolicNameAndOptionalVersion, boolean newValue) {
         RegisteredType item = mgmt.getTypeRegistry().get(symbolicNameAndOptionalVersion);
-        Preconditions.checkNotNull(item, "No such item: "+symbolicNameAndOptionalVersion);
+        Preconditions.checkNotNull(item, "No such item: " + symbolicNameAndOptionalVersion);
         setDeprecated(mgmt, item.getSymbolicName(), item.getVersion(), newValue);
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -24,9 +24,9 @@ import java.util.Set;
 
 import org.apache.brooklyn.util.core.config.ConfigBag;
 
-import com.google.api.client.util.Lists;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -34,7 +34,6 @@ import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
 import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
 import org.apache.brooklyn.core.catalog.internal.CatalogItemBuilder;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
-import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -42,7 +41,7 @@ import org.apache.brooklyn.util.text.Identifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.api.client.util.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
@@ -39,12 +39,12 @@ import org.apache.brooklyn.util.text.StringFunctions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.api.client.util.Lists;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
 @SuppressWarnings("serial")

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -929,7 +929,7 @@
                             </module>
                             <module name="TreeWalker">
                                 <module name="IllegalImport">
-                                    <property name="illegalPkgs" value="com.google.api.client.repackaged,org.python.google"/>
+                                    <property name="illegalPkgs" value="com.google.api.client,org.python.google"/>
                                 </module>
                             </module>
                         </module>

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WinRmMachineLocationLiveTest.java
@@ -35,7 +35,6 @@ import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
-import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
@@ -48,7 +47,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.api.client.util.Charsets;
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;

--- a/usage/downstream-parent/pom.xml
+++ b/usage/downstream-parent/pom.xml
@@ -447,16 +447,8 @@
                 <supportedProjectType>jar</supportedProjectType>
               </supportedProjectTypes>
               <instructions>
-                <!-- OSGi specific instruction -->
                 <!--
-                    By default packages containing impl and internal
-                    are not included in the export list. Setting an
-                    explicit wildcard will include all packages
-                    regardless of name.
-                    In time we should minimize our export lists to
-                    what is really needed.
                 -->
-                <Export-Package>brooklyn.*,org.apache.brooklyn.*</Export-Package>
                 <!-- Brooklyn-Feature prefix triggers inclusion of the project's metadata in the server's features list. -->
                 <Brooklyn-Feature-Name>${project.name}</Brooklyn-Feature-Name>
               </instructions>

--- a/usage/downstream-parent/pom.xml
+++ b/usage/downstream-parent/pom.xml
@@ -448,8 +448,29 @@
               </supportedProjectTypes>
               <instructions>
                 <!--
+                  Exclude packages used by Brooklyn that are not OSGi bundles. Including any
+                  of the below may cause bundles to fail to load into the catalogue with
+                  messages like "Unable to resolve 150.0: missing requirement [150.0]
+                  osgi.wiring.package; (osgi.wiring.package=com.maxmind.geoip2)".
                 -->
-                <!-- Brooklyn-Feature prefix triggers inclusion of the project's metadata in the server's features list. -->
+                <Import-Package>
+                  !com.maxmind.geoip2.*,
+                  !io.airlift.command.*,
+                  !io.cloudsoft.winrm4j.*,
+                  !javax.inject.*,
+                  !org.apache.felix.framework.*,
+                  !org.apache.http.*,
+                  !org.jclouds.googlecomputeengine.*,
+                  !org.osgi.jmx,
+                  !org.python.*,
+                  !org.reflections.*,
+                  !org.w3c.tidy.*,
+                  *
+                </Import-Package>
+                <!--
+                  Brooklyn-Feature prefix triggers inclusion of the project's metadata in the
+                  server's features list.
+                -->
                 <Brooklyn-Feature-Name>${project.name}</Brooklyn-Feature-Name>
               </instructions>
             </configuration>

--- a/usage/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
+++ b/usage/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
@@ -33,7 +33,6 @@ import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestApplicationImpl;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.launcher.BrooklynLauncher;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -61,9 +60,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 
-import com.google.api.client.util.Preconditions;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -339,7 +338,7 @@ public class BrooklynLauncherTest {
     }
 
     private BrooklynLauncher newLauncherForTests(boolean minimal) {
-        Preconditions.checkArgument(launcher==null, "can only be used if no launcher yet");
+        Preconditions.checkArgument(launcher == null, "can only be used if no launcher yet");
         BrooklynLauncher launcher = BrooklynLauncher.newInstance();
         if (minimal)
             launcher.brooklynProperties(LocalManagementContextForTests.builder(true).buildProperties());

--- a/usage/qa/pom.xml
+++ b/usage/qa/pom.xml
@@ -83,6 +83,12 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-verifier</artifactId>
+            <version>1.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -102,7 +108,16 @@
                         </execution>
                     </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes combine.children="append">
+                        <exclude>src/test/projects/downstream-parent-test/README</exclude>
+                    </excludes>
+                  </configuration>
+            </plugin>
         </plugins>
     </build> 
 </project>
-
+v

--- a/usage/qa/src/test/java/org/apache/brooklyn/qa/downstreamparent/DownstreamParentTest.java
+++ b/usage/qa/src/test/java/org/apache/brooklyn/qa/downstreamparent/DownstreamParentTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.qa.downstreamparent;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.brooklyn.util.net.Networking;
+import org.apache.maven.it.Verifier;
+import org.apache.maven.shared.utils.io.FileUtils;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class DownstreamParentTest {
+
+    private static final String PROJECTS_DIR = "src/test/projects";
+    private static final String WORK_DIR = "target/ut/";
+
+    /**
+     * Asserts that a trivial project using brooklyn-downstream-parent can be
+     * loaded into Brooklyn's catalogue and its entities deployed.
+     */
+    @Test(groups = "Integration")
+    public void testDownstreamProjectsCanBeLoadedIntoBrooklynCatalogByDefault() throws Exception {
+        int port = Networking.nextAvailablePort(57000);
+        File dir = getBasedir("downstream-parent-test");
+        Verifier verifier = new Verifier(dir.getAbsolutePath());
+        verifier.setMavenDebug(true);
+        verifier.executeGoal("post-integration-test", ImmutableMap.of(
+                "bindPort", String.valueOf(port)));
+        verifier.verifyErrorFreeLog();
+        verifier.verifyTextInLog("Hello from the init method of the HelloEntity");
+    }
+
+    /** Replicates the behaviour of getBasedir in JUnit's TestResources class */
+    public File getBasedir(String project) throws IOException {
+        File src = (new File(PROJECTS_DIR, project)).getCanonicalFile();
+        assertTrue(src.isDirectory(), "Test project directory does not exist: " + src.getPath());
+        File basedir = (new File(WORK_DIR, getClass().getSimpleName() + "_" + project)).getCanonicalFile();
+        FileUtils.deleteDirectory(basedir);
+        assertTrue(basedir.mkdirs(), "Test project working directory created");
+        FileUtils.copyDirectoryStructure(src, basedir);
+        return basedir;
+    }
+}

--- a/usage/qa/src/test/projects/downstream-parent-test/README
+++ b/usage/qa/src/test/projects/downstream-parent-test/README
@@ -1,0 +1,5 @@
+A successful build of this project (`mvn clean verify`) means that projects that
+use brooklyn-downstream-parent can be loaded into Brooklyn's catalogue by default.
+
+If the build fails there is almost certainly something wrong with the parent and
+the wider consumers of Brooklyn will probably face similar problems.

--- a/usage/qa/src/test/projects/downstream-parent-test/pom.xml
+++ b/usage/qa/src/test/projects/downstream-parent-test/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.brooklyn.downstream-parent-test</groupId>
+    <artifactId>catalogue-load-test</artifactId>
+    <version>0.9.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+    <packaging>jar</packaging>
+
+    <name>Downstream parent catalogue load test test</name>
+
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-downstream-parent</artifactId>
+        <version>0.9.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+    </parent>
+
+    <repositories>
+        <repository>
+            <id>apache-snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-all</artifactId>
+            <version>0.9.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>io.brooklyn.maven</groupId>
+                <artifactId>brooklyn-maven-plugin</artifactId>
+                <version>0.3.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>Run and deploy Brooklyn</id>
+                        <goals>
+                            <goal>start-server</goal>
+                        </goals>
+                        <configuration>
+                            <bindPort>${bindPort}</bindPort>
+                            <!--
+                            Make sure that the test entities aren't already on the classpath.
+                            -->
+                            <outputDirOnClasspath>false</outputDirOnClasspath>
+                            <arguments>
+                                <argument>--catalogInitial</argument>
+                                <argument>${project.build.outputDirectory}/catalog.bom</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>Deploy entity from catalogue</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <blueprint>${project.build.outputDirectory}/blueprint.yaml</blueprint>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>Stop Brooklyn</id>
+                        <goals>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/usage/qa/src/test/projects/downstream-parent-test/src/main/java/com/example/HelloEntity.java
+++ b/usage/qa/src/test/projects/downstream-parent-test/src/main/java/com/example/HelloEntity.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+
+@ImplementedBy(HelloEntityImpl.class)
+public interface HelloEntity extends Entity {
+}

--- a/usage/qa/src/test/projects/downstream-parent-test/src/main/java/com/example/HelloEntityImpl.java
+++ b/usage/qa/src/test/projects/downstream-parent-test/src/main/java/com/example/HelloEntityImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.example;
+
+import org.apache.brooklyn.core.entity.AbstractEntity;
+
+public class HelloEntityImpl extends AbstractEntity implements HelloEntity {
+
+    @Override
+    public void init() {
+        super.init();
+        System.out.println("Hello from the init method of the HelloEntity");
+    }
+
+}

--- a/usage/qa/src/test/projects/downstream-parent-test/src/main/resources/blueprint.yaml
+++ b/usage/qa/src/test/projects/downstream-parent-test/src/main/resources/blueprint.yaml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+services:
+- type: downstream-project

--- a/usage/qa/src/test/projects/downstream-parent-test/src/main/resources/catalog.bom
+++ b/usage/qa/src/test/projects/downstream-parent-test/src/main/resources/catalog.bom
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  version: 1.0
+
+  brooklyn.libraries:
+  - "file://${project.build.directory}/${project.build.finalName}.${project.packaging}"
+
+  items:
+
+  - id: downstream-project
+    name: Downstream project
+    itemType: template
+    description: |
+      A downstream project
+    item:
+      services:
+      - type: com.example.HelloEntity

--- a/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestSensorImpl.java
+++ b/usage/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestSensorImpl.java
@@ -18,7 +18,7 @@
  */
 package org.apache.brooklyn.test.framework;
 
-import com.google.api.client.util.Objects;
+import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
Removes the `Export-Package` manifest configuration from `brooklyn-downstream-parent` and adds a number of excludes of packages that are not bundles to `Import-Package`. 

Projects using downstream-parent can be loaded into catalogues via bundles by default. This can be tested by running `DownstreamParentTest` in the QA module.