### PR TITLE
improvements to rest-api module

### DIFF
--- a/brooklyn-server/karaf/features/src/main/history/dependencies.xml
+++ b/brooklyn-server/karaf/features/src/main/history/dependencies.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" name="org.apache.brooklyn-0.9.0-SNAPSHOT">
+    <feature version="0.0.0">
+        <feature prerequisite="false" dependency="false">brooklyn-api</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-api</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-camp-base</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-camp-base</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-camp-base</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-camp-brooklyn</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-core</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-core</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-rest-api</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-utils-common</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-utils-common</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-utils-common</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-utils-common</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-utils-rest-swagger</feature>
+        <feature prerequisite="false" dependency="false">brooklyn-utils-rest-swagger</feature>
+        <feature prerequisite="false" dependency="false">jetty</feature>
+        <feature prerequisite="false" dependency="false">swagger-crippled</feature>
+        <feature prerequisite="false" dependency="false">war</feature>
+        <feature prerequisite="false" dependency="false">war</feature>
+        <bundle>mvn:ch.qos.logback/logback-classic/1.0.7</bundle>
+        <bundle>mvn:ch.qos.logback/logback-core/1.0.7</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.4.5</bundle>
+        <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.4.5</bundle>
+        <bundle>mvn:com.google.code.gson/gson/2.3</bundle>
+        <bundle>mvn:com.google.guava/guava/17.0</bundle>
+        <bundle>mvn:com.jayway.jsonpath/json-path/2.0.0</bundle>
+        <bundle>mvn:com.sun.jersey.contribs/jersey-multipart/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-core/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-core/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-server/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-server/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-servlet/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-servlet/1.19</bundle>
+        <bundle>mvn:com.sun.jersey/jersey-servlet/1.19</bundle>
+        <bundle>mvn:com.thoughtworks.xstream/xstream/1.4.7</bundle>
+        <bundle>mvn:commons-beanutils/commons-beanutils/1.9.1</bundle>
+        <bundle>mvn:commons-codec/commons-codec/1.9</bundle>
+        <bundle>mvn:commons-codec/commons-codec/1.9</bundle>
+        <bundle>mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle>mvn:commons-io/commons-io/2.4</bundle>
+        <bundle>mvn:commons-lang/commons-lang/2.4</bundle>
+        <bundle>mvn:io.swagger/swagger-annotations/1.5.3</bundle>
+        <bundle>mvn:io.swagger/swagger-models/1.5.3</bundle>
+        <bundle>mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+        <bundle>mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+        <bundle>mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
+        <bundle>mvn:net.minidev/asm/1.0.2</bundle>
+        <bundle>mvn:net.minidev/json-smart/2.1.1</bundle>
+        <bundle>mvn:net.schmizz/sshj/0.8.1</bundle>
+        <bundle>mvn:org.apache.brooklyn.camp/camp-base/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn.camp/camp-server/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-api/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-camp/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-commands/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-core/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-jsgui/0.9.0-SNAPSHOT/war</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-logback-includes/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-rest-api/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-rest-server/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-rt-osgi/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-utils-common/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-utils-common/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-utils-groovy/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-utils-rest-swagger/0.9.0-SNAPSHOT</bundle>
+        <bundle>mvn:org.apache.commons/commons-compress/1.4</bundle>
+        <bundle>mvn:org.apache.commons/commons-lang3/3.1</bundle>
+        <bundle>mvn:org.apache.commons/commons-lang3/3.1</bundle>
+        <bundle>mvn:org.apache.commons/commons-lang3/3.1</bundle>
+        <bundle>mvn:org.apache.commons/commons-lang3/3.1</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.4.1</bundle>
+        <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.1</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/1.1.3_2</bundle>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/0.9.9_1</bundle>
+        <bundle>mvn:org.bouncycastle/bcpkix-jdk15on/1.49</bundle>
+        <bundle>mvn:org.bouncycastle/bcprov-ext-jdk15on/1.49</bundle>
+        <bundle>mvn:org.codehaus.groovy/groovy-all/2.3.7</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.13</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.13</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.13</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-jaxrs/1.9.13</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.13</bundle>
+        <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.13</bundle>
+        <bundle>mvn:org.freemarker/freemarker/2.3.22</bundle>
+        <bundle>mvn:org.jvnet.mimepull/mimepull/1.9.3</bundle>
+        <bundle>mvn:org.slf4j/jul-to-slf4j/1.6.6</bundle>
+        <bundle>mvn:org.yaml/snakeyaml/1.11</bundle>
+        <bundle>wrap:mvn:com.google.http-client/google-http-client/1.18.0-rc</bundle>
+        <bundle>wrap:mvn:com.maxmind.geoip2/geoip2/0.8.1</bundle>
+        <bundle>wrap:mvn:javax.validation/validation-api/1.1.0.Final</bundle>
+        <bundle>wrap:mvn:org.tukaani/xz/1.4</bundle>
+        <bundle>wrap:mvn:xpp3/xpp3_min/1.1.4c</bundle>
+    </feature>
+</features>

--- a/brooklyn-server/rest/rest-api/pom.xml
+++ b/brooklyn-server/rest/rest-api/pom.xml
@@ -35,12 +35,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-api</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.sun.jersey.contribs</groupId>
@@ -51,18 +48,6 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
@@ -70,20 +55,21 @@
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.brooklyn</groupId>
-            <artifactId>brooklyn-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.brooklyn</groupId>
-            <artifactId>brooklyn-utils-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-utils-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -91,9 +77,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.brooklyn</groupId>
-            <artifactId>brooklyn-test-support</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.jackson.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
@@ -28,7 +28,11 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path("/v1/activities")

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -35,8 +35,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.codehaus.jackson.JsonNode;
-
 import org.apache.brooklyn.rest.domain.ApplicationSpec;
 import org.apache.brooklyn.rest.domain.ApplicationSummary;
 import org.apache.brooklyn.rest.domain.EntitySummary;
