### PR TITLE
Fix: SshFeed duplicate cmds

### DIFF
--- a/brooklyn-dist/release/change-version.sh
+++ b/brooklyn-dist/release/change-version.sh
@@ -66,5 +66,5 @@ if [ ${FILES_COUNT} -ne 0 ]; then
     sed -i.bak -e "/${VERSION_MARKER_NL}/{n;s/${CURRENT_VERSION}/${NEW_VERSION}/g;}" $FILES
 fi
 
-echo "Changed ${CURRENT_VERSION} to ${NEW_VERSION} for "${FILES_COUNT}" files"
+echo "Changed ${VERSION_MARKER} from ${CURRENT_VERSION} to ${NEW_VERSION} for "${FILES_COUNT}" files"
 echo "(Do a \`find . -name \"*.bak\" -delete\`  to delete the backup files.)"

--- a/brooklyn-server/core/src/test/java/org/apache/brooklyn/feed/ssh/SshFeedIntegrationTest.java
+++ b/brooklyn-server/core/src/test/java/org/apache/brooklyn/feed/ssh/SshFeedIntegrationTest.java
@@ -26,7 +26,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityInternal.FeedSupport;
 import org.apache.brooklyn.core.sensor.Sensors;
@@ -37,14 +37,11 @@ import org.apache.brooklyn.feed.ssh.SshFeedIntegrationTest;
 import org.apache.brooklyn.feed.ssh.SshPollConfig;
 import org.apache.brooklyn.feed.ssh.SshPollValue;
 import org.apache.brooklyn.feed.ssh.SshValueFunctions;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.StringFunctions;
 import org.apache.brooklyn.util.text.StringPredicates;
-import org.apache.brooklyn.util.time.Duration;
-import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -68,7 +65,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
 
     private LocalhostMachineProvisioningLocation loc;
     private SshMachineLocation machine;
-    private EntityLocal entity;
+    private TestEntity entity;
     private SshFeed feed;
     
     @BeforeMethod(alwaysRun=true)
@@ -104,7 +101,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(SshValueFunctions.stdout()))
                 .build();
         
-        EntityTestUtils.assertAttributeEventuallyNonNull(entity2, SENSOR_STRING);
+        EntityAsserts.assertAttributeEventuallyNonNull(entity2, SENSOR_STRING);
         String val = entity2.getAttribute(SENSOR_STRING);
         Assert.assertTrue(val.contains("hello"), "val="+val);
         Assert.assertEquals(val.trim(), "hello");
@@ -135,7 +132,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(SshValueFunctions.exitStatus()))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, 123);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 123);
     }
     
     @Test(groups="Integration")
@@ -148,7 +145,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(SshValueFunctions.stdout()))
                 .build();
         
-        EntityTestUtils.assertAttributeEventually(entity, SENSOR_STRING, 
+        EntityAsserts.assertAttributeEventually(entity, SENSOR_STRING, 
             Predicates.compose(Predicates.equalTo("hello"), StringFunctions.trim()));
     }
 
@@ -164,7 +161,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onFailure(SshValueFunctions.stderr()))
                 .build();
         
-        EntityTestUtils.assertAttributeEventually(entity, SENSOR_STRING, StringPredicates.containsLiteral(cmd));
+        EntityAsserts.assertAttributeEventually(entity, SENSOR_STRING, StringPredicates.containsLiteral(cmd));
     }
     
     @Test(groups="Integration")
@@ -181,7 +178,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                             }}))
                 .build();
         
-        EntityTestUtils.assertAttributeEventually(entity, SENSOR_STRING, StringPredicates.containsLiteral("Exit status 123"));
+        EntityAsserts.assertAttributeEventually(entity, SENSOR_STRING, StringPredicates.containsLiteral("Exit status 123"));
     }
     
     @Test(groups="Integration")
@@ -202,10 +199,10 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
             }));
 
         // TODO would be nice to hook in and assert no errors
-        EntityTestUtils.assertAttributeEqualsContinually(entity2, SENSOR_STRING, null);
+        EntityAsserts.assertAttributeEqualsContinually(entity2, SENSOR_STRING, null);
 
         entity2.sensors().set(Attributes.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEventually(entity2, SENSOR_STRING, StringPredicates.containsLiteral("hello"));
+        EntityAsserts.assertAttributeEventually(entity2, SENSOR_STRING, StringPredicates.containsLiteral("hello"));
     }
 
     
@@ -235,10 +232,10 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(SshValueFunctions.stdout()))
                 .build();
         
-        EntityTestUtils.assertAttributeEventuallyNonNull(entity2, SENSOR_STRING);        
+        EntityAsserts.assertAttributeEventuallyNonNull(entity2, SENSOR_STRING);
         final String val1 = assertDifferentOneInOutput(entity2);
         
-        EntityTestUtils.assertAttributeEventually(entity2, SENSOR_STRING, Predicates.not(Predicates.equalTo(val1)));        
+        EntityAsserts.assertAttributeEventually(entity2, SENSOR_STRING, Predicates.not(Predicates.equalTo(val1)));        
         final String val2 = assertDifferentOneInOutput(entity2);
         log.info("vals from dynamic sensors are: "+val1.trim()+" and "+val2.trim());
     }

