### PR TITLE
Test correct persistence of attributeWhenReady

### DIFF
--- a/brooklyn-server/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/brooklyn-server/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -95,7 +95,6 @@ public class DslAndRebindYamlTest extends AbstractYamlTest {
 
     public Application rebind(Application app) throws Exception {
         RebindTestUtils.waitForPersisted(app);
-        // Removed because of issues in some tests: // RebindTestUtils.checkCurrentMementoSerializable(app);
         Application result = RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());
         mgmtContexts.add(result.getManagementContext());
         return result;


### PR DESCRIPTION
An entity with an instance of `attributeWhenReady` is serialised and then deserialised