### PR TITLE
Better control over opening inbound ports

### DIFF
--- a/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/InboundPortsUtils.java
+++ b/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/InboundPortsUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class InboundPortsUtils {
+    private static final Logger log = LoggerFactory.getLogger(InboundPortsUtils.class);
+
+    /**
+     * Returns the required open inbound ports for an Entity.
+     * If {@code portsAutoInfer} is {@code true} then
+     * return the first value for each {@link org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey}
+     * config key {@link PortRange} plus any ports defined with a config key matching the provided regex.
+     * @param entity the Entity
+     * @param portsAutoInfer if {@code true} then also return the first value for each {@link org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey}
+     * config key {@link PortRange} plus any ports defined with a config keys matching the provided regex
+     * @param portRegex the regex to match config keys that define inbound ports
+     * @return a collection of port numbers
+     */
+    public static Collection<Integer> getRequiredOpenPorts(Entity entity, Boolean portsAutoInfer, String portRegex) {
+        return getRequiredOpenPorts(entity, ImmutableSet.<ConfigKey<?>>of(), portsAutoInfer, portRegex);
+    }
+
+    /**
+     * Returns the required open inbound ports for an Entity.
+     * If {@code portsAutoInfer} is {@code true} then
+     * return the first value for each {@link org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey}
+     * config key {@link PortRange} plus any ports defined with a config key matching the provided regex.
+     * This method also accepts an extra set of config keys in addition to those that are defined in the EntityType of the entity itself.
+     * @param entity the Entity
+     * @param extraConfigKeys extra set of config key to inspect for inbound ports
+     * @param portsAutoInfer if {@code true} then return the first value for each {@link org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey}
+     * config key {@link PortRange} plus any ports defined with a config keys matching the provided regex
+     * @param portRegex the regex to match config keys that define inbound ports
+     * @return a collection of port numbers
+     */
+    public static Collection<Integer> getRequiredOpenPorts(Entity entity, Set<ConfigKey<?>> extraConfigKeys, Boolean portsAutoInfer, String portRegex) {
+        Set<Integer> ports = MutableSet.of();
+
+        /* TODO: This won't work if there's a port collision, which will cause the corresponding port attribute
+           to be incremented until a free port is found. In that case the entity will use the free port, but the
+           firewall will open the initial port instead. Mostly a problem for SameServerEntity, localhost location.
+         */
+        if (portsAutoInfer == null || portsAutoInfer.booleanValue()) { // auto-infer defaults to true if not specified
+            Set<ConfigKey<?>> configKeys = Sets.newHashSet(extraConfigKeys);
+            configKeys.addAll(entity.getEntityType().getConfigKeys());
+
+            if (portRegex == null) portRegex = ".*\\.port"; // defaults to legacy regex if not specified
+            Pattern portsPattern = Pattern.compile(portRegex);
+            for (ConfigKey<?> k : configKeys) {
+                if (PortRange.class.isAssignableFrom(k.getType()) || portsPattern.matcher(k.getName()).matches()) {
+                    Object value = entity.config().get(k);
+                    Maybe<PortRange> maybePortRange = TypeCoercions.tryCoerce(value, new TypeToken<PortRange>() {
+                    });
+                    if (maybePortRange.isPresentAndNonNull()) {
+                        PortRange p = maybePortRange.get();
+                        if (p != null && !p.isEmpty())
+                            ports.add(p.iterator().next());
+                    }
+                }
+            }
+        }
+
+        log.debug("getRequiredOpenPorts detected default {} for {}", ports, entity);
+        return ports;
+    }
+}