--- a/brooklyn-server/core/src/test/java/org/apache/brooklyn/feed/ssh/SshFeedTest.java
+++ b/brooklyn-server/core/src/test/java/org/apache/brooklyn/feed/ssh/SshFeedTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.feed.ssh;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.stream.Streams;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
+public class SshFeedTest extends BrooklynAppUnitTestSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(SshFeedTest.class);
+    
+    final static AttributeSensor<String> SENSOR_STRING = Sensors.newStringSensor("aString", "");
+    final static AttributeSensor<String> SENSOR_STRING2 = Sensors.newStringSensor("aString2", "");
+
+    private LocalhostMachineProvisioningLocation loc;
+    private EntityLocal entity;
+    private SshFeed feed;
+    
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        loc = app.newLocalhostProvisioningLocation();
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+        RecordingSshMachineLocation.execScriptCalls.clear();
+    }
+
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        if (feed != null) feed.stop();
+        super.tearDown();
+        if (loc != null) Streams.closeQuietly(loc);
+        RecordingSshMachineLocation.execScriptCalls.clear();
+    }
+    
+    @Test(groups="Integration") // integration because slow 
+    public void testSharesCallWhenSameCommand() throws Exception {
+        final RecordingSshMachineLocation recordingMachine = mgmt.getLocationManager().createLocation(LocationSpec.create(RecordingSshMachineLocation.class));
+        app.start(ImmutableList.of(recordingMachine));
+        
+        final String cmd = "myCommand";
+        
+        feed = SshFeed.builder()
+                .period(Duration.PRACTICALLY_FOREVER)
+                .entity(entity)
+                .poll(new SshPollConfig<String>(SENSOR_STRING)
+                        .env(ImmutableMap.of("mykey", "myval"))
+                        .command(cmd)
+                        .onSuccess(Functions.constant("success")))
+                .poll(new SshPollConfig<String>(SENSOR_STRING2)
+                        .env(ImmutableMap.of("mykey", "myval"))
+                        .command(cmd)
+                        .onSuccess(Functions.constant("success2")))
+                .build();
+        
+        // Expect it to only execute once (i.e. share exec result for both sensors).
+        // Wait several seconds, in case it takes a while to do the second exec.
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertEquals(RecordingSshMachineLocation.execScriptCalls, ImmutableList.of(ImmutableList.of(cmd)));
+            }});
+        Asserts.succeedsContinually(ImmutableMap.of("timeout", Duration.FIVE_SECONDS), new Runnable() {
+            public void run() {
+                assertEquals(RecordingSshMachineLocation.execScriptCalls, ImmutableList.of(ImmutableList.of(cmd)));
+            }});
+    }
+
+    @Test
+    public void testDifferentCallsWhenDifferentCommands() throws Exception {
+        final RecordingSshMachineLocation recordingMachine = mgmt.getLocationManager().createLocation(LocationSpec.create(RecordingSshMachineLocation.class));
+        app.start(ImmutableList.of(recordingMachine));
+        
+        final String cmd = "myCommand";
+        final String cmd2 = "myCommand2";
+        
+        feed = SshFeed.builder()
+                .period(Duration.PRACTICALLY_FOREVER)
+                .entity(entity)
+                .poll(new SshPollConfig<String>(SENSOR_STRING)
+                        .command(cmd)
+                        .onSuccess(Functions.constant("success")))
+                .poll(new SshPollConfig<String>(SENSOR_STRING2)
+                        .command(cmd2)
+                        .onSuccess(Functions.constant("success")))
+                .build();
+        
+        // Expect it to execute the different commands (i.e. not share)
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertEquals(ImmutableSet.copyOf(RecordingSshMachineLocation.execScriptCalls), ImmutableSet.of(ImmutableList.of(cmd), ImmutableList.of(cmd2)));
+            }});
+    }
+
+    @Test
+    public void testDifferentCallsWhenDifferentEnv() throws Exception {
+        final RecordingSshMachineLocation recordingMachine = mgmt.getLocationManager().createLocation(LocationSpec.create(RecordingSshMachineLocation.class));
+        app.start(ImmutableList.of(recordingMachine));
+        
+        final String cmd = "myCommand";
+        
+        feed = SshFeed.builder()
+                .period(Duration.PRACTICALLY_FOREVER)
+                .entity(entity)
+                .poll(new SshPollConfig<String>(SENSOR_STRING)
+                        .env(ImmutableMap.of("mykey", "myval"))
+                        .command(cmd)
+                        .onSuccess(Functions.constant("success")))
+                .poll(new SshPollConfig<String>(SENSOR_STRING2)
+                        .env(ImmutableMap.of("mykey", "myval2"))
+                        .command(cmd)
+                        .onSuccess(Functions.constant("success")))
+                .build();
+        
+        // Expect it to execute the command twice, with different envs (i.e. not share)
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertEquals(RecordingSshMachineLocation.execScriptCalls, ImmutableList.of(ImmutableList.of(cmd), ImmutableList.of(cmd)));
+            }});
+    }
+
+    public static class RecordingSshMachineLocation extends SshMachineLocation {
+        public static List<List<String>> execScriptCalls = Lists.newCopyOnWriteArrayList();
+
+        @Override 
+        public int execScript(String summary, List<String> cmds) {
+            execScriptCalls.add(cmds);
+            return 0;
+        }
+        @Override 
+        public int execScript(Map<String,?> props, String summaryForLogging, List<String> cmds) {
+            execScriptCalls.add(cmds);
+            return 0;
+        }
+        @Override 
+        public int execScript(String summaryForLogging, List<String> cmds, Map<String,?> env) {
+            execScriptCalls.add(cmds);
+            return 0;
+        }
+        @Override 
+        public int execScript(Map<String,?> props, String summaryForLogging, List<String> cmds, Map<String,?> env) {
+            execScriptCalls.add(cmds);
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Fix the avoidance of executing the same command repeatedly, if an `SshFeed` is configured with multiple sensors that use the output of the same command.