### PR TITLE
turn off sticky sessions to allow easy balancing validation

### DIFF
--- a/brooklyn-server/server-cli/src/main/resources/brooklyn/default.catalog.bom
+++ b/brooklyn-server/server-cli/src/main/resources/brooklyn/default.catalog.bom
@@ -332,6 +332,8 @@ brooklyn.catalog:
           # point this load balancer at the cluster, specifying port to forward to
           loadbalancer.serverpool:  $brooklyn:entity("my-web-cluster")
           member.sensor.portNumber: app.port
+          # disable sticky sessions to allow easy validation of balancing via browser refresh
+          nginx.sticky: false
       
       brooklyn.enrichers:
       # publish a few useful info sensors and KPI's to the root of the app


### PR DESCRIPTION
turning off sticky sessions in template 4 allows the user to very easily validate balancing in action by refreshing the browser where they'll see a different VanillaSoftwareProcess entity id and IP address as requests round robin across balancer members.
```
I am VanillaSoftwareProcessImpl{id=sqyei7aO}, part of the cluster.
```
```
I am running at 10.220.0.230, with on-box IP configuration:
```