### PR TITLE
deprecate group.members.delegate and prevent delegate creation when adding to quarantine

### DIFF
--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
@@ -58,8 +58,12 @@ public interface AbstractGroup extends Entity, Group, Changeable {
     AttributeSensor<Entity> FIRST = Sensors.newSensor(Entity.class,
             "cluster.first.entity", "The first member of the cluster");
 
+    /**
+     * @deprecated since 0.9.0, the UI no longer relies on the use of delegates to represent group membership (see #929)
+     */
+    @Deprecated
     ConfigKey<Boolean> MEMBER_DELEGATE_CHILDREN = ConfigKeys.newBooleanConfigKey(
-            "group.members.delegate", "Add delegate child entities for members of the group", Boolean.FALSE);
+            "group.members.delegate", "Deprecated: Add delegate child entities for members of the group", Boolean.FALSE);
 
     ConfigKey<String> MEMBER_DELEGATE_NAME_FORMAT = ConfigKeys.newStringConfigKey(
             "group.members.delegate.nameFormat", "Delegate members name format string (Use %s for the original entity display name)", "%s");

--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
@@ -146,6 +146,7 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
                 sensors().emit(MEMBER_ADDED, member);
 
                 if (Boolean.TRUE.equals(getConfig(MEMBER_DELEGATE_CHILDREN))) {
+                    log.warn("Use of deprecated ConfigKey {} in {} (as of 0.9.0)", MEMBER_DELEGATE_CHILDREN.getName(), this);
                     Optional<Entity> result = Iterables.tryFind(getChildren(), Predicates.equalTo(member));
                     if (!result.isPresent()) {
                         String nameFormat = Optional.fromNullable(getConfig(MEMBER_DELEGATE_NAME_FORMAT)).or("%s");

--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/entity/group/QuarantineGroup.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/entity/group/QuarantineGroup.java
@@ -27,8 +27,6 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 @ImplementedBy(QuarantineGroupImpl.class)
 public interface QuarantineGroup extends AbstractGroup {
 
-    ConfigKey<Boolean> MEMBER_DELEGATE_CHILDREN = ConfigKeys.newConfigKeyWithDefault(AbstractGroup.MEMBER_DELEGATE_CHILDREN, Boolean.TRUE);
-
     @Effector(description="Removes all members of the quarantined group, unmanaging them")
     void expungeMembers(
             @EffectorParam(name="firstStop", description="Whether to first call stop() on those members that are stoppable") boolean stopFirst);


### PR DESCRIPTION
Use of delegate to denote quarantine group membership in the gui is no longer required following #929