### PR TITLE
fix race in DSTTest.testCancel

### DIFF
--- a/brooklyn-server/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
+++ b/brooklyn-server/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
@@ -298,7 +298,7 @@ public class BasicTask<T> implements TaskInternal<T> {
     public synchronized boolean cancel(TaskCancellationMode mode) {
         if (isDone()) return false;
         if (log.isTraceEnabled()) {
-            log.trace("BT cancelling "+this+" mode "+mode);
+            log.trace("BT cancelling "+this+" mode "+mode+", from thread "+Thread.currentThread());
         }
         cancelled = true;
         doCancel(mode);

--- a/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/jmx/JmxService.java
+++ b/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/jmx/JmxService.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.entity.software.base.test.jmx;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanNotificationInfo;
@@ -47,6 +46,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.entity.java.UsesJmx;
 import org.apache.brooklyn.feed.jmx.JmxHelper;
+import org.apache.brooklyn.test.NetworkingTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +68,10 @@ public class JmxService {
     private String url;
 
     public JmxService() throws Exception {
-        this("localhost", 28000 + (int)Math.floor(new Random().nextDouble() * 1000));
-        logger.warn("use of deprecated default host and port in JmxService");
+        this("localhost", NetworkingTestUtils.randomPortAround(28000));
+        
+        // TODO why this message if the constructor is not actually deprecated, and it seems useful?
+        //logger.warn("use of deprecated default host and port in JmxService");
     }
     
     /**
@@ -151,10 +153,12 @@ public class JmxService {
      * @throws MBeanRegistrationException 
      * @throws InstanceAlreadyExistsException 
      */
+    @SuppressWarnings({ "rawtypes" })
     public GeneralisedDynamicMBean registerMBean(Map initialAttributes, String name) throws InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException, MalformedObjectNameException, NullPointerException {
         return registerMBean(initialAttributes, ImmutableMap.of(), name);
     }
     
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public GeneralisedDynamicMBean registerMBean(Map initialAttributes, Map operations, String name) throws InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException, MalformedObjectNameException, NullPointerException {
         GeneralisedDynamicMBean mbean = new GeneralisedDynamicMBean(initialAttributes, operations);
         server.registerMBean(mbean, new ObjectName(name));

--- a/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxFeedTest.java
+++ b/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxFeedTest.java
@@ -65,6 +65,7 @@ import org.apache.brooklyn.entity.software.base.test.jmx.GeneralisedDynamicMBean
 import org.apache.brooklyn.entity.software.base.test.jmx.JmxService;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.NetworkingTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -114,7 +115,13 @@ public class JmxFeedTest {
         @Override public void init() {
             sensors().set(Attributes.HOSTNAME, "localhost");
             sensors().set(UsesJmx.JMX_PORT, 
-                    LocalhostMachineProvisioningLocation.obtainPort(PortRanges.fromString("40123+")));
+                    LocalhostMachineProvisioningLocation.obtainPort(PortRanges.fromString(
+                        // just doing "40123+" was not enough to avoid collisions (on 40125),
+                        // observed on jenkins, not sure why but 
+                        // maybe something else had a UDP connection we weren't detected,
+                        // or the static lock our localhost uses was being bypassed;
+                        // this should improve things (2016-01)
+                        NetworkingTestUtils.randomPortAround(40000)+"+")));
             // only supports no-agent, at the moment
             config().set(UsesJmx.JMX_AGENT_MODE, JmxAgentModes.NONE);
             sensors().set(UsesJmx.RMI_REGISTRY_PORT, -1);  // -1 means to use the JMX_PORT only

--- a/brooklyn-server/test-support/src/main/java/org/apache/brooklyn/test/NetworkingTestUtils.java
+++ b/brooklyn-server/test-support/src/main/java/org/apache/brooklyn/test/NetworkingTestUtils.java
@@ -22,13 +22,13 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
 
-import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 
 public class NetworkingTestUtils {
@@ -64,5 +64,15 @@ public class NetworkingTestUtils {
             String errmsg = "port "+entry.getValue()+" not available for "+entry.getKey();
             assertTrue(Networking.isPortAvailable(entry.getValue()), errmsg);
         }
+    }
+    
+    /** Returns a port not in use somewhere around the seed;
+     * this is not a foolproof way to prevent collisions, 
+     * but strikes a good balance of traceability (different callers will use different ranges)
+     * and collision avoidance, esp when combined with <code>Localhost...obtain(thisResult+"+");</code>.
+     */
+    @Beta
+    public static int randomPortAround(int seed) {
+        return Networking.nextAvailablePort( seed + (int)Math.floor(Math.random() * 1000) );
     }
 }

--- a/brooklyn-server/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/brooklyn-server/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.util.net;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -26,7 +28,6 @@ import java.net.NetworkInterface;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
-import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -47,8 +48,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
 import com.google.common.primitives.UnsignedBytes;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class Networking {
 


### PR DESCRIPTION
seeing errors on jenkins server though it runs fine locally;
have patched what looks like one race, but not sure it explains the failure
at https://builds.apache.org/job/incubator-brooklyn-pull-requests/org.apache.brooklyn$brooklyn-core/2440/testReport/junit/org.apache.brooklyn.util.core.task/DynamicSequentialTaskTest/testCancelled/
where we are seeing an extra semaphore at the end of the test;
have added comments and logging in case it is seen again.
(locally all is well.)