@@ -53,20 +51,11 @@ import io.swagger.annotations.ApiParam;
 public interface ApplicationApi {
 
     @GET
-    @Path("/tree")
-    @ApiOperation(
-            value = "Fetch applications and entities tree hierarchy"
-    )
-    /** @deprecated since 0.6.0 use {@link #fetch(String)} (with slightly different, but better semantics) */
-    @Deprecated
-    public JsonNode applicationTree();
-
-    @GET
     @Path("/fetch")
     @ApiOperation(
             value = "Fetch display details for all applications and optionally selected additional entities"
     )
-    public JsonNode fetch(
+    public List<EntitySummary> fetch(
             @ApiParam(value="Selected additional entity ID's to include, comma-separated", required=false)
             @DefaultValue("")
             @QueryParam("items") String items);

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LocationApi.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LocationApi.java
@@ -48,16 +48,6 @@ import io.swagger.annotations.ApiParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface LocationApi {
 
-    /**
-     * @deprecated since 0.7.0; use {@link CatalogApi#listLocations(String, String)}
-     */
-    @GET
-    @ApiOperation(value = "Fetch the list of location definitions",
-            response = org.apache.brooklyn.rest.domain.LocationSummary.class,
-            responseContainer = "List")
-    @Deprecated
-    public List<LocationSummary> list();
-
     // this is here to support the web GUI's circles
     @GET
     @Path("/usage/LocatedLocations")
@@ -88,14 +78,4 @@ public interface LocationApi {
             @ApiParam(name = "locationSpec", value = "Location specification object", required = true)
             @Valid LocationSpec locationSpec);
 
-    /**
-     * @deprecated since 0.7.0; use {@link CatalogApi#deleteLocation(String, String)}
-     */
-    @DELETE
-    @Path("/{locationId}")
-    @ApiOperation(value = "Deletes a location definition by id")
-    @Deprecated
-    public void delete(
-            @ApiParam(value = "Location id to delete", required = true)
-            @PathParam("locationId") String locationId);
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ScriptApi.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ScriptApi.java
@@ -37,9 +37,6 @@ import javax.ws.rs.core.MediaType;
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ScriptApi {
     
-    public static final String USER_DATA_MAP_SESSION_ATTRIBUTE = "brooklyn.script.groovy.user.data";
-    public static final String USER_LAST_VALUE_SESSION_ATTRIBUTE = "brooklyn.script.groovy.user.last";
-    
     @POST
     @Path("/groovy")
     @Consumes("application/text")

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -53,7 +53,7 @@ public interface ServerApi {
     public final String MIME_TYPE_ZIP = "application/zip";
     // TODO support TGZ, and check mime type
     public final String MIME_TYPE_TGZ = "application/gzip";
-    
+
     @POST
     @Path("/properties/reload")
     @ApiOperation(value = "Reload brooklyn.properties")
@@ -79,7 +79,7 @@ public interface ServerApi {
 
     @GET
     @Path("/version")
-    @ApiOperation(value = "Return version identifier information for this Brooklyn instance", 
+    @ApiOperation(value = "Return version identifier information for this Brooklyn instance",
             response = String.class,
             responseContainer = "List")
     public VersionSummary getVersion();
@@ -88,17 +88,17 @@ public interface ServerApi {
     @Path("/up")
     @ApiOperation(value = "Returns whether this server is up - fully started, and not stopping, though it may have errors")
     public boolean isUp();
-    
+
     @GET
     @Path("/shuttingDown")
     @ApiOperation(value = "Returns whether this server is shutting down")
     public boolean isShuttingDown();
-    
+
     @GET
     @Path("/healthy")
     @ApiOperation(value = "Returns whether this node is healthy - fully started, not stopping, and no errors")
     public boolean isHealthy();
-    
+
     @Deprecated /** @deprecated since 0.7.0 use /ha/node (which returns correct JSON) */
     @GET
     @Path("/status")
@@ -130,17 +130,17 @@ public interface ServerApi {
     @ApiOperation(value = "Returns the status of all Brooklyn instances in the management plane [DEPRECATED; see ../ha/states]",
             response = org.apache.brooklyn.rest.domain.HighAvailabilitySummary.class)
     public HighAvailabilitySummary getHighAvailability();
-    
+
     @GET
     @Path("/ha/state")
     @ApiOperation(value = "Returns the HA state of this management node")
     public ManagementNodeState getHighAvailabilityNodeState();
-    
+
     @GET
     @Path("/ha/metrics")
     @ApiOperation(value = "Returns a collection of HA metrics")
     public Map<String,Object> getHighAvailabilityMetrics();
-    
+
     @POST
     @Path("/ha/state")
     @ApiOperation(value = "Changes the HA state of this management node")
@@ -158,19 +158,19 @@ public interface ServerApi {
     @Path("/ha/states/clear")
     @ApiOperation(value = "Clears HA node information for non-master nodes; active nodes will repopulate and other records will be erased")
     public Response clearHighAvailabilityPlaneStates();
-    
+
     @GET
     @Path("/ha/priority")
     @ApiOperation(value = "Returns the HA node priority for MASTER failover")
     public long getHighAvailabitlityPriority();
-    
+
     @POST
     @Path("/ha/priority")
     @ApiOperation(value = "Sets the HA node priority for MASTER failover")
     public long setHighAvailabilityPriority(
             @ApiParam(name = "priority", value = "The priority to be set")
             @FormParam("priority") long priority);
-    
+
     @GET
     @Produces(MIME_TYPE_ZIP)
     @Path("/ha/persist/export")
@@ -198,9 +198,9 @@ public interface ServerApi {
 
     @GET
     @Path("/user")
-    @ApiOperation(value = "Return user information for this Brooklyn instance", 
+    @ApiOperation(value = "Return user information for this Brooklyn instance",
             response = String.class,
             responseContainer = "List")
-    public String getUser(); 
+    public String getUser();
 
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/AccessSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/AccessSummary.java
@@ -21,18 +21,17 @@ package org.apache.brooklyn.rest.domain;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
 @Beta
 public class AccessSummary implements Serializable {
 
     private static final long serialVersionUID = 5097292906225042890L;
-    
+
     private final boolean locationProvisioningAllowed;
     private final Map<String, URI> links;
 
@@ -51,17 +50,19 @@ public class AccessSummary implements Serializable {
     public Map<String, URI> getLinks() {
         return links;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof AccessSummary)) return false;
-        AccessSummary other = (AccessSummary) o;
-        return locationProvisioningAllowed == other.isLocationProvisioningAllowed();
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AccessSummary that = (AccessSummary) o;
+        return locationProvisioningAllowed == that.locationProvisioningAllowed &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(locationProvisioningAllowed);
+        return Objects.hash(locationProvisioningAllowed, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApiError.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApiError.java
@@ -21,17 +21,15 @@ package org.apache.brooklyn.rest.domain;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.brooklyn.util.text.Strings;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 
@@ -46,17 +44,11 @@ public class ApiError implements Serializable {
     public static ApiError of(Throwable t) {
         return builderFromThrowable(t).build();
     }
-    
+
     public static ApiError of(String message) {
         return builder().message(message).build();
     }
-    
-    /** @deprecated since 0.7.0; use {@link #builderFromThrowable(Throwable)} */
-    @Deprecated
-    public static Builder fromThrowable(Throwable t) {
-        return builderFromThrowable(t);
-    }
-    
+
     /**
      * @return An {@link ApiError.Builder} whose message is initialised to either the throwable's
      *         message or the throwable's class name if the message is null and whose details are
@@ -89,17 +81,17 @@ public class ApiError implements Serializable {
         public Builder errorCode(Status errorCode) {
             return errorCode(errorCode.getStatusCode());
         }
-        
+
         public Builder errorCode(Integer errorCode) {
             this.errorCode = errorCode;
             return this;
         }
-        
+
         /** as {@link #prefixMessage(String, String)} with default separator of `: ` */
         public Builder prefixMessage(String prefix) {
             return prefixMessage(prefix, ": ");
         }
-        
+
         /** puts a prefix in front of the message, with the given separator if there is already a message;
          * if there is no message, it simply sets the prefix as the message
          */
@@ -108,35 +100,27 @@ public class ApiError implements Serializable {
             else message(prefix+separatorIfMessageNotBlank+message);
             return this;
         }
-        
+
         public ApiError build() {
             return new ApiError(message, details, errorCode);
         }
 
-        /** @deprecated since 0.7.0; use {@link #copy(ApiError)} */
-        @Deprecated
-        public Builder fromApiError(ApiError error) {
-            return copy(error);
-        }
-        
         public Builder copy(ApiError error) {
             return this
                     .message(error.message)
                     .details(error.details)
                     .errorCode(error.error);
         }
-        
+
         public String getMessage() {
             return message;
         }
     }
 
     private final String message;
-    
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
+
     private final String details;
 
-    @JsonSerialize(include=Inclusion.NON_NULL)
     private final Integer error;
 
     public ApiError(String message) { this(message, null); }
@@ -146,7 +130,7 @@ public class ApiError implements Serializable {
             @JsonProperty("details") String details,
             @JsonProperty("error") Integer error) {
         this.message = checkNotNull(message, "message");
-        this.details = details != null ? details : "";
+        this.details = details;
         this.error = error;
     }
 
@@ -161,29 +145,29 @@ public class ApiError implements Serializable {
     public Integer getError() {
         return error;
     }
-    
+
     @Override
-    public boolean equals(Object other) {
-        if (this == other) return true;
-        if (other == null || getClass() != other.getClass()) return false;
-        ApiError that = ApiError.class.cast(other);
-        return Objects.equal(this.message, that.message) &&
-                Objects.equal(this.details, that.details) &&
-                Objects.equal(this.error, that.error);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiError apiError = (ApiError) o;
+        return Objects.equals(message, apiError.message) &&
+                Objects.equals(details, apiError.details) &&
+                Objects.equals(error, apiError.error);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(message, details, error);
+        return Objects.hash(message, details, error);
     }
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("message", message)
-                .add("details", details)
-                .add("error", error)
-                .toString();
+        return "ApiError{" +
+                "message='" + message + '\'' +
+                ", details='" + details + '\'' +
+                ", error=" + error +
+                '}';
     }
 
     public Response asBadRequestResponseJson() {
@@ -196,11 +180,11 @@ public class ApiError implements Serializable {
             .entity(this)
             .build();
     }
-    
+
     public Response asResponse(MediaType type) {
         return asResponse(null, type);
     }
-    
+
     public Response asJsonResponse() {
         return asResponse(MediaType.APPLICATION_JSON_TYPE);
     }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApplicationSpec.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApplicationSpec.java
@@ -24,12 +24,10 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -86,12 +84,9 @@ public class ApplicationSpec implements HasName, Serializable {
     }
 
     private final String name;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String type;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final Set<EntitySpec> entities;
     private final Set<String> locations;
-    @JsonSerialize(include = Inclusion.NON_EMPTY)
     private final Map<String, String> config;
 
   public ApplicationSpec(
@@ -110,7 +105,7 @@ public class ApplicationSpec implements HasName, Serializable {
       this.locations = ImmutableSet.copyOf(checkNotNull(locations, "locations must be provided for an application spec"));
       this.config = config == null ? Collections.<String, String>emptyMap() : ImmutableMap.<String, String>copyOf(config);
       if (this.entities!=null && this.type!=null) throw new IllegalStateException("cannot supply both type and entities for an application spec");
-      // valid for both to be null, e.g. for an anonymous type 
+      // valid for both to be null, e.g. for an anonymous type
 //      if (this.entities==null && this.type==null) throw new IllegalStateException("must supply either type or entities for an application spec");
   }
 
@@ -137,35 +132,19 @@ public class ApplicationSpec implements HasName, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         ApplicationSpec that = (ApplicationSpec) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (type != null ? !type.equals(that.type) : that.type != null)
-            return false;
-        if (entities != null ? !entities.equals(that.entities) : that.entities != null)
-            return false;
-        if (locations != null ? !locations.equals(that.locations) : that.locations != null)
-            return false;
-        if (config != null ? !config.equals(that.config) : that.config != null)
-            return false;
-
-        return true;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(entities, that.entities) &&
+                Objects.equals(locations, that.locations) &&
+                Objects.equals(config, that.config);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (entities != null ? entities.hashCode() : 0);
-        result = 31 * result + (locations != null ? locations.hashCode() : 0);
-        result = 31 * result + (config != null ? config.hashCode() : 0);
-        return result;
+        return Objects.hash(name, type, entities, locations, config);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApplicationSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApplicationSummary.java
@@ -23,9 +23,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class ApplicationSummary implements HasId, Serializable {
@@ -63,7 +63,7 @@ public class ApplicationSummary implements HasId, Serializable {
     public String getId() {
         return id;
     }
-    
+
     public ApplicationSpec getSpec() {
         return spec;
     }
@@ -88,21 +88,16 @@ public class ApplicationSummary implements HasId, Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         ApplicationSummary that = (ApplicationSummary) o;
-
-        if (spec != null ? !spec.equals(that.spec) : that.spec != null)
-            return false;
-        if (status != that.status) return false;
-
-        return true;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(spec, that.spec) &&
+                status == that.status &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        int result = spec != null ? spec.hashCode() : 0;
-        result = 31 * result + (status != null ? status.hashCode() : 0);
-        return result;
+        return Objects.hash(id, spec, status, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/BrooklynFeatureSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/BrooklynFeatureSummary.java
@@ -23,12 +23,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonAnyGetter;
-import org.codehaus.jackson.annotate.JsonAnySetter;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 
 public class BrooklynFeatureSummary implements Serializable {
@@ -88,4 +88,31 @@ public class BrooklynFeatureSummary implements Serializable {
         additionalData.put(name, value);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BrooklynFeatureSummary that = (BrooklynFeatureSummary) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(symbolicName, that.symbolicName) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(lastModified, that.lastModified) &&
+                Objects.equals(additionalData, that.additionalData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, symbolicName, version, lastModified, additionalData);
+    }
+
+    @Override
+    public String toString() {
+        return "BrooklynFeatureSummary{" +
+                "name='" + name + '\'' +
+                ", symbolicName='" + symbolicName + '\'' +
+                ", version='" + version + '\'' +
+                ", lastModified='" + lastModified + '\'' +
+                ", additionalData=" + additionalData +
+                '}';
+    }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogEntitySummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogEntitySummary.java
@@ -20,23 +20,19 @@ package org.apache.brooklyn.rest.domain;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CatalogEntitySummary extends CatalogItemSummary {
 
     private static final long serialVersionUID = 1063908984191424539L;
 
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final Set<EntityConfigSummary> config;
-    
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
+
     private final Set<SensorSummary> sensors;
 
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final Set<EffectorSummary> effectors;
 
     public CatalogEntitySummary(
@@ -48,8 +44,8 @@ public class CatalogEntitySummary extends CatalogItemSummary {
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
             @JsonProperty("tags") Set<Object> tags,
-            @JsonProperty("config") Set<EntityConfigSummary> config, 
-            @JsonProperty("sensors") Set<SensorSummary> sensors, 
+            @JsonProperty("config") Set<EntityConfigSummary> config,
+            @JsonProperty("sensors") Set<SensorSummary> sensors,
             @JsonProperty("effectors") Set<EffectorSummary> effectors,
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
@@ -63,21 +59,37 @@ public class CatalogEntitySummary extends CatalogItemSummary {
     public Set<EntityConfigSummary> getConfig() {
         return config;
     }
-    
+
     public Set<SensorSummary> getSensors() {
         return sensors;
     }
-    
+
     public Set<EffectorSummary> getEffectors() {
         return effectors;
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        CatalogEntitySummary that = (CatalogEntitySummary) o;
+        return Objects.equals(config, that.config) &&
+                Objects.equals(sensors, that.sensors) &&
+                Objects.equals(effectors, that.effectors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), config, sensors, effectors);
+    }
+
+    @Override
     public String toString() {
-        return super.toString()+"["+
-                "config="+getConfig()+"; " +
-                "sensors="+getSensors()+"; "+
-                "effectors="+getEffectors()+"; "+
-                "deprecated="+isDeprecated()+"]";
+        return "CatalogEntitySummary{" +
+                "config=" + config +
+                ", sensors=" + sensors +
+                ", effectors=" + effectors +
+                '}';
     }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogItemSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogItemSummary.java
@@ -23,15 +23,11 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -42,7 +38,7 @@ import com.google.common.collect.ImmutableMap;
 public class CatalogItemSummary implements HasId, HasName, Serializable {
 
     private static final long serialVersionUID = -823483595879417681L;
-    
+
     private final String id;
     private final String symbolicName;
     private final String version;
@@ -50,19 +46,16 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
     //needed for backwards compatibility only (json serializer works on fields, not getters)
     @Deprecated
     private final String type;
-    
+
     private final String javaType;
-    
+
     private final String name;
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final String description;
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final String iconUrl;
     private final String planYaml;
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
     private final List<Object> tags;
     private final boolean deprecated;
-    
+
     private final Map<String, URI> links;
 
     public CatalogItemSummary(
@@ -142,22 +135,44 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
     }
 
     @Override
-    public String toString() {
-        return Objects.toStringHelper(this)
-                .add("id", symbolicName)
-                .add("version", version)
-                .add("deprecated", deprecated)
-                .toString();
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CatalogItemSummary that = (CatalogItemSummary) o;
+        return deprecated == that.deprecated &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(symbolicName, that.symbolicName) &&
+                Objects.equals(version, that.version) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(javaType, that.javaType) &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(iconUrl, that.iconUrl) &&
+                Objects.equals(planYaml, that.planYaml) &&
+                Objects.equals(tags, that.tags) &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(symbolicName, version, name, javaType, tags, deprecated);
+        return Objects.hash(id, symbolicName, version, type, javaType, name, description, iconUrl, planYaml, tags, deprecated, links);
     }
-    
+
     @Override
-    public boolean equals(Object obj) {
-        return EqualsBuilder.reflectionEquals(this, obj);
+    public String toString() {
+        return "CatalogItemSummary{" +
+                "id='" + id + '\'' +
+                ", symbolicName='" + symbolicName + '\'' +
+                ", version='" + version + '\'' +
+                ", type='" + type + '\'' +
+                ", javaType='" + javaType + '\'' +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", iconUrl='" + iconUrl + '\'' +
+                ", planYaml='" + planYaml + '\'' +
+                ", tags=" + tags +
+                ", deprecated=" + deprecated +
+                ", links=" + links +
+                '}';
     }
-    
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogLocationSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogLocationSummary.java
@@ -20,16 +20,16 @@ package org.apache.brooklyn.rest.domain;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 
 public class CatalogLocationSummary extends CatalogItemSummary {
 
     private static final long serialVersionUID = 8420991584336514673L;
-    
+
     private final Set<LocationConfigSummary> config;
 
     public CatalogLocationSummary(
@@ -49,9 +49,23 @@ public class CatalogLocationSummary extends CatalogItemSummary {
         // TODO expose config from policies
         this.config = (config == null) ? ImmutableSet.<LocationConfigSummary>of() : config;
     }
-    
+
     public Set<LocationConfigSummary> getConfig() {
         return config;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        CatalogLocationSummary that = (CatalogLocationSummary) o;
+        return Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), config);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogPolicySummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogPolicySummary.java
@@ -20,19 +20,16 @@ package org.apache.brooklyn.rest.domain;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
 
 public class CatalogPolicySummary extends CatalogItemSummary {
 
     private static final long serialVersionUID = -588856488327394445L;
-    
-    @JsonSerialize(include=Inclusion.NON_EMPTY)
+
     private final Set<PolicyConfigSummary> config;
 
     public CatalogPolicySummary(
@@ -52,14 +49,29 @@ public class CatalogPolicySummary extends CatalogItemSummary {
         // TODO expose config from policies
         this.config = (config == null) ? ImmutableSet.<PolicyConfigSummary>of() : config;
     }
-    
+
     public Set<PolicyConfigSummary> getConfig() {
         return config;
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        CatalogPolicySummary that = (CatalogPolicySummary) o;
+        return Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), config);
+    }
+
+    @Override
     public String toString() {
-        return super.toString()+"["+
-                "config="+getConfig()+"]";
+        return "CatalogPolicySummary{" +
+                "config=" + config +
+                '}';
     }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ConfigSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ConfigSummary.java
@@ -23,15 +23,14 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.util.collections.Jsonya;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
@@ -39,20 +38,14 @@ import com.google.common.collect.ImmutableMap;
 public abstract class ConfigSummary implements HasName, Serializable {
 
     private static final long serialVersionUID = -2831796487073496730L;
-    
+
     private final String name;
     private final String type;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final Object defaultValue;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String description;
-    @JsonSerialize
     private final boolean reconfigurable;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String label;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final Double priority;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final List<Map<String, String>> possibleValues;
 
     protected ConfigSummary(
@@ -151,21 +144,33 @@ public abstract class ConfigSummary implements HasName, Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         ConfigSummary that = (ConfigSummary) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-
-        return true;
+        return reconfigurable == that.reconfigurable &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(defaultValue, that.defaultValue) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(label, that.label) &&
+                Objects.equals(priority, that.priority) &&
+                Objects.equals(possibleValues, that.possibleValues);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        return result;
+        return Objects.hash(name, type, defaultValue, description, reconfigurable, label, priority, possibleValues);
     }
 
     @Override
-    public abstract String toString();
+    public String toString() {
+        return "ConfigSummary{" +
+                "name='" + name + '\'' +
+                ", type='" + type + '\'' +
+                ", defaultValue=" + defaultValue +
+                ", description='" + description + '\'' +
+                ", reconfigurable=" + reconfigurable +
+                ", label='" + label + '\'' +
+                ", priority=" + priority +
+                ", possibleValues=" + possibleValues +
+                '}';
+    }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EffectorSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EffectorSummary.java
@@ -23,10 +23,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
@@ -36,10 +33,9 @@ public class EffectorSummary implements HasName, Serializable {
 
     public static class ParameterSummary<T> implements HasName, Serializable {
         private static final long serialVersionUID = -6393686096290306153L;
-        
+
         private final String name;
         private final String type;
-        @JsonSerialize(include = Inclusion.NON_NULL)
         private final String description;
         private final T defaultValue;
 
@@ -75,9 +71,9 @@ public class EffectorSummary implements HasName, Serializable {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-    
+
           ParameterSummary<?> that = (ParameterSummary<?>) o;
-    
+
           return Objects.equal(this.name, that.name)
                   && Objects.equal(this.type, that.type)
                   && Objects.equal(this.description, that.description)
@@ -104,9 +100,7 @@ public class EffectorSummary implements HasName, Serializable {
     private final String name;
     private final String returnType;
     private final Set<ParameterSummary<?>> parameters;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String description;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final Map<String, URI> links;
 
     public EffectorSummary(
@@ -147,31 +141,17 @@ public class EffectorSummary implements HasName, Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         EffectorSummary that = (EffectorSummary) o;
-
-        if (description != null ? !description.equals(that.description) : that.description != null)
-            return false;
-        if (links != null ? !links.equals(that.links) : that.links != null)
-            return false;
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null)
-            return false;
-        if (returnType != null ? !returnType.equals(that.returnType) : that.returnType != null)
-            return false;
-
-        return true;
+        return java.util.Objects.equals(name, that.name) &&
+                java.util.Objects.equals(returnType, that.returnType) &&
+                java.util.Objects.equals(parameters, that.parameters) &&
+                java.util.Objects.equals(description, that.description) &&
+                java.util.Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (returnType != null ? returnType.hashCode() : 0);
-        result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
-        result = 31 * result + (links != null ? links.hashCode() : 0);
-        return result;
+        return java.util.Objects.hash(name, returnType, parameters, description, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityConfigSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityConfigSummary.java
@@ -18,22 +18,20 @@
  */
 package org.apache.brooklyn.rest.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.brooklyn.config.ConfigKey;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class EntityConfigSummary extends ConfigSummary {
 
     private static final long serialVersionUID = -1336134336883426030L;
-    
-    @JsonSerialize(include = Inclusion.NON_NULL)
+
     private final Map<String, URI> links;
 
     public EntityConfigSummary(
@@ -58,6 +56,20 @@ public class EntityConfigSummary extends ConfigSummary {
     @Override
     public Map<String, URI> getLinks() {
         return links;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EntityConfigSummary that = (EntityConfigSummary) o;
+        return Objects.equals(links, that.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntitySpec.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntitySpec.java
@@ -20,18 +20,18 @@ package org.apache.brooklyn.rest.domain;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-
-import org.codehaus.jackson.annotate.JsonProperty;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 public class EntitySpec implements HasName, Serializable {
 
     private static final long serialVersionUID = -3882575609132757188L;
-    
+
     private final String name;
     private final String type;
     private final Map<String, String> config;
@@ -70,25 +70,15 @@ public class EntitySpec implements HasName, Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        EntitySpec entitySpec = (EntitySpec) o;
-
-        if (config != null ? !config.equals(entitySpec.config) : entitySpec.config != null)
-            return false;
-        if (name != null ? !name.equals(entitySpec.name) : entitySpec.name != null)
-            return false;
-        if (type != null ? !type.equals(entitySpec.type) : entitySpec.type != null)
-            return false;
-
-        return true;
+        EntitySpec that = (EntitySpec) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(config, that.config);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (config != null ? config.hashCode() : 0);
-        return result;
+        return Objects.hash(name, type, config);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntitySummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntitySummary.java
@@ -18,24 +18,21 @@
  */
 package org.apache.brooklyn.rest.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
-
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
 public class EntitySummary implements HasId, HasName, Serializable {
 
     private static final long serialVersionUID = 100490507982229165L;
-    
+
     private final String id;
     private final String name;
     private final String type;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String catalogItemId;
     private final Map<String, URI> links;
 
@@ -76,12 +73,19 @@ public class EntitySummary implements HasId, HasName, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof EntitySummary) && id.equals(((EntitySummary) o).getId());
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EntitySummary that = (EntitySummary) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(catalogItemId, that.catalogItemId) &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        return id != null ? id.hashCode() : 0;
+        return Objects.hash(id, name, type, catalogItemId, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/HighAvailabilitySummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/HighAvailabilitySummary.java
@@ -21,10 +21,9 @@ package org.apache.brooklyn.rest.domain;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class HighAvailabilitySummary implements Serializable {
@@ -33,13 +32,13 @@ public class HighAvailabilitySummary implements Serializable {
 
     public static class HaNodeSummary implements Serializable {
         private static final long serialVersionUID = 9205960988226816539L;
-        
+
         private final String nodeId;
         private final URI nodeUri;
         private final String status;
         private final Long localTimestamp;
         private final Long remoteTimestamp;
-        
+
         public HaNodeSummary(
                 @JsonProperty("nodeId") String nodeId,
                 @JsonProperty("nodeUri") URI nodeUri,
@@ -75,12 +74,19 @@ public class HighAvailabilitySummary implements Serializable {
 
         @Override
         public boolean equals(Object o) {
-            return (o instanceof HaNodeSummary) && Objects.equal(nodeId, ((HaNodeSummary) o).getNodeId());
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            HaNodeSummary that = (HaNodeSummary) o;
+            return Objects.equals(nodeId, that.nodeId) &&
+                    Objects.equals(nodeUri, that.nodeUri) &&
+                    Objects.equals(status, that.status) &&
+                    Objects.equals(localTimestamp, that.localTimestamp) &&
+                    Objects.equals(remoteTimestamp, that.remoteTimestamp);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(nodeId);
+            return Objects.hash(nodeId, nodeUri, status, localTimestamp, remoteTimestamp);
         }
 
         @Override
@@ -126,19 +132,34 @@ public class HighAvailabilitySummary implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        return (o instanceof HighAvailabilitySummary) && ownId.equals(((HighAvailabilitySummary) o).getOwnId());
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HighAvailabilitySummary that = (HighAvailabilitySummary) o;
+
+        if (ownId != null ? !ownId.equals(that.ownId) : that.ownId != null) return false;
+        if (masterId != null ? !masterId.equals(that.masterId) : that.masterId != null) return false;
+        if (nodes != null ? !nodes.equals(that.nodes) : that.nodes != null) return false;
+        return links != null ? links.equals(that.links) : that.links == null;
+
     }
 
     @Override
     public int hashCode() {
-        return ownId != null ? ownId.hashCode() : 0;
+        int result = ownId != null ? ownId.hashCode() : 0;
+        result = 31 * result + (masterId != null ? masterId.hashCode() : 0);
+        result = 31 * result + (nodes != null ? nodes.hashCode() : 0);
+        result = 31 * result + (links != null ? links.hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
-        return "HighAvailabilitySummary{"
-                + "ownId='" + ownId + '\''
-                + ", links=" + links
-                + '}';
+        return "HighAvailabilitySummary{" +
+                "ownId='" + ownId + '\'' +
+                ", masterId='" + masterId + '\'' +
+                ", nodes=" + nodes +
+                ", links=" + links +
+                '}';
     }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LinkWithMetadata.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LinkWithMetadata.java
@@ -20,11 +20,11 @@ package org.apache.brooklyn.rest.domain;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 
@@ -34,55 +34,44 @@ public class LinkWithMetadata implements Serializable {
     // TODO remove 'metadata' and promote its contents to be top-level fields; then unmark as Beta
 
     private static final long serialVersionUID = 3146368899471495143L;
-    
+
     private final String link;
     private final Map<String,Object> metadata;
-    
+
     public LinkWithMetadata(
-            @JsonProperty("link") String link, 
+            @JsonProperty("link") String link,
             @Nullable @JsonProperty("metadata") Map<String,?> metadata) {
         this.link = link;
         this.metadata = (metadata == null) ? ImmutableMap.<String,Object>of() : ImmutableMap.<String,Object>copyOf(metadata);
     }
-    
+
     public String getLink() {
         return link;
     }
-    
+
     public Map<String, Object> getMetadata() {
         return metadata;
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((link == null) ? 0 : link.hashCode());
-        result = prime * result + ((metadata == null) ? 0 : metadata.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LinkWithMetadata that = (LinkWithMetadata) o;
+        return Objects.equals(link, that.link) &&
+                Objects.equals(metadata, that.metadata);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LinkWithMetadata other = (LinkWithMetadata) obj;
-        if (link == null) {
-            if (other.link != null)
-                return false;
-        } else if (!link.equals(other.link))
-            return false;
-        if (metadata == null) {
-            if (other.metadata != null)
-                return false;
-        } else if (!metadata.equals(other.metadata))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(link, metadata);
     }
 
-    
+    @Override
+    public String toString() {
+        return "LinkWithMetadata{" +
+                "link='" + link + '\'' +
+                ", metadata=" + metadata +
+                '}';
+    }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationConfigSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationConfigSummary.java
@@ -21,18 +21,15 @@ package org.apache.brooklyn.rest.domain;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class LocationConfigSummary extends ConfigSummary {
 
     private static final long serialVersionUID = 2232321501735217002L;
-    
-    @JsonSerialize(include = Inclusion.NON_NULL)
+
     private final Map<String, URI> links;
 
     public LocationConfigSummary(
@@ -55,10 +52,23 @@ public class LocationConfigSummary extends ConfigSummary {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        LocationConfigSummary that = (LocationConfigSummary) o;
+        return Objects.equals(links, that.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), links);
+    }
+
+    @Override
     public String toString() {
-        return "LocationConfigSummary{"
-                + "name='" + getName() + '\''
-                + ", type='" + getType() + '\''
-                + '}';
+        return "LocationConfigSummary{" +
+                "links=" + links +
+                '}';
     }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSpec.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSpec.java
@@ -21,14 +21,11 @@ package org.apache.brooklyn.rest.domain;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 // FIXME change name, due to confusion with LocationSpec <- no need, as we can kill the class instead soon!
@@ -36,13 +33,9 @@ import com.google.common.collect.ImmutableMap;
 public class LocationSpec implements HasName, HasConfig, Serializable {
 
     private static final long serialVersionUID = -1562824224808185255L;
-    
-    @JsonSerialize(include = Inclusion.NON_NULL)
-    private final String name;
-    @JsonSerialize(include = Inclusion.NON_NULL)
-    private final String spec;
 
-    @JsonSerialize(include = Inclusion.NON_EMPTY)
+    private final String name;
+    private final String spec;
     private final Map<String, ?> config;
 
     public static LocationSpec localhost() {
@@ -75,14 +68,15 @@ public class LocationSpec implements HasName, HasConfig, Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         LocationSpec that = (LocationSpec) o;
-        return Objects.equal(name, that.name) && Objects.equal(spec, that.spec) && Objects.equal(config, that.config);
+        return Objects.equals(name, that.name) &&
+                Objects.equals(spec, that.spec) &&
+                Objects.equals(config, that.config);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(spec, name, config);
+        return Objects.hash(name, spec, config);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSummary.java
@@ -22,14 +22,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class LocationSummary extends LocationSpec implements HasName, HasId {
@@ -39,7 +36,6 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
     private final String id;
 
     /** only intended for instantiated Locations, not definitions */
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String type;
     private final Map<String, URI> links;
 
@@ -71,14 +67,18 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         LocationSummary that = (LocationSummary) o;
-        return Objects.equal(id, that.id);
+        return Objects.equals(id, that.id) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id, links);
+        return Objects.hash(super.hashCode(), id, type, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/PolicyConfigSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/PolicyConfigSummary.java
@@ -20,18 +20,15 @@ package org.apache.brooklyn.rest.domain;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class PolicyConfigSummary extends ConfigSummary {
 
     private static final long serialVersionUID = 4339330833863794513L;
-    
-    @JsonSerialize(include = Inclusion.NON_NULL)
+
     private final Map<String, URI> links;
 
     public PolicyConfigSummary(
@@ -48,6 +45,20 @@ public class PolicyConfigSummary extends ConfigSummary {
     @Override
     public Map<String, URI> getLinks() {
         return links;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        PolicyConfigSummary that = (PolicyConfigSummary) o;
+        return Objects.equals(links, that.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/PolicySummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/PolicySummary.java
@@ -21,20 +21,17 @@ package org.apache.brooklyn.rest.domain;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class PolicySummary implements HasName, HasId, Serializable {
 
     private static final long serialVersionUID = -5086680835225136768L;
-    
+
     private final String id;
     private final String name;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String catalogItemId;
     private final Status state;
     private final Map<String, URI> links;
@@ -77,23 +74,18 @@ public class PolicySummary implements HasName, HasId, Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (!(o instanceof PolicySummary)) return false;
         PolicySummary that = (PolicySummary) o;
-
-        if (id != null ? !id.equals(that.id) : that.id != null)
-            return false;
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-
-        return true;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(catalogItemId, that.catalogItemId) &&
+                state == that.state &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        return result;
+        return Objects.hash(id, name, catalogItemId, state, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ScriptExecutionSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ScriptExecutionSummary.java
@@ -19,28 +19,23 @@
 package org.apache.brooklyn.rest.domain;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ScriptExecutionSummary implements Serializable {
 
     private static final long serialVersionUID = -7707936602991185960L;
-    
-    @JsonSerialize(include = Inclusion.NON_NULL)
+
     private final Object result;
-    @JsonSerialize(include = Inclusion.NON_EMPTY)
     private final String problem;
-    @JsonSerialize(include = Inclusion.NON_EMPTY)
     private final String stdout;
-    @JsonSerialize(include = Inclusion.NON_EMPTY)
     private final String stderr;
 
     public ScriptExecutionSummary(
-            @JsonProperty("result") Object result, 
-            @JsonProperty("problem") String problem, 
-            @JsonProperty("stdout") String stdout, 
+            @JsonProperty("result") Object result,
+            @JsonProperty("problem") String problem,
+            @JsonProperty("stdout") String stdout,
             @JsonProperty("stderr") String stderr) {
         super();
         this.result = result;
@@ -63,5 +58,31 @@ public class ScriptExecutionSummary implements Serializable {
 
     public String getStdout() {
         return stdout;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ScriptExecutionSummary)) return false;
+        ScriptExecutionSummary that = (ScriptExecutionSummary) o;
+        return Objects.equals(result, that.result) &&
+                Objects.equals(problem, that.problem) &&
+                Objects.equals(stdout, that.stdout) &&
+                Objects.equals(stderr, that.stderr);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(result, problem, stdout, stderr);
+    }
+
+    @Override
+    public String toString() {
+        return "ScriptExecutionSummary{" +
+                "result=" + result +
+                ", problem='" + problem + '\'' +
+                ", stdout='" + stdout + '\'' +
+                ", stderr='" + stderr + '\'' +
+                '}';
     }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/SensorSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/SensorSummary.java
@@ -21,22 +21,18 @@ package org.apache.brooklyn.rest.domain;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 public class SensorSummary implements HasName, Serializable {
 
     private static final long serialVersionUID = 1154308408351165426L;
-    
+
     private final String name;
     private final String type;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String description;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final Map<String, URI> links;
 
     public SensorSummary(
@@ -70,29 +66,17 @@ public class SensorSummary implements HasName, Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+        if (!(o instanceof SensorSummary)) return false;
         SensorSummary that = (SensorSummary) o;
-
-        if (description != null ? !description.equals(that.description) : that.description != null)
-            return false;
-        if (links != null ? !links.equals(that.links) : that.links != null)
-            return false;
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (type != null ? !type.equals(that.type) : that.type != null)
-            return false;
-
-        return true;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (links != null ? links.hashCode() : 0);
-        return result;
+        return Objects.hash(name, type, description, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/SummaryComparators.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/SummaryComparators.java
@@ -20,61 +20,23 @@ package org.apache.brooklyn.rest.domain;
 
 import java.util.Comparator;
 
-import javax.annotation.Nonnull;
-
-import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.util.text.NaturalOrderComparator;
-import org.apache.brooklyn.util.text.Strings;
 
 /**
  * Useful comparators for domain objects
  */
 public class SummaryComparators {
-    
-    private SummaryComparators() {}
-    
+
+    private SummaryComparators() {
+    }
+
     private static NaturalOrderComparator COMPARATOR = new NaturalOrderComparator();
-    
-    @Nonnull
-    static String getDisplayNameOrName(HasName o1) {
-        String n1 = null;
-        if (o1 instanceof BrooklynObject)
-            n1 = ((BrooklynObject)o1).getDisplayName();
-        if (Strings.isEmpty(n1) && o1 instanceof HasConfig && ((HasConfig)o1).getConfig()!=null)
-            n1 = Strings.toString(((HasConfig)o1).getConfig().get("displayName"));
-        // prefer display name if set
-        if (Strings.isEmpty(n1))
-            n1 = o1.getName();
-        if (n1==null) {
-            // put last
-            return "~~~";
-        }
-        return n1;
-    }
-    
-    public static Comparator<HasName> displayNameComparator() {
-        return new Comparator<HasName>() {
-            @Override
-            public int compare(HasName o1, HasName o2) {
-                return COMPARATOR.compare(getDisplayNameOrName(o1).toLowerCase(), getDisplayNameOrName(o2).toLowerCase());
-            }
-        };
-    }
 
     public static Comparator<HasName> nameComparator() {
         return new Comparator<HasName>() {
             @Override
             public int compare(HasName o1, HasName o2) {
                 return COMPARATOR.compare(o1.getName(), o2.getName());
-            }
-        };
-    }
-
-    public static Comparator<HasId> idComparator() {
-        return new Comparator<HasId>() {
-            @Override
-            public int compare(HasId o1, HasId o2) {
-                return o1.getId().compareTo(o2.getId());
             }
         };
     }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/TaskSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/TaskSummary.java
@@ -24,21 +24,20 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.brooklyn.util.collections.Jsonya;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 public class TaskSummary implements HasId, Serializable {
 
     private static final long serialVersionUID = 4637850742127078158L;
-    
+
     private final String id;
     private final String displayName;
     private final String entityId;
@@ -58,32 +57,29 @@ public class TaskSummary implements HasId, Serializable {
     private final List<LinkWithMetadata> children;
     private final LinkWithMetadata submittedByTask;
 
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final LinkWithMetadata blockingTask;
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final String blockingDetails;
 
     private final String detailedStatus;
 
-    @JsonSerialize(include = Inclusion.NON_NULL)
     private final Map<String, LinkWithMetadata> streams;
 
     private final Map<String, URI> links;
 
     public TaskSummary(
-            @JsonProperty("id") String id, 
-            @JsonProperty("displayName") String displayName, 
-            @JsonProperty("description") String description, 
-            @JsonProperty("entityId") String entityId, 
-            @JsonProperty("entityDisplayName") String entityDisplayName, 
+            @JsonProperty("id") String id,
+            @JsonProperty("displayName") String displayName,
+            @JsonProperty("description") String description,
+            @JsonProperty("entityId") String entityId,
+            @JsonProperty("entityDisplayName") String entityDisplayName,
             @JsonProperty("tags") Set<Object> tags,
-            @JsonProperty("submitTimeUtc") Long submitTimeUtc, 
-            @JsonProperty("startTimeUtc") Long startTimeUtc, 
-            @JsonProperty("endTimeUtc") Long endTimeUtc, 
-            @JsonProperty("currentStatus") String currentStatus, 
-            @JsonProperty("result") Object result, 
-            @JsonProperty("isError") boolean isError, 
-            @JsonProperty("isCancelled") boolean isCancelled, 
+            @JsonProperty("submitTimeUtc") Long submitTimeUtc,
+            @JsonProperty("startTimeUtc") Long startTimeUtc,
+            @JsonProperty("endTimeUtc") Long endTimeUtc,
+            @JsonProperty("currentStatus") String currentStatus,
+            @JsonProperty("result") Object result,
+            @JsonProperty("isError") boolean isError,
+            @JsonProperty("isCancelled") boolean isCancelled,
             @JsonProperty("children") List<LinkWithMetadata> children,
             @JsonProperty("submittedByTask") LinkWithMetadata submittedByTask,
             @JsonProperty("blockingTask") LinkWithMetadata blockingTask,
@@ -168,20 +164,6 @@ public class TaskSummary implements HasId, Serializable {
         return result;
     }
 
-    /** @deprecated since 0.7.0 use {@link #isError} instead. */
-    @Deprecated
-    @JsonIgnore
-    public boolean getIsError() {
-        return isError;
-    }
-
-    /** @deprecated since 0.7.0 use {@link #isCancelled} instead. */
-    @Deprecated
-    @JsonIgnore
-    public boolean getIsCancelled() {
-        return isCancelled;
-    }
-
     public boolean isError() {
         return isError;
     }
@@ -216,6 +198,38 @@ public class TaskSummary implements HasId, Serializable {
 
     public Map<String, URI> getLinks() {
         return links;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TaskSummary)) return false;
+        TaskSummary that = (TaskSummary) o;
+        return isError == that.isError &&
+                isCancelled == that.isCancelled &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(displayName, that.displayName) &&
+                Objects.equals(entityId, that.entityId) &&
+                Objects.equals(entityDisplayName, that.entityDisplayName) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(tags, that.tags) &&
+                Objects.equals(submitTimeUtc, that.submitTimeUtc) &&
+                Objects.equals(startTimeUtc, that.startTimeUtc) &&
+                Objects.equals(endTimeUtc, that.endTimeUtc) &&
+                Objects.equals(currentStatus, that.currentStatus) &&
+                Objects.equals(result, that.result) &&
+                Objects.equals(children, that.children) &&
+                Objects.equals(submittedByTask, that.submittedByTask) &&
+                Objects.equals(blockingTask, that.blockingTask) &&
+                Objects.equals(blockingDetails, that.blockingDetails) &&
+                Objects.equals(detailedStatus, that.detailedStatus) &&
+                Objects.equals(streams, that.streams) &&
+                Objects.equals(links, that.links);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, displayName, entityId, entityDisplayName, description, tags, submitTimeUtc, startTimeUtc, endTimeUtc, currentStatus, result, isError, isCancelled, children, submittedByTask, blockingTask, blockingDetails, detailedStatus, streams, links);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/UsageStatistic.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/UsageStatistic.java
@@ -22,19 +22,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Adam Lowe
  */
 public class UsageStatistic implements HasId, Serializable {
-    
+
     private static final long serialVersionUID = 5701414937003064442L;
-    
+
     private final Status status;
     private final String id;
     private final String applicationId;
@@ -44,12 +43,12 @@ public class UsageStatistic implements HasId, Serializable {
     private final Map<String,String> metadata;
 
     public UsageStatistic(
-            @JsonProperty("status") Status status, 
-            @JsonProperty("id") String id, 
+            @JsonProperty("status") Status status,
+            @JsonProperty("id") String id,
             @JsonProperty("applicationId") String applicationId,
             @JsonProperty("start") String start,
             @JsonProperty("end") String end,
-            @JsonProperty("duration") long duration, 
+            @JsonProperty("duration") long duration,
             @JsonProperty("metadata") Map<String, String> metadata) {
         this.status = checkNotNull(status, "status");
         this.id = checkNotNull(id, "id");
@@ -92,20 +91,20 @@ public class UsageStatistic implements HasId, Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UsageStatistic statistic = (UsageStatistic) o;
-
-        return Objects.equal(status, statistic.status) &&
-                Objects.equal(id, statistic.id) &&
-                Objects.equal(applicationId, statistic.applicationId) &&
-                Objects.equal(start, statistic.start) &&
-                Objects.equal(end, statistic.end) &&
-                Objects.equal(metadata, statistic.metadata);
+        if (!(o instanceof UsageStatistic)) return false;
+        UsageStatistic that = (UsageStatistic) o;
+        return duration == that.duration &&
+                status == that.status &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(applicationId, that.applicationId) &&
+                Objects.equals(start, that.start) &&
+                Objects.equals(end, that.end) &&
+                Objects.equals(metadata, that.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(status, id, applicationId, start, end, metadata);
+        return Objects.hash(status, id, applicationId, start, end, duration, metadata);
     }
 
     @Override

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/UsageStatistics.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/UsageStatistics.java
@@ -22,20 +22,16 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import com.google.common.base.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-/**
- * @author Aled Sage
- */
 public class UsageStatistics implements Serializable {
 
     private static final long serialVersionUID = -1842301852728290967L;
-    
+
     // TODO populate links with /apps endpoint to link to /usage/applications/{id}, to make it more
     // RESTy
 
@@ -58,19 +54,23 @@ public class UsageStatistics implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof UsageStatistics))
-            return false;
-        UsageStatistics other = (UsageStatistics) o;
-        return Objects.equal(statistics, other.statistics);
+        if (this == o) return true;
+        if (!(o instanceof UsageStatistics)) return false;
+        UsageStatistics that = (UsageStatistics) o;
+        return Objects.equals(statistics, that.statistics) &&
+                Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(statistics);
+        return Objects.hash(statistics, links);
     }
 
     @Override
     public String toString() {
-        return "UsageStatistics{" + "statistics=" + statistics + ", links=" + links + '}';
+        return "UsageStatistics{" +
+                "statistics=" + statistics +
+                ", links=" + links +
+                '}';
     }
 }

--- a/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/VersionSummary.java
+++ b/brooklyn-server/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/VersionSummary.java
@@ -18,21 +18,22 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class VersionSummary implements Serializable {
 
     private static final long serialVersionUID = 7275038546963638540L;
-    
+
     private final String version;
     private final String buildSha1;
     private final String buildBranch;
@@ -77,4 +78,29 @@ public class VersionSummary implements Serializable {
         return features;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VersionSummary)) return false;
+        VersionSummary that = (VersionSummary) o;
+        return Objects.equals(version, that.version) &&
+                Objects.equals(buildSha1, that.buildSha1) &&
+                Objects.equals(buildBranch, that.buildBranch) &&
+                Objects.equals(features, that.features);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, buildSha1, buildBranch, features);
+    }
+
+    @Override
+    public String toString() {
+        return "VersionSummary{" +
+                "version='" + version + '\'' +
+                ", buildSha1='" + buildSha1 + '\'' +
+                ", buildBranch='" + buildBranch + '\'' +
+                ", features=" + features +
+                '}';
+    }
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/AbstractDomainTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/AbstractDomainTest.java
@@ -18,41 +18,27 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-
 import java.io.IOException;
 
 import org.testng.annotations.Test;
 
-@Deprecated
-public class LocationSpecTest {
+import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
+import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
+import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
+import static org.testng.Assert.assertEquals;
 
-    // TODO when removing the deprecated class this tests, change the tests here to point at LocationSummary
-    
-    final LocationSpec locationSpec = LocationSpec.localhost();
+public abstract class AbstractDomainTest {
+
+    protected abstract String getPath();
+    protected abstract Object getDomainObject();
 
     @Test
     public void testSerializeToJSON() throws IOException {
-        assertEquals(asJson(locationSpec), jsonFixture("fixtures/location.json"));
+        assertEquals(asJson(getDomainObject()), jsonFixture(getPath()));
     }
 
     @Test
     public void testDeserializeFromJSON() throws IOException {
-        assertEquals(fromJson(jsonFixture("fixtures/location.json"), LocationSpec.class), locationSpec);
-    }
-
-    @Test
-    public void testDeserializeFromJSONWithNoCredential() throws IOException {
-        LocationSpec loaded = fromJson(jsonFixture("fixtures/location-without-credential.json"), LocationSpec.class);
-
-        assertEquals(loaded.getSpec(), locationSpec.getSpec());
-
-        assertEquals(loaded.getConfig().size(), 1);
-        assertEquals(loaded.getConfig().get("identity"), "bob");
-        assertNull(loaded.getConfig().get("credential"));
+        assertEquals(fromJson(jsonFixture(getPath()), getDomainObject().getClass()), getDomainObject());
     }
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/ApiErrorTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/ApiErrorTest.java
@@ -25,19 +25,27 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 import java.io.IOException;
+import java.net.URI;
 
 import org.testng.annotations.Test;
 import org.testng.util.Strings;
 
-public class ApiErrorTest {
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
-    @Test
-    public void testSerializeApiError() throws IOException {
-        ApiError error = ApiError.builder()
+public class ApiErrorTest extends AbstractDomainTest {
+
+    @Override
+    protected String getPath() {
+        return "fixtures/api-error-basic.json";
+    }
+
+    @Override
+    protected Object getDomainObject() {
+        return ApiError.builder()
                 .message("explanatory message")
                 .details("accompanying details")
                 .build();
-        assertEquals(asJson(error), jsonFixture("fixtures/api-error-basic.json"));
     }
 
     @Test

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/ApplicationSpecTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/ApplicationSpecTest.java
@@ -18,36 +18,23 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
-import static org.testng.Assert.assertEquals;
-
-import java.io.IOException;
-
-import org.testng.annotations.Test;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class ApplicationSpecTest {
+public class ApplicationSpecTest extends AbstractDomainTest {
 
-    final EntitySpec entitySpec = new EntitySpec("Vanilla Java App", "org.apache.brooklyn.entity.java.VanillaJavaApp",
-            ImmutableMap.<String, String>of(
-                    "initialSize", "1",
-                    "creationScriptUrl", "http://my.brooklyn.io/storage/foo.sql"));
-
-    final ApplicationSpec applicationSpec = ApplicationSpec.builder().name("myapp")
-            .entities(ImmutableSet.of(entitySpec)).locations(ImmutableSet.of("/v1/locations/1"))
-            .build();
-
-    @Test
-    public void testSerializeToJSON() throws IOException {
-        assertEquals(asJson(applicationSpec), jsonFixture("fixtures/application-spec.json"));
+    @Override
+    protected String getPath() {
+        return "fixtures/application-spec.json";
     }
 
-    @Test
-    public void testDeserializeFromJSON() throws IOException {
-        assertEquals(fromJson(jsonFixture("fixtures/application-spec.json"), ApplicationSpec.class), applicationSpec);
+    @Override
+    protected Object getDomainObject() {
+        EntitySpec entitySpec = new EntitySpec("Vanilla Java App", "org.apache.brooklyn.entity.java.VanillaJavaApp",
+                ImmutableMap.of("initialSize", "1", "creationScriptUrl", "http://my.brooklyn.io/storage/foo.sql"));
+        return ApplicationSpec.builder().name("myapp")
+                .entities(ImmutableSet.of(entitySpec)).locations(ImmutableSet.of("/v1/locations/1"))
+                .build();
     }
+
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/EffectorSummaryTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/EffectorSummaryTest.java
@@ -18,36 +18,27 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
-import static org.testng.Assert.assertEquals;
-
-import java.io.IOException;
 import java.net.URI;
-
-import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class EffectorSummaryTest {
+public class EffectorSummaryTest extends AbstractDomainTest {
 
-    final EffectorSummary effectorSummary = new EffectorSummary(
-            "stop",
-            "void",
-            ImmutableSet.<EffectorSummary.ParameterSummary<?>>of(),
-            "Effector description",
-            ImmutableMap.of(
-                    "self", URI.create("/v1/applications/redis-app/entities/redis-ent/effectors/stop")));
-
-    @Test
-    public void testSerializeToJSON() throws IOException {
-        assertEquals(asJson(effectorSummary), jsonFixture("fixtures/effector-summary.json"));
+    @Override
+    protected String getPath() {
+        return "fixtures/effector-summary.json";
     }
 
-    @Test
-    public void testDeserializeFromJSON() throws IOException {
-        assertEquals(fromJson(jsonFixture("fixtures/effector-summary.json"), EffectorSummary.class), effectorSummary);
+    @Override
+    protected Object getDomainObject() {
+        return new EffectorSummary(
+                "stop",
+                "void",
+                ImmutableSet.<EffectorSummary.ParameterSummary<?>>of(),
+                "Effector description",
+                ImmutableMap.of(
+                        "self", URI.create("/v1/applications/redis-app/entities/redis-ent/effectors/stop")));
     }
+
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/EntitySpecTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/EntitySpecTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
 import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
 import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
 import static org.testng.Assert.assertEquals;
@@ -27,24 +26,23 @@ import java.io.IOException;
 
 import org.testng.annotations.Test;
 
-public class EntitySpecTest {
+public class EntitySpecTest extends AbstractDomainTest {
 
-    final EntitySpec entitySpec = new EntitySpec("Vanilla Java App", "org.apache.brooklyn.entity.java.VanillaJavaApp");
-
-    @Test
-    public void testSerializeToJSON() throws IOException {
-        assertEquals(asJson(new EntitySpec[] { entitySpec }), jsonFixture("fixtures/entity.json"));
+    @Override
+    protected String getPath() {
+        return "fixtures/entity.json";
     }
 
-    @Test
-    public void testDeserializeFromJSON() throws IOException {
-        assertEquals(fromJson(jsonFixture("fixtures/entity.json"), EntitySpec[].class), new EntitySpec[] { entitySpec });
+    @Override
+    protected Object getDomainObject() {
+        EntitySpec entitySpec = new EntitySpec("Vanilla Java App", "org.apache.brooklyn.entity.java.VanillaJavaApp");
+        return new EntitySpec[] { entitySpec };
     }
 
     @Test
     public void testDeserializeFromJSONOnlyWithType() throws IOException {
         EntitySpec actual = fromJson(jsonFixture("fixtures/entity-only-type.json"), EntitySpec.class);
-        assertEquals(actual.getName(), actual.getType());
+        assertEquals(actual.getType(), "org.apache.brooklyn.entity.java.VanillaJavaApp");
         assertEquals(actual.getConfig().size(), 0);
     }
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/EntitySummaryTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/EntitySummaryTest.java
@@ -18,24 +18,21 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
-import static org.testng.Assert.assertEquals;
-
-import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 
-import org.testng.annotations.Test;
-
 import com.google.common.collect.Maps;
 
-public class EntitySummaryTest {
+public class EntitySummaryTest extends AbstractDomainTest {
 
-    static final Map<String, URI> links;
-    static {
-        links = Maps.newLinkedHashMap();
+    @Override
+    protected String getPath() {
+        return "fixtures/entity-summary.json";
+    }
+
+    @Override
+    protected Object getDomainObject() {
+        Map<String, URI> links = Maps.newLinkedHashMap();
         links.put("self", URI.create("/v1/applications/tesr/entities/zQsqdXzi"));
         links.put("catalog", URI.create("/v1/catalog/entities/org.apache.brooklyn.entity.webapp.tomcat.TomcatServer"));
         links.put("application", URI.create("/v1/applications/tesr"));
@@ -43,19 +40,9 @@ public class EntitySummaryTest {
         links.put("effectors", URI.create("fixtures/effector-summary-list.json"));
         links.put("sensors", URI.create("fixtures/sensor-summary-list.json"));
         links.put("activities", URI.create("fixtures/task-summary-list.json"));
-    }
 
-    static final EntitySummary entitySummary = new EntitySummary("zQsqdXzi", "MyTomcat",
-            "org.apache.brooklyn.entity.webapp.tomcat.TomcatServer", null, links);
-
-    @Test
-    public void testSerializeToJSON() throws IOException {
-        assertEquals(asJson(entitySummary), jsonFixture("fixtures/entity-summary.json"));
-    }
-
-    @Test
-    public void testDeserializeFromJSON() throws IOException {
-        assertEquals(fromJson(jsonFixture("fixtures/entity-summary.json"), EntitySummary.class), entitySummary);
+        return new EntitySummary("zQsqdXzi", "MyTomcat",
+                "org.apache.brooklyn.entity.webapp.tomcat.TomcatServer", null, links);
     }
 
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/LocationSummaryTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/LocationSummaryTest.java
@@ -16,28 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.rest.api;
+package org.apache.brooklyn.rest.domain;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import java.net.URI;
+import java.util.Map;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import com.google.common.collect.Maps;
 
-@Path("/v1/version")
-@Api("Version")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
-/** @deprecated since 0.7.0; use /v1/server/version */
-@Deprecated
-public interface VersionApi {
+public class LocationSummaryTest extends AbstractDomainTest {
 
-  @GET
-  @ApiOperation(value = "Return version identifier information for this Brooklyn instance; deprecated, use /server/version", 
-          response = String.class,
-          responseContainer = "List")
-  public String getVersion();
+    @Override
+    protected String getPath() {
+        return "fixtures/location-summary.json";
+    }
+
+    @Override
+    protected Object getDomainObject() {
+        Map<String, URI> links = Maps.newLinkedHashMap();
+        links.put("self", URI.create("/v1/locations/123"));
+
+        return new LocationSummary("123", "localhost", "localhost", null, null, links);
+    }
+
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/VersionSummaryTest.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/VersionSummaryTest.java
@@ -19,44 +19,31 @@
 
 package org.apache.brooklyn.rest.domain;
 
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.asJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.fromJson;
-import static org.apache.brooklyn.rest.util.RestApiTestUtils.jsonFixture;
-import static org.testng.Assert.assertEquals;
-
-import org.testng.annotations.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-public class VersionSummaryTest {
+public class VersionSummaryTest  extends AbstractDomainTest {
 
-    BrooklynFeatureSummary features = new BrooklynFeatureSummary(
-            "Sample Brooklyn Project com.acme.sample:brooklyn-sample v0.1.0-SNAPSHOT",
-            "com.acme.sample.brooklyn-sample",
-            "0.1.0.SNAPSHOT",
-            "523305000",
-            ImmutableMap.of("Brooklyn-Feature-Build-Id", "e0fee1adf795c84eec4735f039503eb18d9c35cc")
-    );
-    VersionSummary summary = new VersionSummary(
-            "0.7.0-SNAPSHOT",
-            "cb4f0a3af2f5042222dd176edc102bfa64e7e0b5",
-            "versions",
-            ImmutableList.of(features)
-    );
-
-    @Test
-    public void testSerialize() {
-        assertEquals(asJson(summary), jsonFixture("fixtures/server-version.json"));
+    @Override
+    protected String getPath() {
+        return "fixtures/server-version.json";
     }
 
-    @Test
-    public void testDeserialize() {
-        VersionSummary deserialized = fromJson(jsonFixture("fixtures/server-version.json"), VersionSummary.class);
-        assertEquals(deserialized.getBuildSha1(), summary.getBuildSha1());
-        assertEquals(deserialized.getFeatures().size(), 1);
-        assertEquals(deserialized.getFeatures().get(0).getSymbolicName(), features.getSymbolicName());
-        assertEquals(deserialized.getFeatures().get(0).getAdditionalData().get("Brooklyn-Feature-Build-Id"), "e0fee1adf795c84eec4735f039503eb18d9c35cc");
+    @Override
+    protected Object getDomainObject() {
+        BrooklynFeatureSummary features = new BrooklynFeatureSummary(
+                "Sample Brooklyn Project com.acme.sample:brooklyn-sample v0.1.0-SNAPSHOT",
+                "com.acme.sample.brooklyn-sample",
+                "0.1.0.SNAPSHOT",
+                "523305000",
+                ImmutableMap.of("Brooklyn-Feature-Build-Id", "e0fee1adf795c84eec4735f039503eb18d9c35cc")
+        );
+        return new VersionSummary(
+                "0.7.0-SNAPSHOT",
+                "cb4f0a3af2f5042222dd176edc102bfa64e7e0b5",
+                "versions",
+                ImmutableList.of(features)
+        );
     }
 
 }

--- a/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/util/RestApiTestUtils.java
+++ b/brooklyn-server/rest/rest-api/src/test/java/org/apache/brooklyn/rest/util/RestApiTestUtils.java
@@ -22,8 +22,10 @@ import java.io.InputStream;
 
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.stream.Streams;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RestApiTestUtils {
 
@@ -36,7 +38,9 @@ public class RestApiTestUtils {
     }
     public static String asJson(Object x) {
         try {
-            return new ObjectMapper().writeValueAsString(x);
+            return new ObjectMapper()
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    .writeValueAsString(x);
         } catch (Exception e) {
             throw Exceptions.propagate(e);
         }

--- a/brooklyn-server/rest/rest-api/src/test/resources/fixtures/application-spec.json
+++ b/brooklyn-server/rest/rest-api/src/test/resources/fixtures/application-spec.json
@@ -13,4 +13,5 @@
     "locations":[
         "/v1/locations/1"
     ]
+    ,"config":{}
 }

--- a/brooklyn-server/rest/rest-api/src/test/resources/fixtures/location-summary.json
+++ b/brooklyn-server/rest/rest-api/src/test/resources/fixtures/location-summary.json
@@ -1,8 +1,9 @@
 {
-    "id":"123",
-    "name":"localhost",
-    "spec":"localhost",
-    "links":{
-        "self":"/v1/locations/123"
-    }
+  "id": "123",
+  "name": "localhost",
+  "spec": "localhost",
+  "config": {},
+  "links": {
+    "self": "/v1/locations/123"
+  }
 }


### PR DESCRIPTION
Initial work to simplify the rest server:

- remove `JsonNode` from API interfaces
- refactor consistently `toString`and `hashCode` and `equals` for the domain objects
- remove deprecated code, although LocationSpec needs still some work
- simplified pom dependencies

Interestingly, with these changes, the `swagger.json`, obtained from the Swagger Annotation, can be used to generate automatically a java client  using something like [that](https://github.com/swagger-api/swagger-codegen#to-generate-a-sample-client-library)

@sjcorbett could you have a look?