### PR TITLE
Expose BrooklynFeatureEnablement.setDefault

### DIFF
--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
@@ -186,7 +186,7 @@ public class BrooklynFeatureEnablement {
         }
     }
     
-    static void setDefault(String property, boolean val) {
+    public static void setDefault(String property, boolean val) {
         synchronized (MUTEX) {
             if (!FEATURE_ENABLEMENTS.containsKey(property)) {
                 String rawVal = System.getProperty(property);


### PR DESCRIPTION
I want the activation of [brooklyn-tosca](https://github.com/cloudsoft/brooklyn-tosca/) to be configurable and to be enabled by default. At the moment any property beginning `brooklyn.experimental.feature` that is not defined in `BrooklynFeatureEnablement` defaults to `false` (because `Boolean.parseBoolean(null) == false`). This change allows downstream projects to explicitly configure defaults.