### PR TITLE
RabbitMQ upgrade

### DIFF
--- a/brooklyn-library/software/messaging/src/main/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitBroker.java
+++ b/brooklyn-library/software/messaging/src/main/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitBroker.java
@@ -44,14 +44,19 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface RabbitBroker extends SoftwareProcess, MessageBroker, AmqpServer {
 
     @SetFromFlag("version")
-    public static final ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "2.8.7");
+    public static final ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "3.6.0");
 
     @SetFromFlag("downloadUrl")
     public static final BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new BasicAttributeSensorAndConfigKey<String>(
-            SoftwareProcess.DOWNLOAD_URL, "http://www.rabbitmq.com/releases/rabbitmq-server/v${version}/rabbitmq-server-generic-unix-${version}.tar.gz");
+            SoftwareProcess.DOWNLOAD_URL, "http://www.rabbitmq.com/releases/rabbitmq-server/v${version}/rabbitmq-server-generic-unix-${version}.tar.xz");
     
     @SetFromFlag("erlangVersion")
-    public static final BasicConfigKey<String> ERLANG_VERSION = new BasicConfigKey<String>(String.class, "erlang.version", "Erlang runtime version", "R15B");
+    public static final BasicConfigKey<String> ERLANG_VERSION = new BasicConfigKey<String>(String.class, "erlang.version", "Erlang runtime version", "18.2");
+
+    @SetFromFlag("erlangDebRepoUrl")
+    public static final BasicConfigKey<String> ERLANG_DEB_REPO_URL = new BasicConfigKey<String>(String.class, "erlang.deb.repo.url", 
+            "Deb file used to configure an external Erlang repository which provides up to date packages for Ubuntu/Debian", 
+            "http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb");
 
     @SetFromFlag("rabbitmqConfigTemplateUrl")
     ConfigKey<String> CONFIG_TEMPLATE_URL = ConfigKeys.newStringConfigKey(

--- a/brooklyn-library/software/messaging/src/main/resources/org/apache/brooklyn/entity/messaging/rabbit/rabbitmq.config
+++ b/brooklyn-library/software/messaging/src/main/resources/org/apache/brooklyn/entity/messaging/rabbit/rabbitmq.config
@@ -1,5 +1,6 @@
 [
 <#if entity.enableManagementPlugin>
+    {rabbit, [{loopback_users, []}]},
     {rabbitmq_mochiweb, [{listeners, [{mgmt, [{port, ${entity.managementPort?c}}]}]}]}
 </#if>
 ].


### PR DESCRIPTION
RabbitMQ to v.3.6.0
Erlang to v.18.2

RabbitMQ recommends Erlang 18. Release notes state:
Minimum required Erlang version is R16B03 for plain ("just TCP")
connections for all protocols 
and 17.5 for TLS ones (18.x is recommended for both).

The recommended provider for up to date Erlang versions is Erlang
Solutions now.
Supported platforms by Erlang Solutions are: CentOS, RHEL, Ubuntu and
Debian.

New Erlang versions for SUSE are provided via the openSUSE repositories