--- a/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SameServerEntity.java
+++ b/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SameServerEntity.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
+import java.util.Collection;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -58,6 +59,12 @@ public interface SameServerEntity extends Entity, Startable {
     
     ConfigKey<QuorumCheck> UP_QUORUM_CHECK = ComputeServiceIndicatorsFromChildrenAndMembers.UP_QUORUM_CHECK;
     ConfigKey<QuorumCheck> RUNNING_QUORUM_CHECK = ComputeServiceIndicatorsFromChildrenAndMembers.RUNNING_QUORUM_CHECK;
+
+    ConfigKey<Collection<Integer>> REQUIRED_OPEN_LOGIN_PORTS = SoftwareProcess.REQUIRED_OPEN_LOGIN_PORTS;
+
+    ConfigKey<String> INBOUND_PORTS_CONFIG_REGEX = SoftwareProcess.INBOUND_PORTS_CONFIG_REGEX;
+
+    ConfigKey<Boolean> INBOUND_PORTS_AUTO_INFER = SoftwareProcess.INBOUND_PORTS_AUTO_INFER;
 
     AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
 

--- a/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -66,7 +66,7 @@ public interface SoftwareProcess extends Entity, Startable {
             ImmutableSet.of(22));
 
     ConfigKey<String> INBOUND_PORTS_CONFIG_REGEX = ConfigKeys.newStringConfigKey("inboundPorts.configRegex",
-            "Regex governing the opening of ports based on sensor names",
+            "Regex governing the opening of ports based on config names",
             ".*\\.port");
 
     ConfigKey<Boolean> INBOUND_PORTS_AUTO_INFER = ConfigKeys.newBooleanConfigKey("inboundPorts.autoInfer",

--- a/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -20,14 +20,20 @@ package org.apache.brooklyn.entity.software.base;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
+import com.google.common.collect.Sets;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.MapConfigKey;
+import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -36,7 +42,10 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
@@ -50,12 +59,19 @@ public interface SoftwareProcess extends Entity, Startable {
     AttributeSensor<String> SUBNET_HOSTNAME = Attributes.SUBNET_HOSTNAME;
     AttributeSensor<String> SUBNET_ADDRESS = Attributes.SUBNET_ADDRESS;
 
-    @SuppressWarnings("serial")
     ConfigKey<Collection<Integer>> REQUIRED_OPEN_LOGIN_PORTS = ConfigKeys.newConfigKey(
             new TypeToken<Collection<Integer>>() {},
             "requiredOpenLoginPorts",
             "The port(s) to be opened, to allow login",
             ImmutableSet.of(22));
+
+    ConfigKey<String> INBOUND_PORTS_CONFIG_REGEX = ConfigKeys.newStringConfigKey("inboundPorts.configRegex",
+            "Regex governing the opening of ports based on sensor names",
+            ".*\\.port");
+
+    ConfigKey<Boolean> INBOUND_PORTS_AUTO_INFER = ConfigKeys.newBooleanConfigKey("inboundPorts.autoInfer",
+            "If set to false turns off the opening of ports based on naming convention, and also those that are of type PortRange in Java entities",
+            true);
 
     @SetFromFlag("startTimeout")
     ConfigKey<Duration> START_TIMEOUT = BrooklynConfigKeys.START_TIMEOUT;
@@ -300,12 +316,12 @@ public interface SoftwareProcess extends Entity, Startable {
     AttributeSensor<MachineProvisioningLocation> PROVISIONING_LOCATION = Sensors.newSensor(
             MachineProvisioningLocation.class, "softwareservice.provisioningLocation", "Location used to provision a machine where this is running");
 
-    AttributeSensor<Boolean> SERVICE_PROCESS_IS_RUNNING = Sensors.newBooleanSensor("service.process.isRunning", 
+    AttributeSensor<Boolean> SERVICE_PROCESS_IS_RUNNING = Sensors.newBooleanSensor("service.process.isRunning",
             "Whether the process for the service is confirmed as running");
-    
+
     AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
     AttributeSensor<Transition> SERVICE_STATE_EXPECTED = Attributes.SERVICE_STATE_EXPECTED;
- 
+
     AttributeSensor<String> PID_FILE = Sensors.newStringSensor("softwareprocess.pid.file", "PID file");
 
     @Beta
@@ -319,14 +335,14 @@ public interface SoftwareProcess extends Entity, Startable {
             "Whether to restart/replace the machine provisioned for this entity:  'true', 'false', or 'auto' are supported, "
             + "with the default being 'auto' which means to restart or reprovision the machine if there is no simpler way known to restart the entity "
             + "(for example, if the machine is unhealthy, it would not be possible to restart the process, not even via a stop-then-start sequence); "
-            + "if the machine was not provisioned for this entity, this parameter has no effect", 
+            + "if the machine was not provisioned for this entity, this parameter has no effect",
             RestartMachineMode.AUTO.toString().toLowerCase());
-        
+
         // we supply a typed variant for retrieval; we want the untyped (above) to use lower case as the default in the GUI
-        // (very hard if using enum, since enum takes the name, and RendererHints do not apply to parameters) 
+        // (very hard if using enum, since enum takes the name, and RendererHints do not apply to parameters)
         @Beta /** @since 0.7.0 semantics of parameters to restart being explored */
         public static final ConfigKey<RestartMachineMode> RESTART_MACHINE_TYPED = ConfigKeys.newConfigKey(RestartMachineMode.class, "restartMachine");
-            
+
         public enum RestartMachineMode { TRUE, FALSE, AUTO }
     }
 
@@ -349,7 +365,7 @@ public interface SoftwareProcess extends Entity, Startable {
                 "IF_NOT_STOPPED stops the machine only if the entity is not marked as stopped, " +
                 "NEVER doesn't stop the machine.", StopMode.IF_NOT_STOPPED);
     }
-    
+
     // NB: the START, STOP, and RESTART effectors themselves are (re)defined by MachineLifecycleEffectorTasks
 
     /**


### PR DESCRIPTION
Add config keys to `SoftwareProcess` governing the opening of ports based on sensor names, so it is explicit when you look at the config keys for the relevant entities.  ie, `SoftwareProcessImpl.getRequiredOpenPorts` uses a config key whose default value is this:
```
    inboundPorts.configRegex=.*\.port
```
Also add a config option whose default value is this:
```
    inboundPorts.autoInfer=true
```
If explicitly set to false, it turns off the opening of ports based on naming convention, and also those defined in Java entities that are of type PortRange.

Remove duplication of code between `SameServerDriverLifecycleEffectorTasks` and `SoftwareProcessImpl`.

Make login port (22) also a config key, not a constant, in `SameServerEntity`.