### PR TITLE
better shutdown

### DIFF
--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -372,10 +372,15 @@ public abstract class AbstractManagementContext implements ManagementContextInte
         return configMap;
     }
 
+    private Object locationRegistrySemaphore = new Object();
+    
     @Override
-    public synchronized LocationRegistry getLocationRegistry() {
-        if (locationRegistry==null) locationRegistry = new BasicLocationRegistry(this);
-        return locationRegistry;
+    public LocationRegistry getLocationRegistry() {
+        // NB: can deadlock if synched on whole LMC
+        synchronized (locationRegistrySemaphore) {
+            if (locationRegistry==null) locationRegistry = new BasicLocationRegistry(this);
+            return locationRegistry;
+        }
     }
 
     @Override

--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -372,7 +372,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
         return configMap;
     }
 
-    private Object locationRegistrySemaphore = new Object();
+    private final Object locationRegistrySemaphore = new Object();
     
     @Override
     public LocationRegistry getLocationRegistry() {

--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynShutdownHooks.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynShutdownHooks.java
@@ -187,7 +187,9 @@ public class BrooklynShutdownHooks {
             }
             entitiesToStop.addAll(entitiesToStopOnShutdown);
             for (ManagementContext mgmt: managementContextsToStopAppsOnShutdown) {
-                entitiesToStop.addAll(mgmt.getApplications());
+                if (mgmt.isRunning()) {
+                    entitiesToStop.addAll(mgmt.getApplications());
+                }
             }
             
             if (entitiesToStop.isEmpty()) {

--- a/brooklyn-server/rest/rest-server/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/brooklyn-server/rest/rest-server/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -218,6 +218,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
                         if (shutdownHandler != null) {
                             shutdownHandler.onShutdownRequest();
                         } else {
+                            // should always be set as it is required by jersey injection?
                             log.warn("ShutdownHandler not set, exiting process");
                             System.exit(0);
                         }

--- a/brooklyn-server/rest/rest-server/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/brooklyn-server/rest/rest-server/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -218,7 +218,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
                         if (shutdownHandler != null) {
                             shutdownHandler.onShutdownRequest();
                         } else {
-                            // should always be set as it is required by jersey injection?
+                            // should normally be set, as @Context is required by jersey injection
                             log.warn("ShutdownHandler not set, exiting process");
                             System.exit(0);
                         }

--- a/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -47,7 +47,7 @@ import org.apache.brooklyn.rest.util.BrooklynRestResourceUtils;
 import org.apache.brooklyn.rest.util.NullHttpServletRequestProvider;
 import org.apache.brooklyn.rest.util.NullServletConfigProvider;
 import org.apache.brooklyn.rest.util.ShutdownHandlerProvider;
-import org.apache.brooklyn.rest.util.TestShutdownHandler;
+import org.apache.brooklyn.rest.util.NoOpRecordingShutdownHandler;
 import org.apache.brooklyn.rest.util.json.BrooklynJacksonJsonProvider;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
@@ -56,7 +56,7 @@ public abstract class BrooklynRestApiTest {
     protected ManagementContext manager;
     
     protected boolean useLocalScannedCatalog = false;
-    protected TestShutdownHandler shutdownListener = createShutdownHandler();
+    protected NoOpRecordingShutdownHandler shutdownListener = createShutdownHandler();
 
     @BeforeMethod(alwaysRun = true)
     public void setUpMethod() {
@@ -69,8 +69,8 @@ public abstract class BrooklynRestApiTest {
         useLocalScannedCatalog = true;
     }
     
-    private TestShutdownHandler createShutdownHandler() {
-        return new TestShutdownHandler();
+    private NoOpRecordingShutdownHandler createShutdownHandler() {
+        return new NoOpRecordingShutdownHandler();
     }
 
     protected synchronized ManagementContext getManagementContext() {

--- a/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/util/NoOpRecordingShutdownHandler.java
+++ b/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/util/NoOpRecordingShutdownHandler.java
@@ -20,7 +20,7 @@ package org.apache.brooklyn.rest.util;
 
 import org.apache.brooklyn.rest.util.ShutdownHandler;
 
-public class TestShutdownHandler implements ShutdownHandler {
+public class NoOpRecordingShutdownHandler implements ShutdownHandler {
     private volatile boolean isRequested;
 
     @Override

--- a/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/util/ServerStoppingShutdownHandler.java
+++ b/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/util/ServerStoppingShutdownHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.util;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.eclipse.jetty.server.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/* not the cleanest way to enforce a clean shutdown, but a simple and effective way;
+ * usage is restricted to BrooklynRestApiLauncher and subclasses, to stop it inline.
+ * the main app stops the server in a more principled way using callbacks. */
+public class ServerStoppingShutdownHandler implements ShutdownHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(ServerStoppingShutdownHandler.class);
+    
+    private final ManagementContext mgmt;
+    private Server server;
+    
+    public ServerStoppingShutdownHandler(ManagementContext mgmt) {
+        this.mgmt = mgmt;
+    }
+
+    @Override
+    public void onShutdownRequest() {
+        log.info("Shutting down (when running in rest-api dev mode)...");
+
+        // essentially same as BrooklynLauncher.terminate() but cut down as this is only used in dev mode
+        
+        if (server!=null) {
+            try {
+                server.stop();
+                server.join();
+            } catch (Exception e) {
+                log.debug("Stopping server gave an error (not usually a concern): "+e);
+                /* NPE may be thrown e.g. if threadpool not started */
+            }
+        }
+
+        if (mgmt instanceof ManagementContextInternal) {
+            ((ManagementContextInternal)mgmt).terminate();
+        }
+    }
+
+    /** Expect this to be injeted; typically it is not known when this is created, but we need it to trigger shutdown. */
+    public void setServer(Server server) {
+        this.server = server;
+    }
+
+}

--- a/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/util/ServerStoppingShutdownHandler.java
+++ b/brooklyn-server/rest/rest-server/src/test/java/org/apache/brooklyn/rest/util/ServerStoppingShutdownHandler.java
@@ -67,7 +67,7 @@ public class ServerStoppingShutdownHandler implements ShutdownHandler {
         }).start();
     }
 
-    /** Expect this to be injeted; typically it is not known when this is created, but we need it to trigger shutdown. */
+    /** Expect this to be injected; typically it is not known when this is created, but we need it to trigger shutdown. */
     public void setServer(Server server) {
         this.server = server;
     }

--- a/brooklyn-server/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/brooklyn-server/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -19,6 +19,12 @@
 package org.apache.brooklyn.cli;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyShell;
+import io.airlift.command.Cli;
+import io.airlift.command.Cli.CliBuilder;
+import io.airlift.command.Command;
+import io.airlift.command.Option;
 
 import java.io.Console;
 import java.io.IOException;
@@ -31,17 +37,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.Beta;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
-import com.google.common.base.Objects.ToStringHelper;
-import com.google.common.base.Stopwatch;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
 import org.apache.brooklyn.api.catalog.CatalogItem;
@@ -89,16 +84,19 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Enums;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.text.Identifiers;
-import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
+import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyShell;
-import io.airlift.command.Cli;
-import io.airlift.command.Cli.CliBuilder;
-import io.airlift.command.Command;
-import io.airlift.command.Option;
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 /**
  * This class is the primary CLI for brooklyn.
@@ -474,17 +472,22 @@ public class Main extends AbstractMain {
             }
             
             BrooklynServerDetails server = launcher.getServerDetails();
-            ManagementContext ctx = server.getManagementContext();
+            ManagementContext mgmt = server.getManagementContext();
             
             if (verbose) {
                 Entities.dumpInfo(launcher.getApplications());
             }
             
             if (!exitAndLeaveAppsRunningAfterStarting) {
-                waitAfterLaunch(ctx, shutdownHandler);
+                waitAfterLaunch(mgmt, shutdownHandler);
             }
 
-            // will call mgmt.terminate() in BrooklynShutdownHookJob
+            // BrooklynShutdownHookJob will invoke terminate() to do mgmt.terminate() and BrooklynWebServer.stop();
+            // and System.exit is invoked immediately after ...
+            // but seems better to do it explicitly here. 
+            // ('launcher' is local to us so the caller *cannot* do it, and no harm in doing it twice.) 
+            launcher.terminate();
+            
             return null;
         }
 

--- a/brooklyn-server/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/brooklyn-server/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -482,11 +482,12 @@ public class Main extends AbstractMain {
                 waitAfterLaunch(mgmt, shutdownHandler);
             }
 
-            // BrooklynShutdownHookJob will invoke terminate() to do mgmt.terminate() and BrooklynWebServer.stop();
-            // and System.exit is invoked immediately after ...
-            // but seems better to do it explicitly here. 
-            // ('launcher' is local to us so the caller *cannot* do it, and no harm in doing it twice.) 
-            launcher.terminate();
+            // do not shutdown servers here here -- 
+            // the BrooklynShutdownHookJob will invoke that and others on System.exit()
+            // which happens immediately after.
+            // might be nice to do it explicitly here, 
+            // but the server shutdown process has some special "shutdown apps" options
+            // so we'd want to refactor BrooklynShutdownHookJob to share code
             
             return null;
         }


### PR DESCRIPTION
call Main.terminate() in the main thread, rather than relying on shutdown hooks

fixes rest-initiated shutdown when using BrooklynJavascriptGuiLauncher
(looks like that has been broken since #771)

/cc @neykov does this look like a reasonable enhancement of your work in #771 ?