### PR TITLE
fix failing (time sensitive) test

### DIFF
--- a/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/brooklyn-server/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -548,7 +548,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         boolean isRunningResult = false;
         long delay = 100;
         Exception firstFailure = null;
-        while (!isRunningResult && !timer.isExpired()) {
+        while (!isRunningResult && timer.isNotExpired()) {
             Time.sleep(delay);
             try {
                 isRunningResult = driver.isRunning();

--- a/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricherTest.java
+++ b/brooklyn-server/software/base/src/test/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricherTest.java
@@ -86,10 +86,10 @@ public class SystemServiceEnricherTest extends BrooklynAppLiveTestSupport {
     }
 
     private void waitFailed(VanillaSoftwareProcess proc) {
-        Asserts.eventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), Suppliers.ofInstance(proc), EntityPredicates.attributeEqualTo(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE));
+        Asserts.eventually(Suppliers.ofInstance(proc), EntityPredicates.attributeEqualTo(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE), Duration.FIVE_MINUTES);
     }
 
     private void waitHealthy(VanillaSoftwareProcess proc) {
-        Asserts.eventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), Suppliers.ofInstance(proc), EntityPredicates.attributeEqualTo(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING));
+        Asserts.eventually(Suppliers.ofInstance(proc), EntityPredicates.attributeEqualTo(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING), Duration.FIVE_MINUTES);
     }
 }

--- a/brooklyn-server/test-support/src/main/java/org/apache/brooklyn/test/WebAppMonitor.java
+++ b/brooklyn-server/test-support/src/main/java/org/apache/brooklyn/test/WebAppMonitor.java
@@ -184,7 +184,7 @@ public class WebAppMonitor implements Runnable {
         return this;
     }
     public WebAppMonitor waitForAtLeastOneAttempt() {
-        return waitForAtLeastOneAttempt(Asserts.DEFAULT_TIMEOUT);
+        return waitForAtLeastOneAttempt(Asserts.DEFAULT_LONG_TIMEOUT);
     }
     public WebAppMonitor waitForAtLeastOneAttempt(Duration timeout) {
         Asserts.succeedsEventually(MutableMap.of("timeout", timeout), new Runnable() {

--- a/brooklyn-server/utils/common/src/main/java/org/apache/brooklyn/util/time/CountdownTimer.java
+++ b/brooklyn-server/utils/common/src/main/java/org/apache/brooklyn/util/time/CountdownTimer.java
@@ -55,7 +55,7 @@ public class CountdownTimer {
         return limit;
     }
 
-    /** return how long the timer has been running (longer than limit if {@link #isExpired()}) */
+    /** return how long the timer has been running (may be longer than {@link #getLimit()} if {@link #isExpired()}) */
     public Duration getDurationElapsed() {
         return Duration.nanos(stopwatch.elapsed(TimeUnit.NANOSECONDS));
     }
@@ -65,15 +65,28 @@ public class CountdownTimer {
         return Duration.millis(limit.toMilliseconds() - stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
-    /** true iff the timer has been running for the duration specified at creation time */
+    /** true iff the timer has run for more than the duration specified at creation time */
     public boolean isExpired() {
         return stopwatch.elapsed(TimeUnit.MILLISECONDS) > limit.toMilliseconds();
     }
-    
-    /** true iff timer is running (even if it is expired) */
-    public boolean isRunning() {
+
+    /** true iff {@link #isNotPaused()} and not {@link #isExpired()} */
+    public boolean isLive() {
+        return isNotPaused() && isNotExpired();
+    }
+
+    /** true iff not {@link #isExpired()} */
+    public boolean isNotExpired() {
+        return !isExpired();
+    }
+
+    /** false if started or paused, true otherwise (ie the timer is counting down, even if it is expired) */
+    public boolean isNotPaused() {
         return stopwatch.isRunning();
     }
+
+    /** @deprecated since 0.9.0 use better named {@link #isNotPaused()} */ @Deprecated
+    public boolean isRunning() { return isNotPaused(); }
     
     // --- constructor methods
     

--- a/brooklyn-server/utils/common/src/test/java/org/apache/brooklyn/util/time/CountdownTimerTest.java
+++ b/brooklyn-server/utils/common/src/test/java/org/apache/brooklyn/util/time/CountdownTimerTest.java
@@ -50,6 +50,9 @@ public class CountdownTimerTest {
         
         CountdownTimer timer = SIMPLE_DURATION.countdownTimer();
         assertFalse(timer.isExpired());
+        assertTrue(timer.isNotExpired());
+        assertTrue(timer.isLive());
+        assertTrue(timer.isNotPaused());
         assertTrue(timer.getDurationElapsed().toMilliseconds() <= OVERHEAD_MS, "elapsed="+timer.getDurationElapsed().toMilliseconds());
         assertTrue(timer.getDurationRemaining().toMilliseconds() >= TOTAL_TIME_MS - OVERHEAD_MS, "remaining="+timer.getDurationElapsed().toMilliseconds());
         
@@ -60,6 +63,10 @@ public class CountdownTimerTest {
         
         Time.sleep(Duration.millis(SECOND_SLEEP_TIME_MS));
         assertTrue(timer.isExpired());
+        assertFalse(timer.isNotExpired());
+        assertFalse(timer.isLive());
+        assertTrue(timer.isNotPaused());
+
     }
     
     public void testNotify() throws InterruptedException {


### PR DESCRIPTION
solves the nondet test failure observed in #1176 .

and improve the "Asserts.eventually" routines which that used,
adding a new simpler eventuallyOnNotify(...) and having it used elsewhere.

also add convenience methods for CountdownTimer so its usage is more readable.
