### PR TITLE
YAML: don’t wrap sub-entities in BasicApplication

### DIFF
--- a/brooklyn-server/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynAssemblyTemplateInstantiator.java
+++ b/brooklyn-server/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynAssemblyTemplateInstantiator.java
@@ -40,6 +40,7 @@ import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 public class BrooklynAssemblyTemplateInstantiator implements AssemblyTemplateSpecInstantiator {
@@ -89,6 +90,16 @@ public class BrooklynAssemblyTemplateInstantiator implements AssemblyTemplateSpe
         // first build the children into an empty shell app
         List<EntitySpec<?>> childSpecs = createServiceSpecs(template, platform, loader, encounteredTypeSymbolicNames);
         for (EntitySpec<?> childSpec : childSpecs) {
+            
+            if (Application.class.isAssignableFrom(childSpec.getType())) {
+                EntitySpec<? extends Application> appSpec = (EntitySpec<? extends Application>) childSpec;
+                if (EntityManagementUtils.canPromoteChildrenInWrappedApplication(appSpec)) {
+                    EntitySpec<?> appChildSpec = Iterables.getOnlyElement(appSpec.getChildren());
+                    EntityManagementUtils.mergeWrapperParentSpecToChildEntity(appSpec, appChildSpec);
+                    childSpec = appChildSpec;
+                }
+            }
+
             app.child(childSpec);
         }
 

--- a/brooklyn-server/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlTemplateTest.java
+++ b/brooklyn-server/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlTemplateTest.java
@@ -18,17 +18,27 @@
  */
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
+import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.typereg.RegisteredTypePredicates;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.osgi.OsgiTestResources;
 import org.testng.Assert;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
 
 
 public class CatalogYamlTemplateTest extends AbstractYamlTest {
@@ -61,6 +71,119 @@ public class CatalogYamlTemplateTest extends AbstractYamlTest {
             "YAML included metadata which should have been excluded; it was:\n"+yaml);
 
         deleteCatalogEntity("t1");
+    }
+
+    @Test
+    public void testServiceTypeEntityOfTypeCatalogTemplateNotWrapped() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: t1",
+                "  item_type: template",
+                "  name: myT1",
+                "  item:",
+                "    services:",
+                "    - type: " + TestEntity.class.getName());
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: t2",
+                "  item_type: template",
+                "  name: myT2",
+                "  item:",
+                "    services:",
+                "    - type: t1",
+                "    - type: t1");
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: t2");
+        waitForApplicationTasks(app);
+        
+        Entities.dumpInfo(app);
+        Entity t1a = Iterables.get(app.getChildren(), 0);
+        Entity t1b = Iterables.get(app.getChildren(), 1);
+        assertEquals(app.getChildren().size(), 2);
+        assertEquals(t1a.getChildren().size(), 0);
+        assertEquals(t1b.getChildren().size(), 0);
+        
+        assertTrue(app instanceof BasicApplication);
+        assertTrue(t1a instanceof TestEntity);
+        assertTrue(t1b instanceof TestEntity);
+    }
+
+    @Test
+    public void testChildEntityOfTypeCatalogTemplateNotWrapped() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: t1",
+                "  item_type: template",
+                "  name: myT1",
+                "  item:",
+                "    services:",
+                "    - type: " + TestEntity.class.getName());
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: t2",
+                "  item_type: template",
+                "  name: myT2",
+                "  item:",
+                "    services:",
+                "    - type: " + TestEntity.class.getName(),
+                "      brooklyn.children:",
+                "      - type: t1");
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: t2");
+        waitForApplicationTasks(app);
+        
+        Entities.dumpInfo(app);
+        Entity t2 = Iterables.getOnlyElement(app.getChildren());
+        Entity t1 = Iterables.getOnlyElement(t2.getChildren());
+        assertEquals(t1.getChildren().size(), 0);
+        
+        assertTrue(app instanceof BasicApplication);
+        assertTrue(t1 instanceof TestEntity);
+        assertTrue(t2 instanceof TestEntity);
+    }
+
+    @Test
+    public void testMemberSpecEntityOfTypeCatalogTemplateNotWrapped() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: t1",
+                "  item_type: template",
+                "  name: myT1",
+                "  item:",
+                "    services:",
+                "    - type: " + TestEntity.class.getName());
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: t2",
+                "  item_type: template",
+                "  name: myT2",
+                "  item:",
+                "    services:",
+                "    - type: " + DynamicCluster.class.getName(),
+                "      brooklyn.config:",
+                "        memberSpec:",
+                "          $brooklyn:entitySpec:",
+                "            type: t1",
+                "        cluster.initial.size: 1");
+
+        Entity app = createAndStartApplication(
+                "location: localhost",
+                "services:",
+                "- type: t2");
+        waitForApplicationTasks(app);
+        
+        Entities.dumpInfo(app);
+        DynamicCluster t2 = (DynamicCluster) Iterables.getOnlyElement(app.getChildren());
+        Entity t1 = Iterables.getOnlyElement(t2.getMembers());
+        assertEquals(t1.getChildren().size(), 0);
+        
+        assertTrue(app instanceof BasicApplication);
+        assertTrue(t2 instanceof DynamicCluster);
+        assertTrue(t1 instanceof TestEntity);
     }
 
     private RegisteredType makeItem() {


### PR DESCRIPTION
Previously, any catalog item of type “template” would always be wrapped
in a BasicApplication. This was being done in three places. The first
is ok; the second two are bad:

1. When deploying a top-level “template” from the catalog.
2. When referring to a “template” catalog item in a member-spec (e.g.
   for a DynamicCluster)
3. When referring to a “template” catalog item in brooklyn.children.

@johnmccabe @ahgittin @neykov you'll be interested in this.

I don't like the approach (duplicating the fix in three places, to remove the wrapping app, for the different contexts that it might be used).

It would feel better for the YAML-parsing to *not* wrap the entity at all, unless there was a really good reason to (e.g. the catalog item consists of multiple top-level services defined in its yaml). The caller could then decide if it needs to wrap it (i.e. if deliberately creating a top-level app), or leave as-is.