### PR TITLE
BROOKLYN-213 Fix localhost external IP loader

### DIFF
--- a/brooklyn-server/core/src/main/resources/org/apache/brooklyn/location/geo/external-ip-address-resolvers.txt
+++ b/brooklyn-server/core/src/main/resources/org/apache/brooklyn/location/geo/external-ip-address-resolvers.txt
@@ -18,7 +18,6 @@
 http://jsonip.com/
 http://myip.dnsomatic.com/
 http://checkip.dyndns.org/
-http://www.telize.com/ip
 http://wtfismyip.com/text
 http://whatismyip.akamai.com/
 http://myip.wampdeveloper.com/


### PR DESCRIPTION
Remove shutdown IP address lookup service from list of resolvers.
Block the lookup methods until either all providers have been checked or the IP address has been resolved.

https://issues.apache.org/jira/browse/BROOKLYN-213