### PR TITLE
Additional security for MySQL

### DIFF
--- a/brooklyn-library/software/database/src/main/resources/org/apache/brooklyn/entity/database/mysql/mysql.conf
+++ b/brooklyn-library/software/database/src/main/resources/org/apache/brooklyn/entity/database/mysql/mysql.conf
@@ -15,5 +15,9 @@ datadir         = ${driver.dataDir}
 bind-address    = 0.0.0.0
 # skip-networking
 
+#Prevent the GRANT statement from automatically creating new user accounts if it would otherwise do so,
+#unless authentication information is specified
+sql_mode = NO_AUTO_CREATE_USER
+
 # Custom configuration options
 ${driver.mySqlServerOptionsString}

--- a/brooklyn-library/software/database/src/main/resources/org/apache/brooklyn/entity/database/mysql/mysql_master.conf
+++ b/brooklyn-library/software/database/src/main/resources/org/apache/brooklyn/entity/database/mysql/mysql_master.conf
@@ -15,6 +15,10 @@ datadir         = ${driver.dataDir}
 bind-address    = 0.0.0.0
 # skip-networking
 
+#Prevent the GRANT statement from automatically creating new user accounts if it would otherwise do so,
+#unless authentication information is specified
+sql_mode = NO_AUTO_CREATE_USER
+
 # Replication config
 server-id       = 1
 binlog-format   = mixed

--- a/brooklyn-library/software/database/src/main/resources/org/apache/brooklyn/entity/database/mysql/mysql_slave.conf
+++ b/brooklyn-library/software/database/src/main/resources/org/apache/brooklyn/entity/database/mysql/mysql_slave.conf
@@ -16,6 +16,10 @@ datadir         = ${driver.dataDir}
 bind-address    = 0.0.0.0
 # skip-networking
 
+#Prevent the GRANT statement from automatically creating new user accounts if it would otherwise do so,
+#unless authentication information is specified
+sql_mode = NO_AUTO_CREATE_USER
+
 # Replication config
 server-id       = ${config["mysql.server_id"]}
 relay-log       = mysql-slave-${config["mysql.server_id"]}-relay


### PR DESCRIPTION
- it changes the default of sql_mode to include "NO_AUTO_CREATE_USER"
- it will prevent the GRANT statement from automatically creating new
user accounts unless authentication information is specified.