### PR TITLE
fix bash web cluster template in default catalog

### DIFF
--- a/brooklyn-server/server-cli/src/main/resources/brooklyn/default.catalog.bom
+++ b/brooklyn-server/server-cli/src/main/resources/brooklyn/default.catalog.bom
@@ -1,4 +1,3 @@
-
 # this catalog bom is an illustration supplying a few useful sample items
 # and templates to get started using Brooklyn
 
@@ -153,14 +152,20 @@ brooklyn.catalog:
               - "http://%s:%s/" 
               - $brooklyn:attributeWhenReady("host.subnet.hostname")
               - $brooklyn:config("my.app.port")
-      
-      location:
-        jclouds:aws-ec2:
-          region:       eu-central-1
-          # edit these (or delete if credentials specified in brooklyn.properties)      
-          identity:     <REPLACE>
-          credential:   <REPLACE>
-        
+
+      # Uncomment and update the following location with your desired location
+      # for example AWS, Softlayer, Bring-your-own-node etc.
+      # This example location is commented out as this template is called from
+      # 4-resilient-bash-web-cluster-template and we do not want a placeholder
+      # location present with invalid values.
+
+      #location:
+      #  jclouds:aws-ec2:
+      #    region:       eu-central-1
+      #    # edit these (or delete if credentials specified in brooklyn.properties)
+      #    identity:     <REPLACE>
+      #    credential:   <REPLACE>
+
   - id: 3-bash-web-and-riak-template
     itemType: template
     name: "Template 3: Bash Web Server and Scaling Riak Cluster"

--- a/brooklyn-server/server-cli/src/main/resources/brooklyn/default.catalog.bom
+++ b/brooklyn-server/server-cli/src/main/resources/brooklyn/default.catalog.bom
@@ -88,9 +88,11 @@ brooklyn.catalog:
       
       # this example builds on the previous one, 
       # adding some scripts to initialize the VM
+      # and a basic enricher to populate a sensor with
       
       services:
       - type:           vanilla-bash-server
+        id:             bash-web-server
         name:           My Bash Web Server VM
         brooklyn.config:
           install.command: |
@@ -138,7 +140,16 @@ brooklyn.catalog:
           # custom 
           my.app.port:  8020
           my.message:   "good to meet you"
-        
+
+        brooklyn.initializers:
+        # make a simple request-count sensor, by counting the number of 200 responses in output.txt
+        - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
+          brooklyn.config:
+            name: reqs.count
+            targetType: int
+            period: 5s
+            command: "cat output.txt | grep HTTP | grep 200 | wc | awk '{print $1}'"
+
         brooklyn.enrichers:
         # publish the URL as a sensor; the GUI will pick this up (main.uri)
         - type: org.apache.brooklyn.enricher.stock.Transformer
@@ -250,24 +261,18 @@ brooklyn.catalog:
                 my.message:   "part of the cluster"
               
               brooklyn.initializers:
-              # make a simple request-count sensor, by counting the number of 200 responses in output.txt
-              - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
-                brooklyn.config:
-                  name: reqs.count
-                  targetType: int
-                  period: 5s
-                  command: "cat output.txt | grep HTTP | grep 200 | wc | awk '{print $1}'"
-              # and publish the port as a sensor so the load-balancer can pick it up
+              # publish the port as a sensor so the load-balancer can pick it up
               - type:           org.apache.brooklyn.core.sensor.StaticSensor
                 brooklyn.config:
                   name:         app.port
                   targetType:   int
-                  static.value: $brooklyn:config("my.app.port")
+                  static.value: $brooklyn:component("bash-web-server").config("my.app.port")
               
               brooklyn.enrichers:
               # derive reqs.per_sec from reqs.count
               - type: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
                 brooklyn.config:
+                  enricher.producer: $brooklyn:entity("bash-web-server")
                   enricher.sourceSensor: reqs.count
                   enricher.targetSensor: reqs.per_sec
                   enricher.delta.period: 1s
@@ -277,6 +282,13 @@ brooklyn.catalog:
                   enricher.sourceSensor: reqs.per_sec
                   enricher.targetSensor: reqs.per_sec.windowed_30s
                   enricher.window.duration: 30s
+              # propagate the host.subnet.hostname from the bash-web-server up to the BasicApplication level
+              - type: org.apache.brooklyn.enricher.stock.Propagator
+                brooklyn.config:
+                  uniqueTag:    host.subnet.hostname
+                  producer:     $brooklyn:entity("bash-web-server")
+                  propagating:
+                  - host.subnet.hostname
               
               # emit failure sensor if a failure connecting to the service is sustained for 30s
               - type: org.apache.brooklyn.policy.ha.ServiceFailureDetector
@@ -327,8 +339,9 @@ brooklyn.catalog:
             resizeUpStabilizationDelay: 2s
             # only scale down when sustained for 1m
             resizeDownStabilizationDelay: 1m
-      
-            maxPoolSize: 10
+
+            # do not scale beyond 3 nodes
+            maxPoolSize: 3
             
       # and add a load-balancer pointing at the cluster
       - type:           load-balancer
@@ -337,6 +350,9 @@ brooklyn.catalog:
           # point this load balancer at the cluster, specifying port to forward to
           loadbalancer.serverpool:  $brooklyn:entity("my-web-cluster")
           member.sensor.portNumber: app.port
+          # disable sticky sessions, round-robin balancing can be observed by
+          # refreshing the balancer url in a browser
+          nginx.sticky: false
       
       brooklyn.enrichers:
       # publish a few useful info sensors and KPI's to the root of the app


### PR DESCRIPTION
the template `4-resilient-bash-web-cluster-template` did not deploy successfully in either `0.8.0-incubating` or `0.9.0-SNAPSHOT` (not checked earlier releases), the following problems are encountered if you try to deploy:

- the cluster member Bash Web Server instances fail to deploy as they try to use the placeholder location defined in the `2-bash-web-server-template` catalog entry. Have commented out the location in template 2.

The observed result for the next two points were that the balancer would never have any Bash Web Server instances added to `proxy.serverpool.targets` and you would just get 404s when browsing to the balancer endpoint.

- the `app.port` sensor isn't populated as its trying to create a sensor on the `BasicApplication` while the config exists on the `VanillaSoftwareProcess`.
Added an id `bash-web-server` to the `vanilla-bash-server` in template 2 to allow us to address the config when creating the `my-app` StaticSensor.

- the balancer is unable to populate `member.sensor.hostname` as its attempting to pull `host.subnet.hostname` from the  `BasicApplication` while this sensor is on the `VanillaSoftwareProcess`. Added a `Propagator`.

- moved the `SshCommandSensor` to template 2 so that it could access the `output.txt` and added `enricher.producer` to the `YamlTimeWeightedDeltaEnricher` so it could pull from the `VanillaSoftwareProcess` (id `bash-web-server`)
- minor usability tweaks turning off sticky session and reducing the `maxPoolSize`

Would appreciate someone having a look at the changes here, as its quite a change in the structure of the template app and may be indicative of issues elsewhere?

**Not** resolved - the `my.message` config in template 4 is not overriding that set in template 2.
