### PR TITLE
Fix catalog XML deserialization

### DIFF
--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogXmlSerializer.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogXmlSerializer.java
@@ -36,7 +36,8 @@ public class CatalogXmlSerializer extends XmlSerializer<Object> {
         super(DeserializingClassRenamesProvider.loadDeserializingClassRenames());
         
         xstream.addDefaultImplementation(ArrayList.class, Collection.class);
-        
+       
+        //Doesn't work well for non-standard lists, like Lists.transform results
         xstream.aliasType("list", List.class);
         xstream.aliasType("map", Map.class);
 

--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.mgmt;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -85,11 +86,17 @@ public class BrooklynTags {
 
     public static class TraitsTag extends ListTag<String> {
         public TraitsTag(List<Class<?>> interfaces) {
-            super(Lists.transform(interfaces, new Function<Class<?>, String>() {
-                @Override public String apply(Class<?> input) {
-                    return input.getName();
-                }
-            }));
+            // The transformed list is a view, meaning that it references
+            // the instances list. This means that it will serialize 
+            // the list of classes along with the anonymous function which
+            // is not what we want. Force eager evaluation instead, using
+            // a simple list, supported by {@link CatalogXmlSerializer}.
+            super(new ArrayList<String>(
+                Lists.transform(interfaces, new Function<Class<?>, String>() {
+                    @Override public String apply(Class<?> input) {
+                        return input.getName();
+                    }
+                })));
         }
 
         @JsonProperty("traits")

--- a/brooklyn-server/core/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogDtoTest.java
+++ b/brooklyn-server/core/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogDtoTest.java
@@ -39,12 +39,14 @@ import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.catalog.internal.CatalogXmlSerializer;
 import org.apache.brooklyn.core.catalog.internal.CatalogClasspathDo.CatalogScanningModes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.util.core.BrooklynMavenArtifacts;
 import org.apache.brooklyn.util.maven.MavenRetriever;
+import org.apache.commons.lang3.ClassUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -111,6 +113,9 @@ public class CatalogDtoTest {
         testEntitiesJavaCatalog.addEntry(CatalogItemBuilder.newTemplate(TestApplication.class.getCanonicalName(), BasicBrooklynCatalog.NO_VERSION)
                 .displayName("Test App from JAR")
                 .javaType(TestApplication.class.getCanonicalName())
+                .tag(BrooklynTags.newNotesTag("Some notes for catalog testing"))
+                .tag(BrooklynTags.newYamlSpecTag("This is the spec for a test catalog item"))
+                .tag(BrooklynTags.newTraitsTag(ClassUtils.getAllInterfaces(TestApplication.class)))
                 .build());
         testEntitiesJavaCatalog.addEntry(CatalogItemBuilder.newEntity(TestEntity.class.getCanonicalName(), BasicBrooklynCatalog.NO_VERSION)
                 .displayName("Test Entity from JAR")


### PR DESCRIPTION
Fixes the serialized XML format so it can be deserialized later.

There's an explicit alias for `List.class`, so the actual object type is not dumped. Any non-ArrayList will fail deserialization as that's what the default for `Collection` is. 
Another positive side of the change is that we won't have function class references serialized.