### PR TITLE
Fixed issue with exceptions in Rest Client

### DIFF
--- a/brooklyn-server/rest/rest-client/src/main/java/org/apache/brooklyn/rest/client/util/http/BuiltResponsePreservingError.java
+++ b/brooklyn-server/rest/rest-client/src/main/java/org/apache/brooklyn/rest/client/util/http/BuiltResponsePreservingError.java
@@ -70,7 +70,9 @@ public class BuiltResponsePreservingError extends BuiltResponse {
     
     @Override
     public Object getEntity() {
-        if (error!=null) Exceptions.propagate(error);
+        if (error!=null) {
+            throw new IllegalStateException("getEntity called on BuiltResponsePreservingError, where an Error had been preserved", error);
+        }
         return super.getEntity();
     }
 


### PR DESCRIPTION
Calling getEntity on BuiltResponsePreservingError would propagate a previously caught and ignored exception. Because of this the output did not mention that getEntity was the line propagating the exception. We now throw an IllegalStateException to make it clear where the exception is coming from