### PR TITLE
Uses externally accessible address for main uri of controller

### DIFF
--- a/brooklyn-library/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/AbstractControllerImpl.java
+++ b/brooklyn-library/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/AbstractControllerImpl.java
@@ -312,7 +312,7 @@ public abstract class AbstractControllerImpl extends SoftwareProcessImpl impleme
         ConfigToAttributes.apply(this);
 
         sensors().set(PROTOCOL, inferProtocol());
-        sensors().set(MAIN_URI, URI.create(inferUrl()));
+        sensors().set(MAIN_URI, URI.create(inferUrl(true)));
         sensors().set(ROOT_URL, inferUrl());
  
         checkNotNull(getPortNumberSensor(), "no sensor configured to infer port number");


### PR DESCRIPTION
Previously, if deploying to BYON AWS instances, the internal IP address was being displayed in the main.uri for the ControlledDynamicWebAppCluster
